### PR TITLE
non-Windows trace events no longer print the full path of the code file.

### DIFF
--- a/edge.c
+++ b/edge.c
@@ -551,7 +551,6 @@ static void daemonize() {
 
 static int keep_on_running;
 
-#ifdef __linux__
 
 static void term_handler(int sig) {
   static int called = 0;
@@ -566,7 +565,6 @@ static void term_handler(int sig) {
 
   keep_on_running = 0;
 }
-#endif
 
 /* *************************************************** */
 
@@ -663,10 +661,8 @@ int main(int argc, char* argv[]) {
   }
 #endif
 
-#ifdef __linux__
   signal(SIGTERM, term_handler);
   signal(SIGINT,  term_handler);
-#endif
 
   keep_on_running = 1;
   traceEvent(TRACE_NORMAL, "edge started");

--- a/n2n.c
+++ b/n2n.c
@@ -86,9 +86,7 @@ void traceEvent(int eventTraceLevel, char* file, int line, char * format, ...) {
     char theDate[N2N_TRACE_DATESIZE];
     char *extra_msg = "";
     time_t theTime = time(NULL);
-#ifdef WIN32
     int i;
-#endif
 
     /* We have two paths - one if we're logging, one if we aren't
      *   Note that the no-log case is those systems which don't support it(WIN32),
@@ -120,7 +118,8 @@ void traceEvent(int eventTraceLevel, char* file, int line, char * format, ...) {
       snprintf(out_buf, sizeof(out_buf), "%s%s", extra_msg, buf);
       syslog(LOG_INFO, "%s", out_buf);
     } else {
-      snprintf(out_buf, sizeof(out_buf), "%s [%s:%d] %s%s", theDate, file, line, extra_msg, buf);
+		for(i=strlen(file)-1; i>0; i--) if(file[i] == '/') { i++; break; };
+		snprintf(out_buf, sizeof(out_buf), "%s [%s:%d] %s%s", theDate, &file[i], line, extra_msg, buf);
 #ifdef __ANDROID_NDK__
         switch (eventTraceLevel) {
             case 0:         // ERROR

--- a/n2n.h
+++ b/n2n.h
@@ -101,7 +101,6 @@ typedef struct ether_hdr ether_hdr_t;
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/udp.h>
-#include <signal.h>
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -112,10 +111,9 @@ typedef struct ether_hdr ether_hdr_t;
 #define closesocket(a) close(a)
 #endif /* #ifndef WIN32 */
 
+#include <signal.h>
 #include <string.h>
-
 #include <stdarg.h>
-
 #include "uthash.h"
 
 #ifdef WIN32

--- a/n2n_wire.h
+++ b/n2n_wire.h
@@ -20,6 +20,7 @@
 #define N2N_WIRE_H_
 
 #include <stdlib.h>
+#include <time.h>
 
 #if defined(WIN32)
 #include "win32/n2n_win32.h"

--- a/sn.c
+++ b/sn.c
@@ -20,9 +20,6 @@
 
 #include "n2n.h"
 
-#ifdef WIN32
-#include <signal.h>
-#endif
 
 #define N2N_SN_LPORT_DEFAULT 7654
 #define N2N_SN_PKTBUF_SIZE   2048
@@ -944,7 +941,6 @@ static void dump_registrations(int signo) {
 
 static int keep_running;
 
-#ifdef __linux__
 
 static void term_handler(int sig) {
   static int called = 0;
@@ -959,7 +955,6 @@ static void term_handler(int sig) {
 
   keep_running = 0;
 }
-#endif
 
 /* *************************************************** */
 
@@ -1012,11 +1007,11 @@ int main(int argc, char * const argv[]) {
 
   traceEvent(TRACE_NORMAL, "supernode started");
 
-#ifdef __linux__
   signal(SIGTERM, term_handler);
   signal(SIGINT, term_handler);
+#ifndef WIN32
   signal(SIGHUP, dump_registrations);
-#endif
+#endif /* #ifndef WIN32 */
 
   keep_running = 1;
   return run_loop(&sss_node);


### PR DESCRIPTION
1. non-Windows trace events no longer print the full path of the code file.
2. fix the problem that the program is forced to exit by pressing the "Ctrl + C" key on the Windows system.