### PR TITLE
Submit minor changes to enable Windows CMake builds w/o requiring additional local mods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ benchmark
 edge
 example_edge_embed
 supernode
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ project(n2n)
 cmake_minimum_required(VERSION 2.6)
 
 # N2n information
-set(N2N_VERSION 2.3.0)
+set(N2N_VERSION 2.5.0)
 set(N2N_OSNAME ${CMAKE_SYSTEM})
 
 # N2n specific params
@@ -70,7 +70,8 @@ target_link_libraries(n2n n2n_win32)
 endif(DEFINED WIN32)
 
 if(N2N_OPTION_AES)
-target_link_libraries(n2n crypto)
+target_link_libraries(n2n ${OPENSSL_LIBRARIES})
+include_directories(${OPENSSL_INCLUDE_DIR})
 endif(N2N_OPTION_AES)
 
 add_executable(edge edge.c)

--- a/edge.c
+++ b/edge.c
@@ -730,7 +730,9 @@ int main(int argc, char* argv[]) {
     
     /* allow multiple sockets to use the same PORT number */
     setsockopt(eee.udp_multicast_sock, SOL_SOCKET, SO_REUSEADDR, &enable_reuse, sizeof(enable_reuse));
+#ifndef WIN32 /* no SO_REUSEPORT in Windows */
     setsockopt(eee.udp_multicast_sock, SOL_SOCKET, SO_REUSEPORT, &enable_reuse, sizeof(enable_reuse));
+#endif
     
     mreq.imr_multiaddr.s_addr = inet_addr(N2N_MULTICAST_GROUP);
     mreq.imr_interface.s_addr = htonl(INADDR_ANY);

--- a/n2n.h
+++ b/n2n.h
@@ -37,11 +37,13 @@
 /* Moved here to define _CRT_SECURE_NO_WARNINGS before all the including takes place */
 #ifdef WIN32
 #include "win32/n2n_win32.h"
+#include "win32/winconfig.h"
 #undef N2N_HAVE_DAEMON
 #undef N2N_HAVE_SETUID
+#else
+#include "config.h"
 #endif
 
-#include "config.h"
 
 #include <time.h>
 #include <ctype.h>

--- a/sn.c
+++ b/sn.c
@@ -20,6 +20,10 @@
 
 #include "n2n.h"
 
+#ifdef WIN32
+#include <signal.h>
+#endif
+
 #define N2N_SN_LPORT_DEFAULT 7654
 #define N2N_SN_PKTBUF_SIZE   2048
 
@@ -919,7 +923,11 @@ int main(int argc, char * const argv[]) {
 
   traceEvent(TRACE_NORMAL, "supernode started");
 
+#ifndef WIN32
   signal(SIGHUP, dump_registrations);
+#else
+  signal(SIGINT, dump_registrations);
+#endif
   
   return run_loop(&sss_node);
 }

--- a/version.c
+++ b/version.c
@@ -1,4 +1,8 @@
+#ifndef WIN32
 #include "config.h"
+#else
+#include "win32/winconfig.h"
+#endif
 
 const char * n2n_sw_version   = PACKAGE_VERSION;
 const char * n2n_sw_osName    = PACKAGE_OSNAME;

--- a/win32/winconfig.h
+++ b/win32/winconfig.h
@@ -1,0 +1,7 @@
+/* winconfig.h.  Win32 replacement for file generated from config.h.in by configure.  */
+
+/* OS name */
+#define PACKAGE_OSNAME N2N_OSNAME
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION N2N_VERSION


### PR DESCRIPTION
For your consideration: I've made a few minor changes so that Windows builds complete without errors.

* Added "build" directory to .gitignore, to ignore out-of-source CMake build artifacts
* Updated CMakeLists.txt to tag builds with version 2.5.0, like `configure` does for other platforms
* Added OpenSSL include/library references for CMake builds
* Added conditional compilation for setsockopt() calls referencing SO_REUSEPORT (not included in Windows)
* Added winconfig.h to take the place of config.h (generated by `configure` on other platforms).
* Replaced `signal(SIGHUP, ...)` with `signal(SIGINT, ...)` on Windows platforms (SIGHUP doesn't exist).