### PR TITLE
fix mk_tar.sh manifest list

### DIFF
--- a/scripts/mk_tar.sh
+++ b/scripts/mk_tar.sh
@@ -28,7 +28,7 @@ PKG_AND_VERSION="${PACKAGE}-${PKG_VERSION}"
 TEMPDIR="tmp"
 
 SOURCE_MANIFEST="
-README
+README.md
 edge.c
 lzoconf.h
 lzodefs.h


### PR DESCRIPTION
The package building scripts are broken as mk_tar.sh expects a README file, but there is a README.md instead.