### PR TITLE
Add feature: selectable tap adapter in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,6 @@ add_library(n2n n2n.c
                 tuntap_netbsd.c
                 tuntap_linux.c
                 tuntap_osx.c
-                version.c
             )
 
 if(DEFINED WIN32)

--- a/edge.c
+++ b/edge.c
@@ -118,7 +118,7 @@ static void help() {
 	 );
   printf("edge "
 #if defined(N2N_CAN_NAME_IFACE)
-	 "-d <tun device> "
+	 "-d <tun/windows-tap device> "
 #endif /* #if defined(N2N_CAN_NAME_IFACE) */
 	 "-a [static:|dhcp:]<tun IP address> "
 	 "-c <community> "
@@ -138,8 +138,8 @@ static void help() {
 	 "[-p <local port>] [-M <mtu>] "
 	 "[-r] [-E] [-v] [-t <mgmt port>] [-b] [-A] [-h]\n\n");
 
-#ifdef __linux__
-  printf("-d <tun device>          | tun device name\n");
+#if defined(N2N_CAN_NAME_IFACE)
+  printf("-d <tun/windows-tap device>          | tun device name. In Windows, it's tap adapter name\n");
 #endif
 
   printf("-a <mode:address>        | Set interface address. For DHCP use '-r -a dhcp:0.0.0.0'\n");

--- a/n2n.h
+++ b/n2n.h
@@ -38,6 +38,7 @@
 #ifdef WIN32
 #include "win32/n2n_win32.h"
 #include "win32/winconfig.h"
+#define N2N_CAN_NAME_IFACE 1
 #undef N2N_HAVE_DAEMON
 #undef N2N_HAVE_SETUID
 #else

--- a/win32/n2n_win32.h
+++ b/win32/n2n_win32.h
@@ -7,6 +7,11 @@
 #ifndef _N2N_WIN32_H_
 #define _N2N_WIN32_H_
 
+#ifndef N2N_IFNAMSIZ
+#define N2N_IFNAMSIZ  16 /* 15 chars * NULL */
+#endif
+
+
 #ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif
@@ -95,6 +100,7 @@ struct ip {
 
 typedef struct tuntap_dev {
 	HANDLE device_handle;
+	char config_device_name[N2N_IFNAMSIZ];
 	char *device_name;
 	char *ifName;
 	OVERLAPPED overlap_read, overlap_write;

--- a/win32/wintap.c
+++ b/win32/wintap.c
@@ -40,6 +40,7 @@ int open_wintap(struct tuntap_dev *device,
   ULONG status = TRUE;
 
   strncpy(config_device_name, device->config_device_name, N2N_IFNAMSIZ);
+  config_device_name[N2N_IFNAMSIZ - 1] = '\0';
 
   memset(device, 0, sizeof(struct tuntap_dev));
   device->device_handle = INVALID_HANDLE_VALUE;
@@ -280,6 +281,7 @@ int tuntap_open(struct tuntap_dev *device,
                 int mtu) {
 
     strncpy(device->config_device_name, dev, N2N_IFNAMSIZ);
+	device->config_device_name[N2N_IFNAMSIZ - 1] = '\0';
     return(open_wintap(device, address_mode, device_ip, device_mask, device_mac, mtu));
 }
 


### PR DESCRIPTION
I have to use multiple TAP devices in Windows, so decide to deal with feature request in issue #1.

But I am not familiar with C, may be with some vuls. Code review is really needed.

Limitation:
Length of tap name in Windows should lesser than 16 (as const N2N_IFNAMSIZ defined)