### PR TITLE
Revamp AES Part 1; including random & encrypted IV, hashed key and max keysize

### DIFF
--- a/benchmark.c
+++ b/benchmark.c
@@ -35,7 +35,7 @@ static int gettimeofday(struct timeval *tp, void *tzp)
 	time_t clock;
 	struct tm tm;
 	SYSTEMTIME wtm;
-	GetSystemTime(&wtm);
+	GetLocalTime(&wtm);
 	tm.tm_year = wtm.wYear - 1900;
 	tm.tm_mon = wtm.wMonth - 1;
 	tm.tm_mday = wtm.wDay;
@@ -89,7 +89,7 @@ int main(int argc, char * argv[]) {
   transop_twofish_setup_psk(&transop_twofish, 0, encrypt_pwd, sizeof(encrypt_pwd)-1);
   memset(&transop_aes_cbc, 0, sizeof(transop_aes_cbc));
   transop_aes_init(&transop_aes_cbc);
-  transop_aes_setup_psk(&transop_aes_cbc, 0, encrypt_pwd, sizeof(encrypt_pwd)-1);
+  transop_aes_setup_psk(&transop_aes_cbc, 0, encrypt_pwd, sizeof(encrypt_pwd)-1,1);
 
   /* Run the tests */
   run_transop_benchmark("transop_null", &transop_null, pktbuf, c);

--- a/benchmark.c
+++ b/benchmark.c
@@ -35,7 +35,7 @@ static int gettimeofday(struct timeval *tp, void *tzp)
 	time_t clock;
 	struct tm tm;
 	SYSTEMTIME wtm;
-	GetLocalTime(&wtm);
+	GetSystemTime(&wtm);
 	tm.tm_year = wtm.wYear - 1900;
 	tm.tm_mon = wtm.wMonth - 1;
 	tm.tm_mday = wtm.wDay;

--- a/n2n_transforms.h
+++ b/n2n_transforms.h
@@ -87,7 +87,8 @@ int transop_twofish_setup_psk( n2n_trans_op_t * ttt,
 int transop_aes_setup_psk( n2n_trans_op_t * ttt, 
                            n2n_sa_t sa_num,
                            uint8_t * encrypt_pwd, 
-                           uint32_t encrypt_pwd_len );
+                           uint32_t encrypt_pwd_len, 
+			   uint8_t aes_version );
 
 /* Initialise an empty transop ready to receive cipherspec elements. */
 int  transop_twofish_init( n2n_trans_op_t * ttt );


### PR DESCRIPTION
This pull request addresses some security issues in the AES module _transform_aes_ as follows:

**Key Stretching**
- the key provided by the user gets hashed
- this hash is used to derive the actual encryption and decryption key
- also, a secondary key is derived from the hash
- for being able to derive two independent keys in the same step, a hash function with wider output is used (SHA512)

**CBC data encryption**
- make use of an full block sized initialization vector (IV) instead of a nonce
- the IV is randomly set for every packet
- as the first data block is quite predictable (preamble, NIC's MACs), the IV gets encrypted as single block using the secondary key
- replay protection could be added to the IV and may be considered in Part 2

**Message authentication**
- a field for a message authentication code is filled with a ECBC-MAC, i.e. the last cipher block gets encrypted using the secondary key
- to ensure safety of ECBC-MAC, i.e. keep it prefix-free, data length is prepended to the data to be encrypted
- thus, the number of padded bytes at the last packet's end is not neccessary anymore and gets removed
- verification of the message authentication code was not first priority and may be included in Part 2

**Any other business**
- version number increased to 2 as packet design changed
- fixes a packet loss issue - at least for local edges
- author's first pull request ever - please be kind :)
