### PR TITLE
Update tuntap_osx.c error message.

### DIFF
--- a/tuntap_osx.c
+++ b/tuntap_osx.c
@@ -46,7 +46,7 @@ int tuntap_open(tuntap_dev *device /* ignored */,
   }
   
   if(device->fd < 0) {
-    traceEvent(TRACE_ERROR, "Unable to open tap device %s", tap_device);
+    traceEvent(TRACE_ERROR, "Unable to open any tap devices /dev/tap0 through /dev/tap254");
     traceEvent(TRACE_ERROR, "Please read https://github.com/ntop/n2n/blob/dev/doc/n2n_on_MacOS.txt");
     return(-1);
   } else {

--- a/tuntap_osx.c
+++ b/tuntap_osx.c
@@ -46,7 +46,7 @@ int tuntap_open(tuntap_dev *device /* ignored */,
   }
   
   if(device->fd < 0) {
-    traceEvent(TRACE_ERROR, "Unable to open any tap devices /dev/tap0 through /dev/tap254");
+    traceEvent(TRACE_ERROR, "Unable to open any tap devices /dev/tap0 through /dev/tap254. Is this user properly authorized to access those descriptors?");
     traceEvent(TRACE_ERROR, "Please read https://github.com/ntop/n2n/blob/dev/doc/n2n_on_MacOS.txt");
     return(-1);
   } else {


### PR DESCRIPTION
Adds clearer explanation of particular tuntap failure.

Previously, it would give a slightly confusing message about "Unable to open tap device /dev/tap254" whenever it failed -- even though the connection process attempted every number from 0 to 254 -- not just 254.

Also added a prompt to check file permissions on failure.