### PR TITLE
added optional payload compression (zstd) for all transforms

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -13,14 +13,24 @@ else
 GIT_RELEASE=${N2N_VERSION_SHORT}
 fi
 
+N2N_LIBS=
+
+AC_CHECK_LIB([zstd], [ZSTD_compress])
+
+if test "x$ac_cv_lib_zstd_ZSTD_compress" != xyes; then
+  AC_MSG_RESULT(Building n2n without ZSTD support)
+else
+  AC_DEFINE([N2N_HAVE_ZSTD], [], [Have ZSTD support])
+  N2N_LIBS="-lzstd ${N2N_LIBS}"
+fi
+
 AC_CHECK_LIB([crypto], [AES_cbc_encrypt])
 
-N2N_LIBS=
 if test "x$ac_cv_lib_crypto_AES_cbc_encrypt" != xyes; then
   AC_MSG_RESULT(Building n2n without AES support)
 else
   AC_DEFINE([N2N_HAVE_AES], [], [Have AES support])
-  N2N_LIBS=-lcrypto
+  N2N_LIBS="-lcrypto ${N2N_LIBS}"
 fi
 
 OLD_CFLAGS="${CFLAGS}"

--- a/edge_utils.c
+++ b/edge_utils.c
@@ -18,6 +18,7 @@
 
 #include "n2n.h"
 #include "lzoconf.h"
+#include <zstd.h>
 
 #ifdef WIN32
 #include <process.h>
@@ -148,6 +149,17 @@ static const char* transop_str(enum n2n_transform tr) {
 
 /* ************************************** */
 
+const char* compression_str(uint8_t cmpr) {
+  switch(cmpr) {
+  case N2N_COMPRESSION_ID_NONE:  return("none");
+  case N2N_COMPRESSION_ID_LZO:   return("lzo1x");
+  case N2N_COMPRESSION_ID_ZSTD:  return("zstd");
+  default:                       return("invalid");
+  };
+}
+
+/* ************************************** */
+
 /** Destination 01:00:5E:00:00:00 - 01:00:5E:7F:FF:FF is multicast ethernet.
  */
 static int is_ethMulticast(const void * buf, size_t bufsize) {
@@ -226,6 +238,10 @@ n2n_edge_t* edge_init(const tuntap_dev *dev, const n2n_edge_conf_t *conf, int *r
     traceEvent(TRACE_ERROR, "LZO compression error");
     goto edge_init_error;
   }
+
+#ifdef N2N_HAVE_ZSTD
+  // zstd does not require initialization. if it were required, this would be a good place
+#endif
 
   for(i=0; i<conf->sn_num; ++i)
     traceEvent(TRACE_NORMAL, "supernode %u => %s\n", i, (conf->sn_ip_array[i]));
@@ -967,20 +983,37 @@ static int handle_PACKET(n2n_edge_t * eee,
 
         /* decompress if necessary */
         uint8_t * deflation_buffer = 0;
-        uint32_t deflated_len;
+        int32_t deflated_len;
         switch (rx_compression_id) {
+          case N2N_COMPRESSION_ID_NONE:
+	    break; // continue afterwards
+
           case N2N_COMPRESSION_ID_LZO:
-	    deflation_buffer = malloc (N2N_PKT_BUF_SIZE);
+    	    deflation_buffer = malloc (N2N_PKT_BUF_SIZE);
 	    lzo1x_decompress (eth_payload, eth_size, deflation_buffer, (lzo_uint*)&deflated_len, NULL);
             break;
-
-          default:
+#ifdef N2N_HAVE_ZSTD
+	  case N2N_COMPRESSION_ID_ZSTD:
+	    deflated_len = N2N_PKT_BUF_SIZE;
+	    deflation_buffer = malloc (deflated_len);
+	    deflated_len = (int32_t)ZSTD_decompress (deflation_buffer, deflated_len, eth_payload, eth_size);
+	    if (ZSTD_isError(deflated_len)) {
+              traceEvent (TRACE_ERROR, "payload decompression failed with zstd error '%s'.",
+				       ZSTD_getErrorName(deflated_len));
+	      free (deflation_buffer);
+	      return (-1); // cannot help it
+	    }
             break;
+#endif
+          default:
+            traceEvent (TRACE_ERROR, "payload decompression failed: received packet indicating unsupported %s compression.",
+				     compression_str(rx_compression_id));
+	    return (-1); // cannot handle it
         }
 
         if (rx_compression_id) {
-          traceEvent (TRACE_DEBUG, "payload decompression [id: %u]: deflated %u bytes to %u bytes",
-                                   rx_compression_id, eth_size, (int)deflated_len);
+          traceEvent (TRACE_DEBUG, "payload decompression [%s]: deflated %u bytes to %u bytes",
+                                   compression_str(rx_compression_id), eth_size, (int)deflated_len);
           memcpy(eth_payload ,deflation_buffer, deflated_len );
           eth_size = deflated_len;
           free (deflation_buffer);
@@ -1345,9 +1378,11 @@ static void send_packet2net(n2n_edge_t * eee,
 
   // compression needs to be tried before encode_PACKET is called for compression indication gets encoded there
   pkt.compression = N2N_COMPRESSION_ID_NONE;
+
   if (eee->conf.compression) {
     uint8_t * compression_buffer;
-    uint32_t  compression_len;
+    int32_t  compression_len;
+
     switch (eee->conf.compression) {
         case N2N_COMPRESSION_ID_LZO:
           compression_buffer = malloc (len + len / 16 + 64 + 3);
@@ -1357,14 +1392,30 @@ static void send_packet2net(n2n_edge_t * eee,
             }
           }
           break;
-
+#ifdef N2N_HAVE_ZSTD
+        case N2N_COMPRESSION_ID_ZSTD:
+	  compression_len = N2N_PKT_BUF_SIZE + 128;
+          compression_buffer = malloc (compression_len); // leaves enough room, for exact size call compression_len = ZSTD_compressBound (len); (slower)
+	  compression_len = (int32_t)ZSTD_compress(compression_buffer, compression_len, tap_pkt, len, ZSTD_COMPRESSION_LEVEL) ;
+          if (!ZSTD_isError(compression_len)) {
+            if (compression_len < len) {
+              pkt.compression = N2N_COMPRESSION_ID_ZSTD;
+            }
+          } else {
+            traceEvent (TRACE_ERROR, "payload compression failed with zstd error '%s'.",
+				      ZSTD_getErrorName(compression_len));
+	    free (compression_buffer);
+	    // continue with unset without pkt.compression --> will send uncompressed
+	  }
+          break;
+#endif
         default:
           break;
     }
 
     if (pkt.compression) {
-      traceEvent (TRACE_DEBUG, "payload compression [id: %u]: compressed %u bytes to %u bytes\n",
-                               pkt.compression, len, compression_len);
+      traceEvent (TRACE_DEBUG, "payload compression [%s]: compressed %u bytes to %u bytes\n",
+                               compression_str(pkt.compression), len, compression_len);
 
       memcpy (tap_pkt, compression_buffer, compression_len);
       len = compression_len;

--- a/n2n.h
+++ b/n2n.h
@@ -165,9 +165,15 @@ typedef struct tuntap_dev {
 /* N2N compression indicators. */
 /* Compression is disabled by default for outgoing packets if no cli
  * option is given. All edges are built with decompression support so
- * they are able to understand each other. */
+ * they are able to understand each other (this applies to lzo only). */
 #define N2N_COMPRESSION_ID_NONE		0	/* default, see edge_init_conf_defaults(...) in edge_utils.c */
-#define N2N_COMPRESSION_ID_LZO		1	/* set if '-z' cli option is present, see setOption(...) in edge.c */
+#define N2N_COMPRESSION_ID_LZO		1	/* set if '-z1' or '-z' cli option is present, see setOption(...) in edge.c */
+#ifdef N2N_HAVE_ZSTD
+#define N2N_COMPRESSION_ID_ZSTD		2	/* set if '-z2' cli option is present, available only if compiled with zstd lib */
+#define ZSTD_COMPRESSION_LEVEL		7	/* 1 (faster) ... 22 (more compression) */
+#endif
+// with the next major packet structure update, make '0' = invalid, and '1' = no compression
+// '2' = LZO, '3' = ZSTD, ... REVISIT then (also: change all occurences in source).
 
 #define N2N_COMPRESSION_ID_BITLEN	3	/* number of bits used for encoding compression id in the uppermost
 				 	           bits of transform_id; will be obsolete as soon as compression gets
@@ -201,7 +207,6 @@ struct peer_info {
     HASH_ADD(hh,head,mac_addr,sizeof(n2n_mac_t),add)
 #define HASH_FIND_PEER(head,mac,out)                                           \
     HASH_FIND(hh,head,mac,sizeof(n2n_mac_t),out)
-
 #define N2N_EDGE_SN_HOST_SIZE   48
 #define N2N_EDGE_NUM_SUPERNODES 2
 #define N2N_EDGE_SUP_ATTEMPTS   3       /* Number of failed attmpts before moving on to next supernode. */
@@ -357,5 +362,5 @@ int quick_edge_init(char *device_name, char *community_name,
 int sn_init(n2n_sn_t *sss);
 void sn_term(n2n_sn_t *sss);
 int run_sn_loop(n2n_sn_t *sss, int *keep_running);
-
+const char* compression_str(uint8_t cmpr);
 #endif /* _N2N_H_ */


### PR DESCRIPTION
This pull request adds optional payload compression using zstd (if installed). If the library is found at compile time, it gets used.

The `-z` cli parameter handles compression as follows:
`-z1` or `-z` LZO compression (always available in n2n)
`-z2` ZSTD compression (if available/compiled)
Omitting any `-z_` parameter leaves the compression disabled for outgoing packets. 

However, an edge node will be able to decompress all incoming compressed packets – lzo (always) and zstd (if compiled). That way, _mixed_ networks in which weaker edges have compression (more costly in terms of CPU cycles) disabled will work.

In n2n, the compression level of zstd defaults to `7`. It is set by a `#define ZSTD_COMPRESSION_LEVEL` in line 173 of the `n2n.h` file.

This implementation does not change the packet layout. The compression indicator still free-rides on the transform indicator as introduced with lzo compression. It should be fully compatible to current dev.

See the (meanwhile closed) discussion of #91 for some more thoughts about compression in n2n.