### PR TITLE
new random number generator (xorshift128+)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,7 +50,7 @@ N2N_OBJS=n2n.o wire.o minilzo.o twofish.o \
 	 edge_utils.o \
          transform_null.o transform_tf.o transform_aes.o \
          tuntap_freebsd.o tuntap_netbsd.o tuntap_linux.o \
-	 tuntap_osx.o
+	 tuntap_osx.o random_numbers.o
 LIBS_EDGE+=$(LIBS_EDGE_OPT)
 LIBS_SN=
 

--- a/edge_utils.c
+++ b/edge_utils.c
@@ -18,6 +18,7 @@
 
 #include "n2n.h"
 #include "lzoconf.h"
+#include "random_numbers.h"
 
 #ifdef WIN32
 #include <process.h>
@@ -173,7 +174,7 @@ n2n_edge_t* edge_init(const tuntap_dev *dev, const n2n_edge_conf_t *conf, int *r
 
   /* REVISIT: BbMaj7 : Should choose something with less predictability
            * particularly for embedded targets with no real-time clock. */
-  srand(eee->start_time);
+  random_number_seed(eee->start_time);
 
   eee->known_peers    = NULL;
   eee->pending_peers  = NULL;
@@ -621,7 +622,7 @@ static void send_register_super(n2n_edge_t * eee,
   memcpy(cmn.community, eee->conf.community_name, N2N_COMMUNITY_SIZE);
 
   for(idx=0; idx < N2N_COOKIE_SIZE; ++idx)
-    eee->last_cookie[idx] = rand() % 0xff;
+    eee->last_cookie[idx] = random_number_32() % 0xff;
 
   memcpy(reg.cookie, eee->last_cookie, N2N_COOKIE_SIZE);
   reg.auth.scheme=0; /* No auth yet */

--- a/edge_utils.c
+++ b/edge_utils.c
@@ -172,9 +172,8 @@ n2n_edge_t* edge_init(const tuntap_dev *dev, const n2n_edge_conf_t *conf, int *r
   memcpy(&eee->device, dev, sizeof(*dev));
   eee->start_time = time(NULL);
 
-  /* REVISIT: BbMaj7 : Should choose something with less predictability
-           * particularly for embedded targets with no real-time clock. */
-  random_number_seed(eee->start_time);
+  /* parameter == 0 uses timer- and clock speed-dependent seed procedure */
+  random_number_seed(0);
 
   eee->known_peers    = NULL;
   eee->pending_peers  = NULL;

--- a/random_numbers.c
+++ b/random_numbers.c
@@ -1,20 +1,9 @@
-
 /* The following code offers an alterate pseudo random number generator
    namely XORSHIFT128+ to use instead of C's rand(). Its performance is 
    on par with C's rand().
  */
 
-
-
 #include <stdint.h>
-#ifdef __GNUC__
-#include <sys/time.h>
-#endif
-#include <time.h>
-#ifdef __linux__
-    #include <sys/syscall.h>
-    #define GRND_NONBLOCK	1
-#endif
 #include "n2n.h"
 #include "random_numbers.h"
 
@@ -22,7 +11,7 @@ struct rn_generator_state_t {
     uint64_t a, b;
  };
 
-/* The state must be seeded so that it is not all zero, choose some
+/* The state must be seeded in a way that it is not all zero, choose some
    arbitrary defaults (in this case: taken from splitmix64)
  */
 static struct rn_generator_state_t rn_current_state
@@ -30,67 +19,23 @@ static struct rn_generator_state_t rn_current_state
 			           .b    = 0xBF58476D1CE4E5B9
 };
 
-static uint64_t reseed_counter = 0;
+int32_t n2n_srand (uint64_t seed) {
+    /* apply splitmix64 algorithm (found on same wiki page as xorshift)
+       twice on the SEED to calcualte A and B of XORSHIFT128PLUS' state */
+    rn_current_state.a = seed;
+    rn_current_state.a = (rn_current_state.a ^ (rn_current_state.a >> 30)) * 0xBF58476D1CE4E5B9;
+    rn_current_state.a = (rn_current_state.a ^ (rn_current_state.a >> 27)) * 0x94D049BB133111EB;
+    rn_current_state.a ^= rn_current_state.a >> 31;
+    /* by applying splitmix64 algorithm twice in a row, an all zero state is
+       avoidedfor any given SEED, especially due to the following line of code */
+    rn_current_state.b = seed + 0x9E3779B97F4A7C15;
+    rn_current_state.b = (rn_current_state.b ^ (rn_current_state.b >> 30)) * 0xBF58476D1CE4E5B9;
+    rn_current_state.b = (rn_current_state.b ^ (rn_current_state.b >> 27)) * 0x94D049BB133111EB;
+    rn_current_state.b ^= rn_current_state.b >> 31;
 
-/* taken from benchmark.c */
-#if defined(WIN32) && !defined(__GNUC__)
-#include <windows.h>
-static int gettimeofday(struct timeval *tp, void *tzp)
-{
-    time_t clock;
-    struct tm tm;
-    SYSTEMTIME wtm;
-    GetLocalTime(&wtm);
-    tm.tm_year = wtm.wYear - 1900;
-    tm.tm_mon = wtm.wMonth - 1;
-    tm.tm_mday = wtm.wDay;
-    tm.tm_hour = wtm.wHour;
-    tm.tm_min = wtm.wMinute;
-    tm.tm_sec = wtm.wSecond;
-    tm.tm_isdst = -1;
-    clock = mktime(&tm);
-    tp->tv_sec = clock;
-    tp->tv_usec = wtm.wMilliseconds * 1000;
-    return (0);
-}
-#endif
-
-static int32_t set_seed (uint64_t seed) {
-    /* shift a --> b */
-    rn_current_state.b = rn_current_state.a;
-    /* for xorshift128p, an all zero state must be avoided
-       so, we generally do not allow 0's */
-    if (seed != 0) {
-	rn_current_state.a = seed;
-	reseed_counter = 0;
-    }
-    else {
-	/* otherwise, entropy seed */
-	/* use whatever it was before, no wiping */
-	rn_current_state.a ^= 0xBF58476D1CE4E5B9;
-	/* time(NULL) = current UTC in seconds */
-	rn_current_state.a ^= (uint64_t)time(NULL) << 32;
-	/* clock() = clock_ticks since program start */
-	rn_current_state.a ^= (uint64_t)clock() * 65537;
-	/* rv_usec = second fraction of current time */
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	rn_current_state.a ^= (uint64_t)tv.tv_usec << 16;
-#ifdef SYS_getrandom
-	uint64_t dev_urandom;
-	if ( syscall(SYS_getrandom, &dev_urandom, sizeof(dev_urandom), GRND_NONBLOCK) == sizeof(dev_urandom) ) {
-	    rn_current_state.a ^= dev_urandom;
-	    traceEvent (TRACE_DEBUG, "random seed: successfully called getrandom syscall");
-	}
-#endif
-    }
-    /* stabilize in case of weak seed with only a few bits set */
-    for (int i = 0; i < 32; i++)
-	random_number_64();
-    /* set the reseed_counter to a value between 1 and 2^18
-       which roughly is the number of packets per two minutes
-       on a 1 Gbit line used to full capacity */
-    reseed_counter = (random_number_64() & 0x3ffff) + 1;
+    /* stabilize in unlikely case of weak state with only a few bits set */
+    for (uint8_t i = 0; i < 32; i++)
+	n2n_rand();
     return (0);
 }
 
@@ -98,14 +43,7 @@ static int32_t set_seed (uint64_t seed) {
    https://en.wikipedia.org/wiki/Xorshift as of July, 2019
    and thus is considered public domain.
  */
-static uint64_t xorshift128p_64 () {
-    if (reseed_counter > 0) {
-	reseed_counter--;
-	if (reseed_counter == 0) {
-	    set_seed (0);
-    	    traceEvent (TRACE_DEBUG, "random seed: successfully reseeded");
-	}
-    }
+uint64_t n2n_rand () {
     uint64_t t =  rn_current_state.a;
     uint64_t const s = rn_current_state.b;
     rn_current_state.a = s;
@@ -114,41 +52,4 @@ static uint64_t xorshift128p_64 () {
     t ^= s ^ (s >> 26);
     rn_current_state.b = t;
     return t + s;
-}
-
-static uint32_t xorshift128p_32 () {
-    if (reseed_counter > 0) {
-	reseed_counter--;
-	if (reseed_counter == 0) set_seed (0);
-    }
-    uint64_t t = rn_current_state.a;
-    uint64_t const s = rn_current_state.b;
-    rn_current_state.a = s;
-    t ^= t << 23;
-    t ^= t >> 17;
-    t ^= s ^ (s >> 26);
-    rn_current_state.b = t;
-    /* downcast to uint32_t */
-    return (uint32_t)(t + s);
-}
-
-/* ---  the following code is public/exported  ---
-	internal functions are wrapped for the
-	sake of future further ramification of
-	internal functions */
-
-int32_t random_number_seed (uint64_t seed) {
-    return (set_seed (seed));
-}
-
-uint64_t random_number_64 () {
-    return (xorshift128p_64 ());
-}
-
-uint32_t random_number_32 () {
-    if (reseed_counter > 0) {
-	reseed_counter--;
-	if (reseed_counter == 0) random_number_seed (0);
-    }
-    return (xorshift128p_32 ());
 }

--- a/random_numbers.c
+++ b/random_numbers.c
@@ -4,11 +4,18 @@
    on par with C's rand().
  */
 
+
+
 #include <stdint.h>
 #ifdef __GNUC__
 #include <sys/time.h>
 #endif
 #include <time.h>
+#ifdef __linux__
+    #include <sys/syscall.h>
+    #define GRND_NONBLOCK	1
+#endif
+#include "n2n.h"
 #include "random_numbers.h"
 
 struct rn_generator_state_t {
@@ -22,6 +29,8 @@ static struct rn_generator_state_t rn_current_state
 			       = { .a    = 0x9E3779B97F4A7C15,
 			           .b    = 0xBF58476D1CE4E5B9
 };
+
+static uint64_t reseed_counter = 0;
 
 /* taken from benchmark.c */
 #if defined(WIN32) && !defined(__GNUC__)
@@ -47,29 +56,41 @@ static int gettimeofday(struct timeval *tp, void *tzp)
 #endif
 
 static int32_t set_seed (uint64_t seed) {
-    /* shift a --> b , so
-       call this function 2 times to enter full 128 bit seed */
+    /* shift a --> b */
     rn_current_state.b = rn_current_state.a;
     /* for xorshift128p, an all zero state must be avoided
        so, we generally do not allow 0's */
     if (seed != 0) {
 	rn_current_state.a = seed;
+	reseed_counter = 0;
     }
     else {
 	/* otherwise, entropy seed */
 	/* use whatever it was before, no wiping */
 	rn_current_state.a ^= 0xBF58476D1CE4E5B9;
-	/* time(NULL) = currenctUTC in seconds;
-	   clock() = clock_ticks since program start */
-	rn_current_state.a ^= (uint64_t)time(NULL) * (uint64_t)clock();
+	/* time(NULL) = current UTC in seconds */
+	rn_current_state.a ^= (uint64_t)time(NULL) << 32;
+	/* clock() = clock_ticks since program start */
+	rn_current_state.a ^= (uint64_t)clock() * 65537;
 	/* rv_usec = second fraction of current time */
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
 	rn_current_state.a ^= (uint64_t)tv.tv_usec << 16;
+#ifdef SYS_getrandom
+	uint64_t dev_urandom;
+	if ( syscall(SYS_getrandom, &dev_urandom, sizeof(dev_urandom), GRND_NONBLOCK) == sizeof(dev_urandom) ) {
+	    rn_current_state.a ^= dev_urandom;
+	    traceEvent (TRACE_DEBUG, "random seed: successfully called getrandom syscall");
+	}
+#endif
     }
     /* stabilize in case of weak seed with only a few bits set */
     for (int i = 0; i < 32; i++)
 	random_number_64();
+    /* set the reseed_counter to a value between 1 and 2^18
+       which roughly is the number of packets per two minutes
+       on a 1 Gbit line used to full capacity */
+    reseed_counter = (random_number_64() & 0x3ffff) + 1;
     return (0);
 }
 
@@ -78,6 +99,13 @@ static int32_t set_seed (uint64_t seed) {
    and thus is considered public domain.
  */
 static uint64_t xorshift128p_64 () {
+    if (reseed_counter > 0) {
+	reseed_counter--;
+	if (reseed_counter == 0) {
+	    set_seed (0);
+    	    traceEvent (TRACE_DEBUG, "random seed: successfully reseeded");
+	}
+    }
     uint64_t t =  rn_current_state.a;
     uint64_t const s = rn_current_state.b;
     rn_current_state.a = s;
@@ -89,6 +117,10 @@ static uint64_t xorshift128p_64 () {
 }
 
 static uint32_t xorshift128p_32 () {
+    if (reseed_counter > 0) {
+	reseed_counter--;
+	if (reseed_counter == 0) set_seed (0);
+    }
     uint64_t t = rn_current_state.a;
     uint64_t const s = rn_current_state.b;
     rn_current_state.a = s;
@@ -114,5 +146,9 @@ uint64_t random_number_64 () {
 }
 
 uint32_t random_number_32 () {
+    if (reseed_counter > 0) {
+	reseed_counter--;
+	if (reseed_counter == 0) random_number_seed (0);
+    }
     return (xorshift128p_32 ());
 }

--- a/random_numbers.c
+++ b/random_numbers.c
@@ -59,13 +59,13 @@ static int32_t set_seed (uint64_t seed) {
 	/* otherwise, entropy seed */
 	/* use whatever it was before, no wiping */
 	rn_current_state.a ^= 0xBF58476D1CE4E5B9;
-	/* time(NULL) = currenctUTC in seconds; 
+	/* time(NULL) = currenctUTC in seconds;
 	   clock() = clock_ticks since program start */
 	rn_current_state.a ^= (uint64_t)time(NULL) * (uint64_t)clock();
 	/* rv_usec = second fraction of current time */
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
-	rn_current_state.a ^= (uint32_t)tv.tv_usec << 16;
+	rn_current_state.a ^= (uint64_t)tv.tv_usec << 16;
     }
     /* stabilize in case of weak seed with only a few bits set */
     for (int i = 0; i < 32; i++)

--- a/random_numbers.c
+++ b/random_numbers.c
@@ -1,0 +1,92 @@
+
+/* The following code offers an alterate pseudo random number generator
+   namely XORSHIFT128+ to use instead of C's pretty simple rand(). Its
+   performance is on par with C's rand().
+ */
+
+#include <stdint.h>
+#include "random_numbers.h"
+
+struct rn_generator_state_t {
+    uint64_t a, b;
+ };
+
+/* The state must be seeded so that it is not all zero, choose some
+   arbitrary defaults (in this case: taken from splitmix64)
+ */
+static struct rn_generator_state_t rn_current_state
+			       = { .a    = 0x9E3779B97F4A7C15,
+			           .b    = 0xBF58476D1CE4E5B9
+};
+
+static int32_t set_seed (uint64_t seed) {
+    /* shift a --> b , so
+       call this function 2 times to enter full 128 bit seed */
+    rn_current_state.b = rn_current_state.a;
+    /* for xorshift128p, an all zero state must be avoided
+       so, we generally do not allow 0's */
+    if (seed != 0) {
+	rn_current_state.a = seed;
+    }
+    else {
+	/* otherwise, default seed */
+	rn_current_state.a = 0x9E3779B97F4A7C15;
+    }
+    return (0);
+}
+
+/* The following code of xorshift128p was taken from
+   https://en.wikipedia.org/wiki/Xorshift as of July, 2019
+   and thus is considered public domain.
+ */
+static uint64_t xorshift128p_64 () {
+    uint64_t t =  rn_current_state.a;
+    uint64_t const s = rn_current_state.b;
+    rn_current_state.a = s;
+    t ^= t << 23;
+    t ^= t >> 17;
+    t ^= s ^ (s >> 26);
+    rn_current_state.b = t;
+    return t + s;
+}
+
+static uint32_t xorshift128p_32 () {
+    uint64_t t = rn_current_state.a;
+    uint64_t const s = rn_current_state.b;
+    rn_current_state.a = s;
+    t ^= t << 23;
+    t ^= t >> 17;
+    t ^= s ^ (s >> 26);
+    rn_current_state.b = t;
+    /* downcast to uint32_t */
+    return (uint32_t)(t + s);
+}
+
+/* ---  the following code is public/exported  ---
+	internal functions are wrapped for the
+	sake of future further ramification of
+	internal functions */
+
+int32_t random_number_seed (uint64_t seed) {
+    return (set_seed (seed));
+}
+
+uint64_t random_number_64 () {
+    return (xorshift128p_64 ());
+}
+
+uint32_t random_number_32 () {
+    return (xorshift128p_32 ());
+}
+
+// !!!
+#include <stdio.h>
+#include "n2n.h"
+int main() {
+  random_number_seed(1);
+  random_number_seed(1);
+  printf ("key: %llx %llx %llx\n", random_number_64(), random_number_64(), random_number_32());
+
+
+  return (0);
+}

--- a/random_numbers.h
+++ b/random_numbers.h
@@ -1,0 +1,5 @@
+int32_t random_number_seed(uint64_t seed);
+
+uint64_t random_number_64();
+
+uint32_t random_number_32();

--- a/random_numbers.h
+++ b/random_numbers.h
@@ -1,5 +1,3 @@
-int32_t random_number_seed(uint64_t seed);
+int32_t n2n_srand(uint64_t seed);
 
-uint64_t random_number_64();
-
-uint32_t random_number_32();
+uint64_t n2n_rand();

--- a/transform_aes.c
+++ b/transform_aes.c
@@ -18,6 +18,7 @@
 
 #include "n2n.h"
 #include "n2n_transforms.h"
+#include "random_numbers.h"
 
 #ifdef N2N_HAVE_AES
 
@@ -106,10 +107,8 @@ static int transop_encode_aes( n2n_trans_op_t * arg,
             encode_uint8( outbuf, &idx, N2N_AES_TRANSFORM_VERSION);
 
             /* Generate and encode the IV seed.
-             * Using two calls to rand() because RAND_MAX is usually < 64bit
-             * (e.g. linux) and sometimes < 32bit (e.g. Windows).
              */
-            iv_seed = ((((uint64_t)rand() & 0xFFFFFFFF)) << 32) | rand();
+            iv_seed = random_number_64();
             encode_buf(outbuf, &idx, &iv_seed, TRANSOP_AES_IV_SEED_SIZE);
 
             /* Encrypt the assembly contents and write the ciphertext after the iv seed. */

--- a/transform_aes.c
+++ b/transform_aes.c
@@ -108,7 +108,7 @@ static int transop_encode_aes( n2n_trans_op_t * arg,
 
             /* Generate and encode the IV seed.
              */
-            iv_seed = random_number_64();
+            iv_seed = n2n_rand();
             encode_buf(outbuf, &idx, &iv_seed, TRANSOP_AES_IV_SEED_SIZE);
 
             /* Encrypt the assembly contents and write the ciphertext after the iv seed. */

--- a/transform_tf.c
+++ b/transform_tf.c
@@ -19,6 +19,7 @@
 #include "n2n.h"
 #include "n2n_transforms.h"
 #include "twofish.h"
+#include "random_numbers.h"
 #ifndef _MSC_VER
 /* Not included in Visual Studio 2008 */
 #include <strings.h> /* index() */
@@ -89,7 +90,7 @@ static int transop_encode_twofish( n2n_trans_op_t * arg,
 	   * written in first followed by the packet payload. The whole
 	   * contents of assembly are encrypted. */
 	  pnonce = (uint32_t *)assembly;
-	  *pnonce = rand();
+	  *pnonce = random_number_32();
 	  memcpy( assembly + TRANSOP_TF_NONCE_SIZE, inbuf, in_len );
 
 	  /* Encrypt the assembly contents and write the ciphertext after the SA. */

--- a/transform_tf.c
+++ b/transform_tf.c
@@ -90,7 +90,7 @@ static int transop_encode_twofish( n2n_trans_op_t * arg,
 	   * written in first followed by the packet payload. The whole
 	   * contents of assembly are encrypted. */
 	  pnonce = (uint32_t *)assembly;
-	  *pnonce = random_number_32();
+	  *pnonce = n2n_rand();
 	  memcpy( assembly + TRANSOP_TF_NONCE_SIZE, inbuf, in_len );
 
 	  /* Encrypt the assembly contents and write the ciphertext after the SA. */

--- a/twofish.c
+++ b/twofish.c
@@ -40,8 +40,8 @@
 #include <time.h>
 #include <ctype.h>
 #include <sys/types.h>
-#include "random_numbers.h"
 #include "twofish.h"
+#include "random_numbers.h"
 
 /* Fixed 8x8 permutation S-boxes */
 static const uint8_t TwoFish_P[2][256] =

--- a/twofish.c
+++ b/twofish.c
@@ -40,6 +40,7 @@
 #include <time.h>
 #include <ctype.h>
 #include <sys/types.h>
+#include "random_numbers.h"
 #include "twofish.h"
 
 /* Fixed 8x8 permutation S-boxes */
@@ -403,7 +404,7 @@ uint32_t TwoFishEncrypt(uint8_t *in,
 	*out=TwoFishAlloc(ilen,binhex,FALSE,tfdata);  /* ...we'll (re-)allocate buffer space. */
       if(*out!=NULL)
 	{	tfdata->output=*out;							/* set output buffer. */
-	  tfdata->header.salt=rand()*65536+rand();		/* toss in some salt. */
+	  tfdata->header.salt=random_number_32()*65536+random_number_32();		/* toss in some salt. */
 	  tfdata->header.length[0]= (uint8_t)(ilen);
 	  tfdata->header.length[1]= (uint8_t)(ilen>>8);
 	  tfdata->header.length[2]= (uint8_t)(ilen>>16);
@@ -980,7 +981,7 @@ int main(int argc, char* argv[])
 
     for ( i=0; i<TEST_DATA_SIZE; ++i )
     {
-        in[i] = rand() & 0xff;
+        in[i] = random_number_32() & 0xff;
     }
 
     outp=outbuf;

--- a/twofish.c
+++ b/twofish.c
@@ -404,7 +404,7 @@ uint32_t TwoFishEncrypt(uint8_t *in,
 	*out=TwoFishAlloc(ilen,binhex,FALSE,tfdata);  /* ...we'll (re-)allocate buffer space. */
       if(*out!=NULL)
 	{	tfdata->output=*out;							/* set output buffer. */
-	  tfdata->header.salt=random_number_32()*65536+random_number_32();		/* toss in some salt. */
+	  tfdata->header.salt=n2n_rand()*65536+n2n_rand();		/* toss in some salt. */
 	  tfdata->header.length[0]= (uint8_t)(ilen);
 	  tfdata->header.length[1]= (uint8_t)(ilen>>8);
 	  tfdata->header.length[2]= (uint8_t)(ilen>>16);
@@ -981,7 +981,7 @@ int main(int argc, char* argv[])
 
     for ( i=0; i<TEST_DATA_SIZE; ++i )
     {
-        in[i] = random_number_32() & 0xff;
+        in[i] = n2n_rand() & 0xff;
     }
 
     outp=outbuf;


### PR DESCRIPTION
To better meet higher security standards, the use of C's linear congruent `rand()` function is replaced by the `xorshift128+` generator as random number generator. The `xorshift128+` generator has a period of 2^128 _(as opposed to 2^31)_, is way less linear, and passes major randomness testing _(BigCrush)_. Furthermore, its performance is on par with `rand()`.

Also, the seeding changed to more timer- as well as cpu cylce-depending values.

Even though this already is fully functional _(and thus provided as pull request)_, it is just the first step towards better random numbers – #117 is halfway done. Further steps to be taken include an additional generator as well as even more sophisticated seeding.