### PR TITLE
Fix purge expired registrations kickoff 2.4 stable

### DIFF
--- a/edge_utils.c
+++ b/edge_utils.c
@@ -1419,6 +1419,8 @@ int run_edge_loop(n2n_edge_t * eee, int *keep_running) {
   size_t numPurged;
   time_t lastIfaceCheck=0;
   time_t lastTransop=0;
+  time_t last_purge_known = 0;
+  time_t last_purge_pending = 0;
 #ifdef __ANDROID_NDK__
     time_t lastArpPeriod=0;
 #endif
@@ -1502,8 +1504,8 @@ int run_edge_loop(n2n_edge_t * eee, int *keep_running) {
 
     update_supernode_reg(eee, nowTime);
 
-    numPurged =  purge_expired_registrations(&(eee->known_peers));
-    numPurged += purge_expired_registrations(&(eee->pending_peers));
+    numPurged =  purge_expired_registrations(&(eee->known_peers), &last_purge_known);
+    numPurged += purge_expired_registrations(&(eee->pending_peers), &last_purge_pending);
 
     if(numPurged > 0) {
       traceEvent(TRACE_NORMAL, "Peer removed: pending=%u, operational=%u",

--- a/n2n.c
+++ b/n2n.c
@@ -307,18 +307,17 @@ void peer_list_add(struct peer_info * * list,
 }
 
 
-size_t purge_expired_registrations(struct peer_info ** peer_list) {
-  static time_t last_purge = 0;
+size_t purge_expired_registrations(struct peer_info ** peer_list, time_t* p_last_purge) {
   time_t now = time(NULL);
   size_t num_reg = 0;
 
-  if((now - last_purge) < PURGE_REGISTRATION_FREQUENCY) return 0;
+  if((now - (*p_last_purge)) < PURGE_REGISTRATION_FREQUENCY) return 0;
 
   traceEvent(TRACE_INFO, "Purging old registrations");
 
   num_reg = purge_peer_list(peer_list, now-REGISTRATION_TIMEOUT);
 
-  last_purge = now;
+  (*p_last_purge) = now;
   traceEvent(TRACE_INFO, "Remove %ld registrations", num_reg);
 
   return num_reg;

--- a/n2n.h
+++ b/n2n.h
@@ -297,7 +297,7 @@ size_t peer_list_size( const struct peer_info * list );
 size_t purge_peer_list( struct peer_info ** peer_list, 
                         time_t purge_before );
 size_t clear_peer_list( struct peer_info ** peer_list );
-size_t purge_expired_registrations( struct peer_info ** peer_list );
+size_t purge_expired_registrations( struct peer_info ** peer_list, time_t* p_last_purge );
 
 /* version.c */
 extern char *n2n_sw_version, *n2n_sw_osName, *n2n_sw_buildDate;

--- a/sn.c
+++ b/sn.c
@@ -859,6 +859,7 @@ static int run_loop( n2n_sn_t * sss )
 {
   uint8_t pktbuf[N2N_SN_PKTBUF_SIZE];
   int keep_running=1;
+  time_t last_purge_edges = 0;
 
   sss->start_time = time(NULL);
 
@@ -934,7 +935,7 @@ static int run_loop( n2n_sn_t * sss )
 	  traceEvent( TRACE_DEBUG, "timeout" );
         }
 
-      purge_expired_registrations( &(sss->edges) );
+      purge_expired_registrations( &(sss->edges), &last_purge_edges );
 
     } /* while */
 


### PR DESCRIPTION
It is based on stable 2.4 branch. 

Fix the pure code issue mentioned in #106
Also fix the "send_register" to add dst mac in packet.

Additional notes for timeout arguments in purge_expired_registrations:

1. Actually eee->pending_peers should has different timeout as eee->known_peers. For example, if REGISTER message is lost during UDP transpot (somehow first REGISTER on one of edge in my test rig has high possibility of lost), entry in pending_peers should be purged more frequently so that we can retry REGISTER soon.

2. If we specify mac address in command line, it can be simply broken if we ctrl-C and restart an edge instance. That's because the local port as well as external port is changed after local edge is restarted but the mapping of mac -> ip:port is not changed on peer edge. Therefore peer edge actually can no longer send message to local edge. Peer edge doesn't update the mapping when a message from local edge arrives because it is known and the message is from the supernode. Local edge can't perform register process because there's no message from peer edge arrives (even no message forwarded from supernode, because local edge is 'known' in peer edge and peer edge always try to send message by staled  'known' port), so local edge always send message through supernode. 
-> We stuck in this situation until eee->known_peers on peer edge purge the local edge with staled 'known' port. But if we set timeout on eee->known_peers with short several seconds, the connection could be recovered in several seconds (instead of 20 minutes by default).

In this PR I leave timeout arguments in purge_expired_registrations as original default but we can consider to make them as configurable.