### PR TITLE
Fix OSX Catalina compilation failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ install(TARGETS edge supernode
 include_directories(.)
 
 add_executable(n2n-benchmark tools/benchmark.c)
-target_link_libraries(n2n-benchmark n2n)
+target_link_libraries(n2n-benchmark n2n ${OPENSSL_LIBRARIES})
 
 find_library(PCAP_LIB pcap)
 if(PCAP_LIB)


### PR DESCRIPTION
Include openssl library path for n2n-benchmark compilation

Fixes https://github.com/ntop/n2n/issues/222