### PR TITLE
enable the running edge or supernode to automatically read the conf by default

### DIFF
--- a/edge.c
+++ b/edge.c
@@ -617,8 +617,6 @@ int main(int argc, char* argv[]) {
   snprintf(ec.ip_mode, sizeof(ec.ip_mode), "static");
   snprintf(ec.netmask, sizeof(ec.netmask), "255.255.255.0");
 
-  traceEvent(TRACE_NORMAL, "Starting n2n edge %s %s", PACKAGE_VERSION, PACKAGE_BUILDDATE);
-
 	if (argc == 1) {
 		if ((access(EDGE_DEFAULT_CONF, F_OK)) == 0) {
 			rc = loadFromFile(EDGE_DEFAULT_CONF, &conf, &ec);
@@ -637,7 +635,9 @@ int main(int argc, char* argv[]) {
   if(rc < 0)
     help();
 
-  if(0 == strcmp("dhcp", ec.ip_mode)) {
+	traceEvent(TRACE_NORMAL, "Starting n2n edge %s %s", PACKAGE_VERSION, PACKAGE_BUILDDATE);
+
+	if(0 == strcmp("dhcp", ec.ip_mode)) {
     traceEvent(TRACE_NORMAL, "Dynamic IP address assignment enabled.");
 
     conf.dyn_ip_mode = 1;

--- a/edge.c
+++ b/edge.c
@@ -23,6 +23,8 @@
 #include <pwd.h>
 #endif
 
+#define EDGE_DEFAULT_CONF "edge.conf" /* edge default configuration file name */
+
 #define N2N_NETMASK_STR_SIZE    16 /* dotted decimal 12 numbers + 3 dots */
 #define N2N_MACNAMSIZ           18 /* AA:BB:CC:DD:EE:FF + NULL*/
 #define N2N_IF_MODE_SIZE        16 /* static | dhcp */
@@ -593,9 +595,6 @@ int main(int argc, char* argv[]) {
   struct passwd *pw = NULL;
 #endif
 
-  if(argc == 1)
-    help();
-
   /* Defaults */
   edge_init_conf_defaults(&conf);
   memset(&ec, 0, sizeof(ec));
@@ -619,6 +618,14 @@ int main(int argc, char* argv[]) {
   snprintf(ec.netmask, sizeof(ec.netmask), "255.255.255.0");
 
   traceEvent(TRACE_NORMAL, "Starting n2n edge %s %s", PACKAGE_VERSION, PACKAGE_BUILDDATE);
+
+	if (argc == 1) {
+		if ((access(EDGE_DEFAULT_CONF, F_OK)) == 0) {
+			rc = loadFromFile(EDGE_DEFAULT_CONF, &conf, &ec);
+		} else {
+			help();
+		}
+	}
 
   if((argc >= 2) && (argv[1][0] != '-')) {
     rc = loadFromFile(argv[1], &conf, &ec);

--- a/n2n.c
+++ b/n2n.c
@@ -86,9 +86,7 @@ void traceEvent(int eventTraceLevel, char* file, int line, char * format, ...) {
     char theDate[N2N_TRACE_DATESIZE];
     char *extra_msg = "";
     time_t theTime = time(NULL);
-#ifdef WIN32
     int i;
-#endif
 
     /* We have two paths - one if we're logging, one if we aren't
      *   Note that the no-log case is those systems which don't support it(WIN32),
@@ -120,7 +118,8 @@ void traceEvent(int eventTraceLevel, char* file, int line, char * format, ...) {
       snprintf(out_buf, sizeof(out_buf), "%s%s", extra_msg, buf);
       syslog(LOG_INFO, "%s", out_buf);
     } else {
-      snprintf(out_buf, sizeof(out_buf), "%s [%s:%d] %s%s", theDate, file, line, extra_msg, buf);
+		for(i=strlen(file)-1; i>0; i--) if(file[i] == '/') { i++; break; };
+		snprintf(out_buf, sizeof(out_buf), "%s [%s:%d] %s%s", theDate, &file[i], line, extra_msg, buf);
 #ifdef __ANDROID_NDK__
         switch (eventTraceLevel) {
             case 0:         // ERROR

--- a/n2n.h
+++ b/n2n.h
@@ -102,7 +102,6 @@ typedef struct ether_hdr ether_hdr_t;
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/udp.h>
-#include <signal.h>
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -113,10 +112,9 @@ typedef struct ether_hdr ether_hdr_t;
 #define closesocket(a) close(a)
 #endif /* #ifndef WIN32 */
 
+#include <signal.h>
 #include <string.h>
-
 #include <stdarg.h>
-
 #include "uthash.h"
 
 #ifdef WIN32

--- a/sn.c
+++ b/sn.c
@@ -988,7 +988,7 @@ int main(int argc, char * const argv[]) {
     rc = loadFromCLI(argc, argv, &sss_node);
 
   if(rc < 0)
-    return(-1);
+	  help();
 
 #if defined(N2N_HAVE_DAEMON)
   if(sss_node.daemon) {

--- a/sn.c
+++ b/sn.c
@@ -20,9 +20,7 @@
 
 #include "n2n.h"
 
-#ifdef WIN32
-#include <signal.h>
-#endif
+#define SN_DEFAULT_CONF "supernode.conf" /* supernode default configuration file name */
 
 #define N2N_SN_LPORT_DEFAULT 7654
 #define N2N_SN_PKTBUF_SIZE   2048
@@ -972,10 +970,15 @@ static void term_handler(int sig)
 int main(int argc, char * const argv[]) {
   int rc;
 
-  if(argc == 1)
-    help();
+	init_sn(&sss_node);
 
-  init_sn(&sss_node);
+	if (argc == 1) {
+		if ((access(SN_DEFAULT_CONF, F_OK)) == 0) {
+			rc = loadFromFile(SN_DEFAULT_CONF, &sss_node);
+		} else {
+			help();
+		}
+	}
 
   if((argc >= 2) && (argv[1][0] != '-')) {
     rc = loadFromFile(argv[1], &sss_node);


### PR DESCRIPTION
The default configuration file (if it exists) can be automatically read in the current directory when the program is launched.
[https://github.com/ntop/n2n/issues/165#issuecomment-509443405](url)