### PR TITLE
Reduce the registration timeout to keep the connection open

### DIFF
--- a/edge_utils.c
+++ b/edge_utils.c
@@ -32,7 +32,7 @@
 #define REGISTER_SUPER_INTERVAL_DFL     60 /* sec */
 #endif /* #if defined(DEBUG) */
 
-#define REGISTER_SUPER_INTERVAL_MIN     20   /* sec */
+#define REGISTER_SUPER_INTERVAL_MIN     5    /* sec */
 #define REGISTER_SUPER_INTERVAL_MAX     3600 /* sec */
 
 #define IFACE_UPDATE_INTERVAL           (30) /* sec. How long it usually takes to get an IP lease. */

--- a/sn.c
+++ b/sn.c
@@ -112,7 +112,8 @@ static void deinit_sn(n2n_sn_t * sss)
  *  should not allow registrations to continue beyond the shutdown point.
  */
 static uint16_t reg_lifetime(n2n_sn_t * sss) {
-  return 120;
+  /* NOTE: UDP firewalls usually have a 30 seconds timeout */
+  return 15;
 }
 
 


### PR DESCRIPTION
Currently the supernode tells the edge nodes to register at intervals of 2 minutes. This means that when the edge node doesn't have any data to send, the connection can stay idle (no packets sent at all) for 2 minutes. This is too much time for a UDP firewall, which will probably close the connection way sooner (30 seconds seems the timeout used in most cases).

Fixes #28