### PR TITLE
Add AES CBC psk encryption

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -76,7 +76,7 @@ supernode: sn.c $(N2N_LIB) n2n.h Makefile
 	$(CC) $(CFLAGS) sn.c $(N2N_LIB) $(LIBS_SN) -o supernode
 
 benchmark: benchmark.c $(N2N_LIB) n2n_wire.h n2n.h Makefile
-	$(CC) $(CFLAGS) benchmark.c $(N2N_LIB) $(LIBS_SN) -o benchmark
+	$(CC) $(CFLAGS) benchmark.c $(N2N_LIB) $(LIBS_EDGE) -o benchmark
 
 example_edge_embed: example_edge_embed.c $(N2N_LIB) n2n.h
 	$(CC) $(CFLAGS) example_edge_embed.c $(N2N_LIB) $(LIBS_EDGE) -o example_edge_embed

--- a/benchmark.c
+++ b/benchmark.c
@@ -70,14 +70,38 @@ uint8_t PKT_CONTENT[]={
 
 /* Prototypes */
 static ssize_t do_encode_packet( uint8_t * pktbuf, size_t bufsize, const n2n_community_t c );
+static void run_transop_benchmark(const char *op_name, n2n_trans_op_t *op_fn, uint8_t *pktbuf, n2n_community_t c);
 
 int main(int argc, char * argv[]) {
   uint8_t pktbuf[N2N_PKT_BUF_SIZE];
-  n2n_trans_op_t transop_null;
+  n2n_community_t c;
+  n2n_trans_op_t transop_null, transop_twofish, transop_aes_cbc;
+  u_char encrypt_pwd[] = "SoMEVer!S$cUREPassWORD";
 
+  memset(c,0,sizeof(N2N_COMMUNITY_SIZE));
+  memcpy(c, "abc123def456", 12);
+
+  /* Init transopts */
+  memset(&transop_null, 0, sizeof(transop_null));
+  transop_null_init(&transop_null);
+  memset(&transop_twofish, 0, sizeof(transop_twofish));
+  transop_twofish_init(&transop_twofish);
+  transop_twofish_setup_psk(&transop_twofish, 0, encrypt_pwd, sizeof(encrypt_pwd)-1);
+  memset(&transop_aes_cbc, 0, sizeof(transop_aes_cbc));
+  transop_twofish_init(&transop_aes_cbc);
+  transop_twofish_setup_psk(&transop_aes_cbc, 0, encrypt_pwd, sizeof(encrypt_pwd)-1);
+
+  /* Run the tests */
+  run_transop_benchmark("transop_null", &transop_null, pktbuf, c);
+  run_transop_benchmark("transop_twofish", &transop_twofish, pktbuf, c);
+  run_transop_benchmark("transop_aes", &transop_aes_cbc, pktbuf, c);
+
+  return 0;
+}
+
+static void run_transop_benchmark(const char *op_name, n2n_trans_op_t *op_fn, uint8_t *pktbuf, n2n_community_t c) {
   n2n_common_t cmn;
   n2n_PACKET_t pkt;
-  n2n_community_t c;
 
   struct timeval t1;
   struct timeval t2;
@@ -89,18 +113,14 @@ int main(int argc, char * argv[]) {
   ssize_t nw;
   ssize_t tdiff;
 
-  transop_null_init( &transop_null );
-  memset(c,0,sizeof(N2N_COMMUNITY_SIZE));
-
   n=10000;
-  memcpy( c, "abc123def456", 12 );
 
   gettimeofday( &t1, NULL );
   for(i=0; i<n; ++i)
     {
       nw = do_encode_packet( pktbuf, N2N_PKT_BUF_SIZE, c);
 
-      nw += transop_null.fwd( &transop_null,
+      nw += op_fn->fwd( op_fn,
 			      pktbuf+nw, N2N_PKT_BUF_SIZE-nw,
 			      PKT_CONTENT, sizeof(PKT_CONTENT) );
 
@@ -110,7 +130,7 @@ int main(int argc, char * argv[]) {
       decode_common( &cmn, pktbuf, &rem, &idx);
       decode_PACKET( &pkt, &cmn, pktbuf, &rem, &idx );
 
-      if ( 0 == (i%1000) )
+      if ( 0 == (i%(n/10)) )
         {
 	  fprintf(stderr,".");
         }
@@ -119,13 +139,12 @@ int main(int argc, char * argv[]) {
 
   tdiff = ((t2.tv_sec - t1.tv_sec) * 1000000) + (t2.tv_usec - t1.tv_usec);
 
-  fprintf( stderr, "\nrun %u times. (%u -> %u nsec each) %u.%06u -> %u.%06u.\n",
+  fprintf( stderr, "\n[%s] %u times: (%u -> %u nsec each) %u.%06u -> %u.%06u.\n",
+	   op_name,
 	   (unsigned int)i, (unsigned int)tdiff,
 	   (unsigned int)((tdiff *1000)/i),
 	   (uint32_t)t1.tv_sec, (uint32_t)t1.tv_usec,
 	   (uint32_t)t2.tv_sec, (uint32_t)t2.tv_usec );
-
-  return 0;
 }
 
 static ssize_t do_encode_packet( uint8_t * pktbuf, size_t bufsize, const n2n_community_t c )
@@ -154,3 +173,4 @@ static ssize_t do_encode_packet( uint8_t * pktbuf, size_t bufsize, const n2n_com
     
   return idx;
 }
+

--- a/benchmark.c
+++ b/benchmark.c
@@ -88,8 +88,8 @@ int main(int argc, char * argv[]) {
   transop_twofish_init(&transop_twofish);
   transop_twofish_setup_psk(&transop_twofish, 0, encrypt_pwd, sizeof(encrypt_pwd)-1);
   memset(&transop_aes_cbc, 0, sizeof(transop_aes_cbc));
-  transop_twofish_init(&transop_aes_cbc);
-  transop_twofish_setup_psk(&transop_aes_cbc, 0, encrypt_pwd, sizeof(encrypt_pwd)-1);
+  transop_aes_init(&transop_aes_cbc);
+  transop_aes_setup_psk(&transop_aes_cbc, 0, encrypt_pwd, sizeof(encrypt_pwd)-1);
 
   /* Run the tests */
   run_transop_benchmark("transop_null", &transop_null, pktbuf, c);

--- a/n2n.h
+++ b/n2n.h
@@ -186,6 +186,7 @@ typedef char n2n_sn_name_t[N2N_EDGE_SN_HOST_SIZE];
 
 struct n2n_edge {
   int                 daemon;                 /**< Non-zero if edge should detach and run in the background. */
+  int                 preferred_aes;          /**< Non-zero if AES is the preferred encryption meothd. */
   uint8_t             re_resolve_supernode_ip;
 
   n2n_sock_t          supernode;
@@ -337,7 +338,9 @@ void set_peer_operational(n2n_edge_t * eee,
 			  const n2n_mac_t mac,
 			  const n2n_sock_t * peer);
 const char * supernode_ip(const n2n_edge_t * eee);
-int edge_init_twofish(n2n_edge_t * eee, uint8_t *encrypt_pwd,
+int edge_init_twofish_psk(n2n_edge_t * eee, uint8_t *encrypt_pwd,
+		      uint32_t encrypt_pwd_len);
+int edge_init_aes_psk(n2n_edge_t * eee, uint8_t *encrypt_pwd,
 		      uint32_t encrypt_pwd_len);
 int run_edge_loop(n2n_edge_t * eee, int *keep_running);
 void edge_term(n2n_edge_t * eee);

--- a/n2n_transforms.h
+++ b/n2n_transforms.h
@@ -78,7 +78,12 @@ struct n2n_trans_op {
 };
 
 /* Setup a single twofish SA for single-key operation. */
-int transop_twofish_setup( n2n_trans_op_t * ttt, 
+int transop_twofish_setup_psk( n2n_trans_op_t * ttt, 
+                           n2n_sa_t sa_num,
+                           uint8_t * encrypt_pwd, 
+                           uint32_t encrypt_pwd_len );
+/* Setup a single AES SA for single-key operation. */
+int transop_aes_setup_psk( n2n_trans_op_t * ttt, 
                            n2n_sa_t sa_num,
                            uint8_t * encrypt_pwd, 
                            uint32_t encrypt_pwd_len );


### PR DESCRIPTION
Adds AES encryption support for pre shared key mode. Previously AES was only enabled when a keyfile was passed with the `-K` (uppercase) option. With this pull request it's possible to use AES with `-k` (lowercase) too, by adding the `-A` option. Encription in use can be verified with using the `-v` option.

Without `-A` (default):
`28/Jan/2019 01:08:42 [transform_tf.c:132] encode_twofish 98 with SA 0.`

With `-A`:
`28/Jan/2019 01:13:09 [transform_aes.c:162] encode_aes 98 with SA 0.`

AES should become the preferred encryption method in the future as, contrary to twofish, it uses a standard system library. Here are some benchmarks on my system (`./benchmark`):

```
[transop_null] 10000 times: (6356 -> 635 nsec each) 1548636359.095106 -> 1548636359.101462.
[transop_twofish] 10000 times: (494206 -> 49420 nsec each) 1548636359.101502 -> 1548636359.595708.
[transop_aes] 10000 times: (63927 -> 6392 nsec each) 1548636359.595725 -> 1548636359.659652.
````

Note: system with AES hardware accelleration