### PR TITLE
transform_aes.c -- make openssl_err_as_string() static

### DIFF
--- a/transform_aes.c
+++ b/transform_aes.c
@@ -77,7 +77,7 @@ static int transop_deinit_aes(n2n_trans_op_t *arg) {
 #ifdef OPENSSL_1_1
 /* get any erorr message out of openssl
    taken from https://en.wikibooks.org/wiki/OpenSSL/Error_handling */
-char *openssl_err_as_string (void) {
+static char *openssl_err_as_string (void) {
   BIO *bio = BIO_new (BIO_s_mem ());
   ERR_print_errors (bio);
   char *buf = NULL;


### PR DESCRIPTION
This pull request makes openssl_err_as_string() static to avoid conflicts with other ciphers that would also use their own same-named function – those can't rely on the AES cipher being around and offering this function.