### PR TITLE
More reliable punching

### DIFF
--- a/doc/NEW_FEATURES.txt
+++ b/doc/NEW_FEATURES.txt
@@ -4,3 +4,18 @@ Between 2.0.x and 2.1.x
 * Better ming Windows build support.
 * Added -E flag to allow multicast ethernet traffic.
 
+* Added -L flag to allow set TTL for registration packet.
+This is an advanced flag to make sure that the registration packet is dropped immediately when it goes out of local nat
+so that it will not trigger some firewall behavior on target peer. Actually, the registration packet is only expected to
+make local nat UDP hole and is not expected to reach the target peer, see https://tools.ietf.org/html/rfc5389.
+To achieve this, the flag should be set as nat level + 1. For example, if we have 2 layer nat in local, we should set
+-L 3.
+Usually we know exactly how much nat layers in local.
+If we are not sure how much nat layers in local, we can use traceroute on Linux to check. Following example shows a local
+single layer nat because on second jump it shows a public ip address. In this case it should set -L 2.
+$ /usr/sbin/traceroute -w1 8.8.8.8
+traceroute to 8.8.8.8 (8.8.8.8), 30 hops max, 60 byte packets
+ 1  192.168.3.1 (192.168.3.1)  0.464 ms  0.587 ms  0.719 ms
+ 2  112.65.17.217 (112.65.17.217)  5.269 ms  7.031 ms  8.666 ms
+
+But this method is not always work due to various local network device policy.

--- a/edge.c
+++ b/edge.c
@@ -143,7 +143,7 @@ static void help() {
 #ifndef __APPLE__
 	 "[-D] "
 #endif
-	 "[-r] [-E] [-v] [-i <reg_interval>] [-t <mgmt port>] [-A] [-h]\n\n");
+	 "[-r] [-E] [-v] [-i <reg_interval>] [-L <reg_ttl>] [-t <mgmt port>] [-A] [-h]\n\n");
 
 #if defined(N2N_CAN_NAME_IFACE)
   printf("-d <tun device>          | tun device name\n");
@@ -155,6 +155,7 @@ static void help() {
   printf("-s <netmask>             | Edge interface netmask in dotted decimal notation (255.255.255.0).\n");
   printf("-l <supernode host:port> | Supernode IP:port\n");
   printf("-i <reg_interval>        | Registration interval, for NAT hole punching (default 20 seconds)\n");
+  printf("-L <reg_ttl>             | TTL for registration packet when UDP NAT hole punching through supernode (default 0 for not set )\n");
   printf("-p <local port>          | Fixed local UDP port.\n");
 #ifndef WIN32
   printf("-u <UID>                 | User ID (numeric) to use when privileges are dropped.\n");
@@ -303,6 +304,10 @@ static int setOption(int optkey, char *optargument, n2n_priv_config_t *ec, n2n_e
     conf->register_interval = atoi(optargument);
     break;
 
+  case 'L': /* supernode registration interval */
+    conf->register_ttl = atoi(optarg);
+    break;
+
 #if defined(N2N_CAN_NAME_IFACE)
   case 'd': /* TUNTAP name */
     {
@@ -393,7 +398,7 @@ static int loadFromCLI(int argc, char *argv[], n2n_edge_conf_t *conf, n2n_priv_c
   u_char c;
 
   while((c = getopt_long(argc, argv,
-			 "k:a:bc:Eu:g:m:M:s:d:l:p:fvhrt:i:SD"
+			 "k:a:bc:Eu:g:m:M:s:d:l:p:fvhrt:i:SDL:"
 #ifdef N2N_HAVE_AES
 			 "A"
 #endif

--- a/n2n.h
+++ b/n2n.h
@@ -217,6 +217,7 @@ typedef struct n2n_edge_conf {
   uint8_t             tos;                    /** TOS for sent packets */
   char                *encrypt_key;
   int                 register_interval;      /**< Interval for supernode registration, also used for UDP NAT hole punching. */
+  int                 register_ttl;           /**< TTL for registration packet when UDP NAT hole punching through supernode. */
   int                 local_port;
   int                 mgmt_port;
 } n2n_edge_conf_t;


### PR DESCRIPTION
1. Some nat router blocks the port if incoming traffic arrives before outcoming traffic being sent. Give edge ability to set proper TTL so that the registration packet is dropped before it arrives peer.
2. Support Symmetric NAT by predicting 15 more ports when sending registration packet
3. Purge pending mac also on P2P normal packet. This is actually more usual condition.

This fixes P2P failure on my environment:
1. Mobile network sometimes act as Symmetric NAT. 2. and 3. makes it P2P connectable
2. Router in my parents' home shows behavior of 1. and setting TTL =  number of nat layers + 1 make it P2P connectable.

Let me know if we need to split it into 2 PRs.
Contentious notes for discussion: 
1. Not sure whether setsock TTL works fine in win32 and I lack of environment to test win32. So I just discard it in win32.
2. We might need to introduce another command line argument to specify the number for predicting port. In this PR (as PoC) I hard code 16 and limited to use this tech only when TTL is specified (I'm afraid that lots of unknown incoming traffic on peer might trigger more router firewall policy). 
3. How to detect how much nat layers between local host and public network automatically?
