### PR TITLE
Fixes packet drops while communicating with multiple nodes in AES PSK

### DIFF
--- a/benchmark.c
+++ b/benchmark.c
@@ -102,6 +102,7 @@ int main(int argc, char * argv[]) {
 static void run_transop_benchmark(const char *op_name, n2n_trans_op_t *op_fn, uint8_t *pktbuf, n2n_community_t c) {
   n2n_common_t cmn;
   n2n_PACKET_t pkt;
+  n2n_mac_t mac_buf;
 
   struct timeval t1;
   struct timeval t2;
@@ -115,6 +116,7 @@ static void run_transop_benchmark(const char *op_name, n2n_trans_op_t *op_fn, ui
 
   n=10000;
 
+  memset(mac_buf, 0, sizeof(mac_buf));
   gettimeofday( &t1, NULL );
   for(i=0; i<n; ++i)
     {
@@ -122,7 +124,7 @@ static void run_transop_benchmark(const char *op_name, n2n_trans_op_t *op_fn, ui
 
       nw += op_fn->fwd( op_fn,
 			      pktbuf+nw, N2N_PKT_BUF_SIZE-nw,
-			      PKT_CONTENT, sizeof(PKT_CONTENT) );
+			      PKT_CONTENT, sizeof(PKT_CONTENT), mac_buf);
 
       idx=0;
       rem=nw;

--- a/edge_utils.c
+++ b/edge_utils.c
@@ -791,7 +791,7 @@ static int handle_PACKET(n2n_edge_t * eee,
 	eh = (ether_hdr_t*)eth_payload;
 	eth_size = eee->transop[rx_transop_idx].rev(&(eee->transop[rx_transop_idx]),
 						    eth_payload, N2N_PKT_BUF_SIZE,
-						    payload, psize);
+						    payload, psize, pkt->srcMac);
 	++(eee->transop[rx_transop_idx].rx_cnt); /* stats */
 
 	if(!(eee->allow_routing)) {
@@ -1192,7 +1192,7 @@ void send_packet2net(n2n_edge_t * eee,
 
   idx += eee->transop[tx_transop_idx].fwd(&(eee->transop[tx_transop_idx]),
 					  pktbuf+idx, N2N_PKT_BUF_SIZE-idx,
-					  tap_pkt, len);
+					  tap_pkt, len, pkt.dstMac);
   ++(eee->transop[tx_transop_idx].tx_cnt); /* stats */
 
   send_packet(eee, destMac, pktbuf, idx); /* to peer or supernode */

--- a/n2n_transforms.h
+++ b/n2n_transforms.h
@@ -55,7 +55,8 @@ typedef int             (*n2n_transform_f)( n2n_trans_op_t * arg,
                                             uint8_t * outbuf,
                                             size_t out_len,
                                             const uint8_t * inbuf,
-                                            size_t in_len );
+                                            size_t in_len,
+                                            const n2n_mac_t peer_mac);
 
 /** Holds the info associated with a data transform plugin.
  *

--- a/transform_null.c
+++ b/transform_null.c
@@ -29,7 +29,8 @@ static int transop_encode_null( n2n_trans_op_t * arg,
                                 uint8_t * outbuf,
                                 size_t out_len,
                                 const uint8_t * inbuf,
-                                size_t in_len )
+                                size_t in_len,
+                                const uint8_t * peer_mac)
 {
     int retval = -1;
 
@@ -51,7 +52,8 @@ static int transop_decode_null( n2n_trans_op_t * arg,
                                 uint8_t * outbuf,
                                 size_t out_len,
                                 const uint8_t * inbuf,
-                                size_t in_len )
+                                size_t in_len,
+                                const uint8_t * peer_mac)
 {
     int retval = -1;
 

--- a/transform_tf.c
+++ b/transform_tf.c
@@ -109,7 +109,8 @@ static int transop_encode_twofish( n2n_trans_op_t * arg,
                                    uint8_t * outbuf,
                                    size_t out_len,
                                    const uint8_t * inbuf,
-                                   size_t in_len )
+                                   size_t in_len,
+				   const uint8_t * peer_mac)
 {
   int len=-1;
   transop_tf_t * priv = (transop_tf_t *)arg->priv;
@@ -209,7 +210,8 @@ static int transop_decode_twofish( n2n_trans_op_t * arg,
                                    uint8_t * outbuf,
                                    size_t out_len,
                                    const uint8_t * inbuf,
-                                   size_t in_len )
+                                   size_t in_len,
+				   const uint8_t * peer_mac)
 {
   int len=0;
   transop_tf_t * priv = (transop_tf_t *)arg->priv;


### PR DESCRIPTION
Per-node AES structures must be kept as CBC cannot work with a single structure across multiple nodes.
The peer mac address is used as a key to determine the structure to use.