### PR TITLE
added optional payload compression (lzo) for all transforms

### DIFF
--- a/edge.c
+++ b/edge.c
@@ -175,6 +175,8 @@ static void help() {
 #ifdef N2N_HAVE_AES
   printf("-A                       | Use AES CBC for encryption (default=use twofish).\n");
 #endif
+  printf("-z                       | Enable lzo1x compression for outgoing data packets\n");
+  printf("                         | (default=disabled).\n");
   printf("-E                       | Accept multicast MAC addresses (default=drop).\n");
   printf("-S                       | Do not connect P2P. Always use the supernode.\n");
 #ifdef __linux__
@@ -291,6 +293,12 @@ static int setOption(int optkey, char *optargument, n2n_priv_config_t *ec, n2n_e
     }
 #endif
 
+  case 'z':
+    {
+      conf->compression = N2N_COMPRESSION_ID_LZO;
+      break;
+    }
+
   case 'l': /* supernode-list */
     if(optargument) {
       if(edge_conf_add_supernode(conf, optargument) != 0) {
@@ -398,7 +406,7 @@ static int loadFromCLI(int argc, char *argv[], n2n_edge_conf_t *conf, n2n_priv_c
   u_char c;
 
   while((c = getopt_long(argc, argv,
-			 "k:a:bc:Eu:g:m:M:s:d:l:p:fvhrt:i:SDL:"
+			 "k:a:bc:Eu:g:m:M:s:d:l:p:fvhrt:i:SDL:z"
 #ifdef N2N_HAVE_AES
 			 "A"
 #endif

--- a/n2n.h
+++ b/n2n.h
@@ -162,11 +162,16 @@ typedef struct tuntap_dev {
 #define MSG_TYPE_PEER_INFO              9
 #define MSG_TYPE_QUERY_PEER            10
 
-/* Set N2N_COMPRESSION_ENABLED to 0 to disable lzo1x compression of ethernet
- * frames. Doing this will break compatibility with the standard n2n packet
- * format so do it only for experimentation. All edges must be built with the
- * same value if they are to understand each other. */
-#define N2N_COMPRESSION_ENABLED 1
+/* N2N compression indicators. */
+/* Compression is disabled by default for outgoing packets if no cli
+ * option is given. All edges are built with decompression support so
+ * they are able to understand each other. */
+#define N2N_COMPRESSION_ID_NONE		0	/* default, see edge_init_conf_defaults(...) in edge_utils.c */
+#define N2N_COMPRESSION_ID_LZO		1	/* set if '-z' cli option is present, see setOption(...) in edge.c */
+
+#define N2N_COMPRESSION_ID_BITLEN	3	/* number of bits used for encoding compression id in the uppermost
+				 	           bits of transform_id; will be obsolete as soon as compression gets
+						   its own field in the packet. REVISIT then. */
 
 #define DEFAULT_MTU   1290
 
@@ -210,6 +215,7 @@ typedef struct n2n_edge_conf {
   n2n_sn_name_t       sn_ip_array[N2N_EDGE_NUM_SUPERNODES];
   n2n_community_t     community_name;         /**< The community. 16 full octets. */
   n2n_transform_t     transop_id;             /**< The transop to use. */
+  uint16_t	      compression;	      /**< Compress outgoing data packets before encryption */
   uint8_t             dyn_ip_mode;            /**< Interface IP address is dynamically allocated, eg. DHCP. */
   uint8_t             allow_routing;          /**< Accept packet no to interface address. */
   uint8_t             drop_multicast;         /**< Multicast ethernet addresses. */

--- a/n2n_wire.h
+++ b/n2n_wire.h
@@ -137,6 +137,7 @@ typedef struct n2n_PACKET
     n2n_mac_t           dstMac;
     n2n_sock_t          sock;
     uint16_t            transform;
+    uint16_t		compression;
 } n2n_PACKET_t;
 
 /* Linked with n2n_register_super in n2n_pc_t. Only from edge to supernode. */


### PR DESCRIPTION
This pull request adds optional payload compression (lzo) for all transforms. It is disabled by default and can be enabled using the new `-z` cli option – symbolizing a squeezed bouncy spring.

There is no need for having all edges enable compression. They all (after applying this pull request) will be able to decompress which is less costly in terms of required CPU power. Compression could be enabled on stronger CPUs only – maybe on desktop grade computers or any other use-case where you need to trade CPU power for bandwidth.

By free-riding on the uppermost bits of the 16-bit _transform_ field (which indicate the encryption type if any) in the packet, this remains compatible to current dev. As soon as major changes disrupt compatibility anyway, _compression_ could easily get its own field by appropriately changing `encode_PACKET(...)` and `decode_PACKET(...)` in `wire.c`.

The code is prepared to easily take your additional compression algorithms. For example, see the `switch` statements in `edge_utils.c`. Those could be chosen by having `-z` accept optional parameters, e.g. `-z2`.

Further discussion in #91 and #198.

Solves #91.