### PR TITLE
added Speck

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -48,9 +48,9 @@ MAN7DIR=$(MANDIR)/man7
 MAN8DIR=$(MANDIR)/man8
 
 N2N_LIB=libn2n.a
-N2N_OBJS=n2n.o wire.o minilzo.o twofish.o \
+N2N_OBJS=n2n.o wire.o minilzo.o twofish.o speck.o \
 	 edge_utils.o sn_utils.o \
-         transform_null.o transform_tf.o transform_aes.o transform_cc20.o \
+         transform_null.o transform_tf.o transform_aes.o transform_cc20.o transform_speck.o \
          tuntap_freebsd.o tuntap_netbsd.o tuntap_linux.o \
 	 tuntap_osx.o
 LIBS_EDGE+=$(LIBS_EDGE_OPT)

--- a/Makefile.in
+++ b/Makefile.in
@@ -7,7 +7,7 @@ GIT_COMMITS=@GIT_COMMITS@
 
 CC?=gcc
 DEBUG?=-g3
-OPTIMIZATION?=-O3
+OPTIMIZATION?=-O3 -march=native
 WARN?=-Wall
 
 #Ultrasparc64 users experiencing SIGBUS should try the following gcc options

--- a/edge.c
+++ b/edge.c
@@ -179,6 +179,7 @@ static void help() {
 #endif
 #ifdef HAVE_OPENSSL_1_1
   printf("-A4                      | Use ChaCha20 for payload encryption. Requires a key.\n");
+  printf("-A5                      | Use Speck    for payload encryption. Requires a key.\n");
 #endif
   printf("-E                       | Accept multicast MAC addresses (default=drop).\n");
   printf("-S                       | Do not connect P2P. Always use the supernode.\n");
@@ -324,6 +325,11 @@ static int setOption(int optkey, char *optargument, n2n_priv_config_t *ec, n2n_e
 	  break;
 	}
 #endif
+      case 5:
+	{
+	  conf->transop_id = N2N_TRANSFORM_ID_SPECK;
+	  break;
+	}
       default:
 	{
  	  conf->transop_id = N2N_TRANSFORM_ID_INVAL;

--- a/edge_utils.c
+++ b/edge_utils.c
@@ -139,6 +139,7 @@ const char* transop_str(enum n2n_transform tr) {
   case N2N_TRANSFORM_ID_TWOFISH: return("twofish");
   case N2N_TRANSFORM_ID_AESCBC:  return("AES-CBC");
   case N2N_TRANSFORM_ID_CHACHA20:return("ChaCha20");
+  case N2N_TRANSFORM_ID_SPECK   :return("Speck");
   default:                       return("invalid");
   };
 }
@@ -247,6 +248,10 @@ n2n_edge_t* edge_init(const tuntap_dev *dev, const n2n_edge_conf_t *conf, int *r
     rc = n2n_transop_cc20_init(&eee->conf, &eee->transop);
     break;
 #endif
+  case N2N_TRANSFORM_ID_SPECK:
+    rc = n2n_transop_speck_init(&eee->conf, &eee->transop);
+    break;
+
   default:
     rc = n2n_transop_null_init(&eee->conf, &eee->transop);
   }

--- a/n2n.h
+++ b/n2n.h
@@ -296,6 +296,7 @@ int n2n_transop_aes_cbc_init(const n2n_edge_conf_t *conf, n2n_trans_op_t *ttt);
 #ifdef HAVE_OPENSSL_1_1
 int n2n_transop_cc20_init(const n2n_edge_conf_t *conf, n2n_trans_op_t *ttt);
 #endif
+int n2n_transop_speck_init(const n2n_edge_conf_t *conf, n2n_trans_op_t *ttt);
 
 /* Log */
 void setTraceLevel(int level);

--- a/n2n_transforms.h
+++ b/n2n_transforms.h
@@ -31,6 +31,7 @@ typedef enum n2n_transform {
   N2N_TRANSFORM_ID_TWOFISH = 2,
   N2N_TRANSFORM_ID_AESCBC = 3,
   N2N_TRANSFORM_ID_CHACHA20 = 4,
+  N2N_TRANSFORM_ID_SPECK = 5,
 } n2n_transform_t;
 
 struct n2n_trans_op;

--- a/speck.c
+++ b/speck.c
@@ -1,26 +1,223 @@
 // cipher SPECK -- 128 bit block size -- 256 bit key size
 // taken from (and modified: removed pure crypto-stream generation and seperated key expansion)
-// https://github.com/nsacyber/simon-speck-supercop/blob/master/crypto_stream/speck128256ctr/ref/stream.c
+// https://github.com/nsacyber/simon-speck-supercop/blob/master/crypto_stream/speck128256ctr/
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 
-// #define u64 unsigned long long
+#ifdef __SSE4_2__	// SSE support ----------------------------------------------------
+
+#include <smmintrin.h>
+
+#define u32 unsigned
+#define u64 unsigned long long
+#define u128 __m128i
+
+#define LCS(x,r) (((x)<<r)|((x)>>(64-r)))
+#define RCS(x,r) (((x)>>r)|((x)<<(64-r)))
+
+#define XOR _mm_xor_si128
+#define AND _mm_and_si128
+#define ADD _mm_add_epi64
+#define SL  _mm_slli_epi64
+#define SR  _mm_srli_epi64
+
+#define _q SET(0x1,0x0)
+#define _two SET(0x2,0x2)
+
+#define SET _mm_set_epi64x
+#define SET1(X,c) (X=SET(c,c))
+#define SET2(X,c) (X=SET(c,c), X=ADD(X,_q))
+
+#define LOW _mm_unpacklo_epi64
+#define HIGH _mm_unpackhi_epi64
+#define LD(ip) _mm_loadu_si128((__m128i *)(ip))
+#define ST(ip,X) _mm_storeu_si128((__m128i *)(ip),X)
+#define STORE(out,X,Y) (ST(out,LOW(Y,X)), ST(out+16,HIGH(Y,X)))
+#define STORE_ALT(out,X,Y) (ST(out,LOW(X,Y)), ST(out+16,HIGH(X,Y)))
+#define XOR_STORE(in,out,X,Y) (ST(out,XOR(LD(in),LOW(Y,X))), ST(out+16,XOR(LD(in+16),HIGH(Y,X))))
+#define XOR_STORE_ALT(in,out,X,Y) (ST(out,XOR(LD(in),LOW(X,Y))), ST(out+16,XOR(LD(in+16),HIGH(X,Y))))
+
+#define SHFL _mm_shuffle_epi8
+#define R8   _mm_set_epi64x(0x080f0e0d0c0b0a09LL,0x0007060504030201LL)
+#define L8   _mm_set_epi64x(0x0e0d0c0b0a09080fLL,0x0605040302010007LL)
+#define ROL8(X)  (SHFL(X,L8))
+#define ROR8(X)  (SHFL(X,R8))
+#define ROL(X,r) (XOR(SL(X,r),SR(X,(64-r))))
+#define ROR(X,r) (XOR(SR(X,r),SL(X,(64-r))))
+
+#define numrounds   34
+#define numkeywords 4
+
+#define R(X,Y,k) (X=XOR(ADD(ROR8(X),Y),k), Y=XOR(ROL(Y,3),X))
+
+#define Rx2(X,Y,k) (R(X[0],Y[0],k))
+#define Rx4(X,Y,k) (R(X[0],Y[0],k), R(X[1],Y[1],k))
+#define Rx6(X,Y,k) (R(X[0],Y[0],k), R(X[1],Y[1],k), R(X[2],Y[2],k))
+
+#define Rx8(X,Y,k) (X[0]=ROR8(X[0]), X[0]=ADD(X[0],Y[0]), X[1]=ROR8(X[1]), X[1]=ADD(X[1],Y[1]), \
+                    X[2]=ROR8(X[2]), X[2]=ADD(X[2],Y[2]), X[3]=ROR8(X[3]), X[3]=ADD(X[3],Y[3]), \
+                    X[0]=XOR(X[0],k), X[1]=XOR(X[1],k), X[2]=XOR(X[2],k), X[3]=XOR(X[3],k), \
+                    Z[0]=Y[0], Z[1]=Y[1], Z[2]=Y[2], Z[3]=Y[3],         \
+                    Z[0]=SL(Z[0],3),  Y[0]=SR(Y[0],61), Z[1]=SL(Z[1],3), Y[1]=SR(Y[1],61), \
+                    Z[2]=SL(Z[2],3),  Y[2]=SR(Y[2],61), Z[3]=SL(Z[3],3), Y[3]=SR(Y[3],61), \
+                    Y[0]=XOR(Y[0],Z[0]), Y[1]=XOR(Y[1],Z[1]), Y[2]=XOR(Y[2],Z[2]), Y[3]=XOR(Y[3],Z[3]), \
+                    Y[0]=XOR(X[0],Y[0]), Y[1]=XOR(X[1],Y[1]), Y[2]=XOR(X[2],Y[2]), Y[3]=XOR(X[3],Y[3]))
+
+#define Rx1(x,y,k) (x[0]=RCS(x[0],8), x[0]+=y[0], x[0]^=k, y[0]=LCS(y[0],3), y[0]^=x[0])
+
+#define Rx1b(x,y,k) (x=RCS(x,8), x+=y, x^=k, y=LCS(y,3), y^=x)
+
+#define Encrypt(X,Y,k,n) (Rx##n(X,Y,k[0]),  Rx##n(X,Y,k[1]),  Rx##n(X,Y,k[2]),  Rx##n(X,Y,k[3]),  Rx##n(X,Y,k[4]),  Rx##n(X,Y,k[5]),  Rx##n(X,Y,k[6]),  Rx##n(X,Y,k[7]), \
+                          Rx##n(X,Y,k[8]),  Rx##n(X,Y,k[9]),  Rx##n(X,Y,k[10]), Rx##n(X,Y,k[11]), Rx##n(X,Y,k[12]), Rx##n(X,Y,k[13]), Rx##n(X,Y,k[14]), Rx##n(X,Y,k[15]), \
+                          Rx##n(X,Y,k[16]), Rx##n(X,Y,k[17]), Rx##n(X,Y,k[18]), Rx##n(X,Y,k[19]), Rx##n(X,Y,k[20]), Rx##n(X,Y,k[21]), Rx##n(X,Y,k[22]), Rx##n(X,Y,k[23]), \
+                          Rx##n(X,Y,k[24]), Rx##n(X,Y,k[25]), Rx##n(X,Y,k[26]), Rx##n(X,Y,k[27]), Rx##n(X,Y,k[28]), Rx##n(X,Y,k[29]), Rx##n(X,Y,k[30]), Rx##n(X,Y,k[31]), \
+                          Rx##n(X,Y,k[32]), Rx##n(X,Y,k[33]))
+
+#define RK(X,Y,k,key,i)   (SET1(k[i],Y), key[i]=Y, X=RCS(X,8), X+=Y, X^=i, Y=LCS(Y,3), Y^=X)
+
+#define EK(A,B,C,D,k,key) (RK(B,A,k,key,0),  RK(C,A,k,key,1),  RK(D,A,k,key,2),  RK(B,A,k,key,3),  RK(C,A,k,key,4),  RK(D,A,k,key,5),  RK(B,A,k,key,6), \
+                           RK(C,A,k,key,7),  RK(D,A,k,key,8),  RK(B,A,k,key,9),  RK(C,A,k,key,10), RK(D,A,k,key,11), RK(B,A,k,key,12), RK(C,A,k,key,13), \
+                           RK(D,A,k,key,14), RK(B,A,k,key,15), RK(C,A,k,key,16), RK(D,A,k,key,17), RK(B,A,k,key,18), RK(C,A,k,key,19), RK(D,A,k,key,20), \
+                           RK(B,A,k,key,21), RK(C,A,k,key,22), RK(D,A,k,key,23), RK(B,A,k,key,24), RK(C,A,k,key,25), RK(D,A,k,key,26), RK(B,A,k,key,27), \
+                           RK(C,A,k,key,28), RK(D,A,k,key,29), RK(B,A,k,key,30), RK(C,A,k,key,31), RK(D,A,k,key,32), RK(B,A,k,key,33))
+
+typedef struct {
+	u128 rk[34];
+	u64 key[34];
+} speck_context_t;
+
+
+static int speck_encrypt_xor (unsigned char *out, const unsigned char *in, u64 nonce[], speck_context_t ctx, int numbytes) {
+
+	u64  x[2], y[2];
+	u128 X[4], Y[4], Z[4];
+
+	if (numbytes == 16) {
+		x[0] = nonce[1]; y[0] = nonce[0]; nonce[0]++;
+		Encrypt (x, y, ctx.key, 1);
+		((u64 *)out)[1] = x[0]; ((u64 *)out)[0] = y[0];
+		return 0;
+	}
+
+	SET1 (X[0], nonce[1]); SET2 (Y[0], nonce[0]);
+
+	if (numbytes == 32)
+		Encrypt (X, Y, ctx.rk, 2);
+	else {
+		X[1] = X[0]; Y[1] = ADD (Y[0], _two);
+		if (numbytes == 64)
+			Encrypt (X, Y, ctx.rk, 4);
+		else {
+			X[2] = X[0]; Y[2] = ADD (Y[1], _two);
+			if (numbytes == 96)
+				Encrypt (X, Y, ctx.rk, 6);
+			else {
+				X[3] = X[0]; Y[3] = ADD (Y[2], _two);
+				Encrypt (X, Y, ctx.rk, 8);
+			}
+		}
+	}
+
+	nonce[0] += (numbytes>>4);
+
+	XOR_STORE (in, out, X[0], Y[0]);
+	if (numbytes >= 64)
+		XOR_STORE (in + 32, out + 32, X[1], Y[1]);
+	if (numbytes >= 96)
+		XOR_STORE (in + 64, out + 64, X[2], Y[2]);
+	if (numbytes >= 128)
+		XOR_STORE (in + 96, out + 96, X[3], Y[3]);
+
+	return 0;
+}
+
+
+int speck_expand_key (const unsigned char *k, speck_context_t *ctx) {
+
+	u64 K[4];
+	size_t i;
+	for(i = 0; i < numkeywords; i++)
+		K[i] = ((u64 *)k)[i];
+
+	EK (K[0], K[1], K[2], K[3], ctx->rk, ctx->key);
+
+	return 0;
+}
+
+
+int speck_ctr (unsigned char *out, const unsigned char *in, unsigned long long inlen,
+	       const unsigned char *n, speck_context_t ctx) {
+
+	int i;
+	u64 nonce[2];
+	unsigned char block[16];
+	u64 * const block64 = (u64 *)block;
+
+	if (!inlen)
+		return 0;
+
+	nonce[0] = ((u64 *)n)[0];
+	nonce[1] = ((u64 *)n)[1];
+
+	while (inlen >= 128) {
+		speck_encrypt_xor (out, in, nonce, ctx, 128);
+		in += 128; inlen -= 128; out += 128;
+	}
+
+	if (inlen >= 96) {
+		speck_encrypt_xor (out, in, nonce, ctx, 96);
+		in += 96; inlen -= 96; out += 96;
+	}
+
+	if (inlen >= 64) {
+		speck_encrypt_xor (out, in, nonce, ctx, 64);
+		in += 64; inlen -= 64; out += 64;
+	}
+
+	if (inlen >= 32) {
+		speck_encrypt_xor (out, in, nonce, ctx, 32);
+		in += 32; inlen -= 32; out += 32;
+	}
+
+	if (inlen >= 16) {
+		speck_encrypt_xor (block, in, nonce, ctx, 16);
+		((u64 *)out)[0] = block64[0] ^ ((u64 *)in)[0];
+		((u64 *)out)[1] = block64[1] ^ ((u64 *)in)[1];
+		in += 16; inlen -= 16; out += 16;
+	}
+
+	if (inlen > 0) {
+		speck_encrypt_xor (block, in, nonce, ctx, 16);
+		for (i = 0; i < inlen; i++)
+			out[i] = block[i] ^ in[i];
+	}
+
+	return 0;
+}
+
+
+#else 		// (close to) C reference code --------------------------------------------
+
+
 #define u64 uint64_t
 
 #define ROR64(x,r) (((x)>>(r))|((x)<<(64-(r))))
 #define ROL64(x,r) (((x)<<(r))|((x)>>(64-(r))))
 #define R(x,y,k) (x=ROR64(x,8), x+=y, x^=k, y=ROL64(y,3), y^=x)
-#define RI(x,y,k) (y^=x, y=ROR64(y,3), x^=k, x-=y, x=ROL64(x,8))
+
+typedef struct {
+	u64 key[34];
+} speck_context_t;
 
 
-static int speck_encrypt(u64 *u, u64 *v, u64 key[]) {
+static int speck_encrypt (u64 *u, u64 *v, speck_context_t ctx) {
 
 	u64 i, x = *u, y = *v;
 
 	for (i = 0; i < 34; i++)
-		R (x, y, key[i]);
+		R (x, y, ctx.key[i]);
 
 	*u = x; *v = y;
 
@@ -28,24 +225,8 @@ static int speck_encrypt(u64 *u, u64 *v, u64 key[]) {
 }
 
 
-// not neccessary for CTR mode
-/* static int speck_decrypt(u64 *u, u64 *v, u64 key[]) {
-
-	int i;
-	u64 x=*u,y=*v;
-	for (i = 33; i >= 0 ;i--)
-		RI (x, y, key[i]);
-
-	*u = x; *v = y;
-
-	return 0;
-} */
-
-
-int speck_ctr (unsigned char *out, const unsigned char *in,
-	       unsigned long long inlen,
-	       const unsigned char *n,
-	       u64 rk[]) {
+int speck_ctr (unsigned char *out, const unsigned char *in, unsigned long long inlen,
+	       const unsigned char *n, speck_context_t ctx) {
 
 	u64 i, nonce[2], x, y, t;
 	unsigned char *block = malloc (16);
@@ -54,15 +235,13 @@ int speck_ctr (unsigned char *out, const unsigned char *in,
 		free (block);
 		return 0;
 	}
-// !!! htole64 !!!
 	nonce[0] = htole64 ( ((u64*)n)[0] );
 	nonce[1] = htole64 ( ((u64*)n)[1] );
 
 	t=0;
-	while(inlen >= 16) {
+	while (inlen >= 16) {
 		x = nonce[1]; y = nonce[0]; nonce[0]++;
-		speck_encrypt (&x, &y, rk);
-// !!! htole64 !!!
+		speck_encrypt (&x, &y, ctx);
 		((u64 *)out)[1+t] = htole64 (x ^ ((u64 *)in)[1+t]);
 		((u64 *)out)[0+t] = htole64 (y ^ ((u64 *)in)[0+t]);
 		t += 2;
@@ -70,40 +249,39 @@ int speck_ctr (unsigned char *out, const unsigned char *in,
 	}
 	if (inlen > 0) {
 		x = nonce[1]; y = nonce[0];
-		speck_encrypt (&x, &y, rk);
-// !!! htole64 !!!
+		speck_encrypt (&x, &y, ctx);
 		((u64 *)block)[1] = htole64 (x); ((u64 *)block)[0] = htole64 (y);
-		for (i=0; i < inlen; i++)
+		for (i = 0; i < inlen; i++)
 			out[i + 8*t] = block[i] ^ in[i + 8*t];
 	}
 
 	free (block);
-
 	return 0;
 }
 
 
-int speck_expand_key (const unsigned char *k, u64 rk[]) {
+int speck_expand_key (const unsigned char *k, speck_context_t * ctx) {
 
 	u64 K[4];
 	u64 i;
 
-	for (i=0; i < 4; i++)
-// !!! htole64 !!!
+	for (i = 0; i < 4; i++)
 		K[i] = htole64 ( ((u64 *)k)[i] );
 
-
-	u64 D = K[3], C = K[2], B = K[1], A = K[0];
-
 	for (i = 0; i < 33; i += 3) {
-		rk[i  ] = A; R (B, A, i    );
-		rk[i+1] = A; R (C, A, i + 1);
-		rk[i+2] = A; R (D, A, i + 2);
+		ctx->key[i  ] = K[0];
+		R (K[1], K[0], i    );
+		ctx->key[i+1] = K[0];
+		R (K[2], K[0], i + 1);
+		ctx->key[i+2] = K[0];
+		R (K[3], K[0], i + 2);
 	}
-	rk[33] = A;
-
+	ctx->key[33] = K[0];
 	return 1;
 }
+
+
+#endif // SSE, C ref
 
 
 int speck_test () {
@@ -123,18 +301,22 @@ int speck_test () {
 	uint8_t ct[16]  = { 0x43, 0x8f, 0x18, 0x9c, 0x8d, 0xb4, 0xee, 0x4e,
 			    0x3e, 0xf5, 0xc0, 0x05, 0x04, 0x01, 0x09, 0x41 };
 
-	u64 round_keys[34];
-	speck_expand_key (key, round_keys);
 
-	speck_ctr (pt, pt, 16, iv, round_keys);
 
-fprintf (stderr, "rk00: %016lx\n",             round_keys[0]);
-fprintf (stderr, "rk33: %016lx\n",             round_keys[33]);
+	speck_context_t ctx;
+
+	speck_expand_key (key, &ctx);
+
+	speck_ctr (pt, pt, 16, iv, ctx);
+
+	u64 i;
+fprintf (stderr, "rk00: %016llx\n",  ctx.key[0]);
+fprintf (stderr, "rk33: %016llx\n",  ctx.key[33]);
 fprintf (stderr, "out : %016lx\n", *(uint64_t*)pt);
-fprintf (stderr, "mem : " ); for (int i=0; i < 16; i++) fprintf (stderr, "%02x ", pt[i]); fprintf (stderr, "\n");
+fprintf (stderr, "mem : " ); for (i=0; i < 16; i++) fprintf (stderr, "%02x ", pt[i]); fprintf (stderr, "\n");
 
 	int ret = 1;
-	for (int i=0; i < 16; i++)
+	for (i=0; i < 16; i++)
 		if (pt[i] != ct[i]) ret = 0;
 
 	return (ret);
@@ -146,4 +328,3 @@ int main (int argc, char* argv[]) {
 	fprintf (stdout, "SPECK SELF TEST RESULT: %u\n", speck_test (0,NULL));
 }
 */
-

--- a/speck.c
+++ b/speck.c
@@ -1,0 +1,149 @@
+// cipher SPECK -- 128 bit block size -- 256 bit key size
+// taken from (and modified: removed pure crypto-stream generation and seperated key expansion)
+// https://github.com/nsacyber/simon-speck-supercop/blob/master/crypto_stream/speck128256ctr/ref/stream.c
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+// #define u64 unsigned long long
+#define u64 uint64_t
+
+#define ROR64(x,r) (((x)>>(r))|((x)<<(64-(r))))
+#define ROL64(x,r) (((x)<<(r))|((x)>>(64-(r))))
+#define R(x,y,k) (x=ROR64(x,8), x+=y, x^=k, y=ROL64(y,3), y^=x)
+#define RI(x,y,k) (y^=x, y=ROR64(y,3), x^=k, x-=y, x=ROL64(x,8))
+
+
+static int speck_encrypt(u64 *u, u64 *v, u64 key[]) {
+
+	u64 i, x = *u, y = *v;
+
+	for (i = 0; i < 34; i++)
+		R (x, y, key[i]);
+
+	*u = x; *v = y;
+
+	return 0;
+}
+
+
+// not neccessary for CTR mode
+/* static int speck_decrypt(u64 *u, u64 *v, u64 key[]) {
+
+	int i;
+	u64 x=*u,y=*v;
+	for (i = 33; i >= 0 ;i--)
+		RI (x, y, key[i]);
+
+	*u = x; *v = y;
+
+	return 0;
+} */
+
+
+int speck_ctr (unsigned char *out, const unsigned char *in,
+	       unsigned long long inlen,
+	       const unsigned char *n,
+	       u64 rk[]) {
+
+	u64 i, nonce[2], x, y, t;
+	unsigned char *block = malloc (16);
+
+	if (!inlen) {
+		free (block);
+		return 0;
+	}
+// !!! htole64 !!!
+	nonce[0] = htole64 ( ((u64*)n)[0] );
+	nonce[1] = htole64 ( ((u64*)n)[1] );
+
+	t=0;
+	while(inlen >= 16) {
+		x = nonce[1]; y = nonce[0]; nonce[0]++;
+		speck_encrypt (&x, &y, rk);
+// !!! htole64 !!!
+		((u64 *)out)[1+t] = htole64 (x ^ ((u64 *)in)[1+t]);
+		((u64 *)out)[0+t] = htole64 (y ^ ((u64 *)in)[0+t]);
+		t += 2;
+		inlen -= 16;
+	}
+	if (inlen > 0) {
+		x = nonce[1]; y = nonce[0];
+		speck_encrypt (&x, &y, rk);
+// !!! htole64 !!!
+		((u64 *)block)[1] = htole64 (x); ((u64 *)block)[0] = htole64 (y);
+		for (i=0; i < inlen; i++)
+			out[i + 8*t] = block[i] ^ in[i + 8*t];
+	}
+
+	free (block);
+
+	return 0;
+}
+
+
+int speck_expand_key (const unsigned char *k, u64 rk[]) {
+
+	u64 K[4];
+	u64 i;
+
+	for (i=0; i < 4; i++)
+// !!! htole64 !!!
+		K[i] = htole64 ( ((u64 *)k)[i] );
+
+
+	u64 D = K[3], C = K[2], B = K[1], A = K[0];
+
+	for (i = 0; i < 33; i += 3) {
+		rk[i  ] = A; R (B, A, i    );
+		rk[i+1] = A; R (C, A, i + 1);
+		rk[i+2] = A; R (D, A, i + 2);
+	}
+	rk[33] = A;
+
+	return 1;
+}
+
+
+int speck_test () {
+
+	uint8_t key[32] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			    0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+			    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			    0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F };
+
+
+	uint8_t iv[16]  = { 0x70, 0x6f, 0x6f, 0x6e, 0x65, 0x72, 0x2e, 0x20,
+			    0x49, 0x6e, 0x20, 0x74, 0x68, 0x6f, 0x73, 0x65 };
+
+	uint8_t pt[16]  = { 0x00 };
+
+	// expected outcome (according to pp. 35 & 36 of Implementation Guide)
+	uint8_t ct[16]  = { 0x43, 0x8f, 0x18, 0x9c, 0x8d, 0xb4, 0xee, 0x4e,
+			    0x3e, 0xf5, 0xc0, 0x05, 0x04, 0x01, 0x09, 0x41 };
+
+	u64 round_keys[34];
+	speck_expand_key (key, round_keys);
+
+	speck_ctr (pt, pt, 16, iv, round_keys);
+
+fprintf (stderr, "rk00: %016lx\n",             round_keys[0]);
+fprintf (stderr, "rk33: %016lx\n",             round_keys[33]);
+fprintf (stderr, "out : %016lx\n", *(uint64_t*)pt);
+fprintf (stderr, "mem : " ); for (int i=0; i < 16; i++) fprintf (stderr, "%02x ", pt[i]); fprintf (stderr, "\n");
+
+	int ret = 1;
+	for (int i=0; i < 16; i++)
+		if (pt[i] != ct[i]) ret = 0;
+
+	return (ret);
+}
+
+/*
+int main (int argc, char* argv[]) {
+
+	fprintf (stdout, "SPECK SELF TEST RESULT: %u\n", speck_test (0,NULL));
+}
+*/
+

--- a/speck.c
+++ b/speck.c
@@ -6,7 +6,214 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#if defined (__SSE4_2__)// SSE support ----------------------------------------------------
+
+#if defined (__AVX2__)	// AVX support ----------------------------------------------------
+
+#include <immintrin.h>
+
+#define u32 uint32_t
+#define u64 uint64_t
+#define u256 __m256i
+
+#define LCS(x,r) (((x)<<r)|((x)>>(64-r)))
+#define RCS(x,r) (((x)>>r)|((x)<<(64-r)))
+
+#define XOR _mm256_xor_si256
+#define AND _mm256_and_si256
+#define ADD _mm256_add_epi64
+#define SL  _mm256_slli_epi64
+#define SR  _mm256_srli_epi64
+
+#define _q SET(0x3,0x1,0x2,0x0)
+#define _four SET(0x4,0x4,0x4,0x4)
+
+#define SET _mm256_set_epi64x
+#define SET1(X,c) (X=SET(c,c,c,c))
+#define SET4(X,c) (X=SET(c,c,c,c), X=ADD(X,_q))
+
+#define LOW  _mm256_unpacklo_epi64
+#define HIGH _mm256_unpackhi_epi64
+#define LD(ip) _mm256_loadu_si256((__m256i *)(ip))
+#define ST(ip,X) _mm256_storeu_si256((__m256i *)(ip),X)
+#define STORE(out,X,Y) (ST(out,LOW(Y,X)), ST(out+32,HIGH(Y,X)))
+#define STORE_ALT(out,X,Y) (ST(out,LOW(X,Y)), ST(out+32,HIGH(X,Y)))
+#define XOR_STORE(in,out,X,Y) (ST(out,XOR(LD(in),LOW(Y,X))), ST(out+32,XOR(LD(in+32),HIGH(Y,X))))
+#define XOR_STORE_ALT(in,out,X,Y) (ST(out,XOR(LD(in),LOW(X,Y))), ST(out+32,XOR(LD(in+32),HIGH(X,Y))))
+
+#define SHFL _mm256_shuffle_epi8
+#define R8 SET(0x080f0e0d0c0b0a09LL,0x0007060504030201LL,0x080f0e0d0c0b0a09LL,0x0007060504030201LL)
+#define L8 SET(0x0e0d0c0b0a09080fLL,0x0605040302010007LL,0x0e0d0c0b0a09080fLL,0x0605040302010007LL)
+#define ROL8(X)  (SHFL(X,L8))
+#define ROR8(X)  (SHFL(X,R8))
+#define ROL(X,r) (XOR(SL(X,r),SR(X,(64-r))))
+#define ROR(X,r) (XOR(SR(X,r),SL(X,(64-r))))
+
+#define numrounds   34
+#define numkeywords 4
+
+#define R(X,Y,k) (X=XOR(ADD(ROR8(X),Y),k), Y=XOR(ROL(Y,3),X))
+
+#define Rx4(X,Y,k)  (R(X[0],Y[0],k))
+#define Rx8(X,Y,k)  (R(X[0],Y[0],k), R(X[1],Y[1],k))
+#define Rx12(X,Y,k) (R(X[0],Y[0],k), R(X[1],Y[1],k), R(X[2],Y[2],k))
+
+#define Rx16(X,Y,k) (X[0]=ROR8(X[0]), X[0]=ADD(X[0],Y[0]), X[1]=ROR8(X[1]), X[1]=ADD(X[1],Y[1]), \
+		     X[2]=ROR8(X[2]), X[2]=ADD(X[2],Y[2]), X[3]=ROR8(X[3]), X[3]=ADD(X[3],Y[3]), \
+		     X[0]=XOR(X[0],k), X[1]=XOR(X[1],k), X[2]=XOR(X[2],k), X[3]=XOR(X[3],k), \
+		     Z[0]=Y[0], Z[1]=Y[1], Z[2]=Y[2], Z[3]=Y[3],	\
+		     Z[0]=SL(Z[0],3),  Y[0]=SR(Y[0],61), Z[1]=SL(Z[1],3), Y[1]=SR(Y[1],61), \
+		     Z[2]=SL(Z[2],3),  Y[2]=SR(Y[2],61), Z[3]=SL(Z[3],3), Y[3]=SR(Y[3],61), \
+		     Y[0]=XOR(Y[0],Z[0]), Y[1]=XOR(Y[1],Z[1]), Y[2]=XOR(Y[2],Z[2]), Y[3]=XOR(Y[3],Z[3]), \
+		     Y[0]=XOR(X[0],Y[0]), Y[1]=XOR(X[1],Y[1]), Y[2]=XOR(X[2],Y[2]), Y[3]=XOR(X[3],Y[3]))
+
+#define Rx2(x,y,k) (x[0]=RCS(x[0],8), x[1]=RCS(x[1],8), x[0]+=y[0], x[1]+=y[1],	\
+                    x[0]^=k, x[1]^=k, y[0]=LCS(y[0],3), y[1]=LCS(y[1],3), y[0]^=x[0], y[1]^=x[1])
+
+#define Rx1(x,y,k) (x[0]=RCS(x[0],8), x[0]+=y[0], x[0]^=k, y[0]=LCS(y[0],3), y[0]^=x[0])
+
+#define Rx1b(x,y,k) (x=RCS(x,8), x+=y, x^=k, y=LCS(y,3), y^=x)
+
+#define Enc(X,Y,k,n) (Rx##n(X,Y,k[0]),  Rx##n(X,Y,k[1]),  Rx##n(X,Y,k[2]),  Rx##n(X,Y,k[3]),  Rx##n(X,Y,k[4]),  Rx##n(X,Y,k[5]),  Rx##n(X,Y,k[6]),  Rx##n(X,Y,k[7]), \
+		      Rx##n(X,Y,k[8]),  Rx##n(X,Y,k[9]),  Rx##n(X,Y,k[10]), Rx##n(X,Y,k[11]), Rx##n(X,Y,k[12]), Rx##n(X,Y,k[13]), Rx##n(X,Y,k[14]), Rx##n(X,Y,k[15]), \
+		      Rx##n(X,Y,k[16]), Rx##n(X,Y,k[17]), Rx##n(X,Y,k[18]), Rx##n(X,Y,k[19]), Rx##n(X,Y,k[20]), Rx##n(X,Y,k[21]), Rx##n(X,Y,k[22]), Rx##n(X,Y,k[23]), \
+		      Rx##n(X,Y,k[24]), Rx##n(X,Y,k[25]), Rx##n(X,Y,k[26]), Rx##n(X,Y,k[27]), Rx##n(X,Y,k[28]), Rx##n(X,Y,k[29]), Rx##n(X,Y,k[30]), Rx##n(X,Y,k[31]), \
+		      Rx##n(X,Y,k[32]), Rx##n(X,Y,k[33]))
+
+#define RK(X,Y,k,key,i)   (SET1(k[i],Y), key[i]=Y, X=RCS(X,8), X+=Y, X^=i, Y=LCS(Y,3), Y^=X)
+
+#define EK(A,B,C,D,k,key) (RK(B,A,k,key,0),  RK(C,A,k,key,1),  RK(D,A,k,key,2),  RK(B,A,k,key,3),  RK(C,A,k,key,4),  RK(D,A,k,key,5),  RK(B,A,k,key,6), \
+			   RK(C,A,k,key,7),  RK(D,A,k,key,8),  RK(B,A,k,key,9),  RK(C,A,k,key,10), RK(D,A,k,key,11), RK(B,A,k,key,12), RK(C,A,k,key,13), \
+			   RK(D,A,k,key,14), RK(B,A,k,key,15), RK(C,A,k,key,16), RK(D,A,k,key,17), RK(B,A,k,key,18), RK(C,A,k,key,19), RK(D,A,k,key,20), \
+			   RK(B,A,k,key,21), RK(C,A,k,key,22), RK(D,A,k,key,23), RK(B,A,k,key,24), RK(C,A,k,key,25), RK(D,A,k,key,26), RK(B,A,k,key,27), \
+			   RK(C,A,k,key,28), RK(D,A,k,key,29), RK(B,A,k,key,30), RK(C,A,k,key,31), RK(D,A,k,key,32), RK(B,A,k,key,33))
+
+typedef struct {
+	u256 rk[34];
+	u64 key[34];
+} speck_context_t;
+
+
+static int Encrypt_Xor(unsigned char *out, const unsigned char *in, u64 nonce[], speck_context_t *ctx, int numbytes)
+{
+  u64  x[2],y[2];
+  u256 X[4],Y[4],Z[4];
+
+  if (numbytes==16){
+    x[0]=nonce[1]; y[0]=nonce[0]; nonce[0]++;
+    Enc(x,y,ctx->key,1);
+    ((u64 *)out)[1]=x[0]; ((u64 *)out)[0]=y[0];
+
+    return 0;
+  }
+
+  if (numbytes==32){
+    x[0]=nonce[1]; y[0]=nonce[0]; nonce[0]++;
+    x[1]=nonce[1]; y[1]=nonce[0]; nonce[0]++;
+    Enc(x,y,ctx->key,2);
+    ((u64 *)out)[1]=x[0]^((u64 *)in)[1]; ((u64 *)out)[0]=y[0]^((u64 *)in)[0];
+    ((u64 *)out)[3]=x[1]^((u64 *)in)[3]; ((u64 *)out)[2]=y[1]^((u64 *)in)[2];
+
+    return 0;
+  }
+
+  SET1(X[0],nonce[1]); SET4(Y[0],nonce[0]);
+
+  if (numbytes==64) Enc(X,Y,ctx->rk,4);
+  else{
+    X[1]=X[0];
+    Y[1]=ADD(Y[0],_four);
+    if (numbytes==128) Enc(X,Y,ctx->rk,8);
+    else{
+      X[2]=X[0];
+      Y[2]=ADD(Y[1],_four);
+      if (numbytes==192) Enc(X,Y,ctx->rk,12);
+      else{
+	X[3]=X[0];
+	Y[3]=ADD(Y[2],_four);
+	Enc(X,Y,ctx->rk,16);
+      }
+    }
+  }
+
+  nonce[0]+=(numbytes>>4);
+
+  XOR_STORE(in,out,X[0],Y[0]);
+  if (numbytes>=128) XOR_STORE(in+64,out+64,X[1],Y[1]);
+  if (numbytes>=192) XOR_STORE(in+128,out+128,X[2],Y[2]);
+  if (numbytes>=256) XOR_STORE(in+192,out+192,X[3],Y[3]);
+
+  return 0;
+}
+
+
+int speck_ctr( unsigned char *out, const unsigned char *in, unsigned long long inlen,
+	       const unsigned char *n, speck_context_t *ctx) {
+
+  int i;
+  u64 nonce[2];
+  unsigned char block[16];
+  u64 * const block64 = (u64 *)block;
+
+  if (!inlen) return 0;
+
+  nonce[0]=((u64 *)n)[0];
+  nonce[1]=((u64 *)n)[1];
+
+  while (inlen>=256){
+    Encrypt_Xor(out,in,nonce,ctx,256);
+    in+=256; inlen-=256; out+=256;
+  }
+
+  if (inlen>=192){
+    Encrypt_Xor(out,in,nonce,ctx,192);
+    in+=192; inlen-=192; out+=192;
+  }
+
+  if (inlen>=128){
+    Encrypt_Xor(out,in,nonce,ctx,128);
+    in+=128; inlen-=128; out+=128;
+  }
+
+  if (inlen>=64){
+    Encrypt_Xor(out,in,nonce,ctx,64);
+    in+=64; inlen-=64; out+=64;
+  }
+
+  if (inlen>=32){
+    Encrypt_Xor(out,in,nonce,ctx,32);
+    in+=32; inlen-=32; out+=32;
+  }
+
+  if (inlen>=16){
+    Encrypt_Xor(block,in,nonce,ctx,16);
+    ((u64 *)out)[0]=block64[0]^((u64 *)in)[0];
+    ((u64 *)out)[1]=block64[1]^((u64 *)in)[1];
+    in+=16; inlen-=16; out+=16;
+  }
+
+  if (inlen>0){
+    Encrypt_Xor(block,in,nonce,ctx,16);
+    for (i=0;i<inlen;i++) out[i]=block[i]^in[i];
+  }
+
+  return 0;
+}
+
+
+int speck_expand_key (const unsigned char *k, speck_context_t *ctx) {
+
+	u64 K[4];
+	size_t i;
+	for(i = 0; i < numkeywords; i++)
+		K[i] = ((u64 *)k)[i];
+
+	EK (K[0], K[1], K[2], K[3], ctx->rk, ctx->key);
+
+	return 0;
+}
+
+
+#elif defined (__SSE4_2__) // SSE support -------------------------------------------------
 
 #include <smmintrin.h>
 
@@ -274,7 +481,7 @@ typedef struct {
 } speck_context_t;
 
 
-int Encrypt_Xor(unsigned char *out, const unsigned char *in, u64 nonce[], speck_context_t *ctx, int numbytes)
+static int Encrypt_Xor(unsigned char *out, const unsigned char *in, u64 nonce[], speck_context_t *ctx, int numbytes)
 {
 
   u64  x[2],y[2];
@@ -287,7 +494,6 @@ int Encrypt_Xor(unsigned char *out, const unsigned char *in, u64 nonce[], speck_
 
     return 0;
   }
-
 
   SET1(X[0],nonce[1]); SET2(Y[0],nonce[0]);
 
@@ -331,10 +537,9 @@ int speck_ctr (unsigned char *out, const unsigned char *in, unsigned long long i
 	       const unsigned char *n, speck_context_t *ctx) {
 
   int i;
-  u64 nonce[2],K[4],key[34],A,B,C,D,x,y;
+  u64 nonce[2];
   unsigned char block[16];
   u64 *const block64=(u64 *)block;
-  u128 rk[34];
 
   if (!inlen) return 0;
 
@@ -460,7 +665,7 @@ int speck_expand_key (const unsigned char *k, speck_context_t *ctx) {
 }
 
 
-#endif // SSE, NEON, plain C
+#endif // AVX, SSE, NEON, plain C
 
 
 int speck_test () {
@@ -487,10 +692,10 @@ int speck_test () {
 	speck_ctr (pt, pt, 16, iv, &ctx);
 
 	u64 i;
-//fprintf (stderr, "rk00: %016llx\n",  ctx.key[0]);
-//fprintf (stderr, "rk33: %016llx\n",  ctx.key[33]);
-//fprintf (stderr, "out : %016lx\n", *(uint64_t*)pt);
-//fprintf (stderr, "mem : " ); for (i=0; i < 16; i++) fprintf (stderr, "%02x ", pt[i]); fprintf (stderr, "\n");
+// fprintf (stderr, "rk00: %016llx\n",  ctx.key[0]);
+// fprintf (stderr, "rk33: %016llx\n",  ctx.key[33]);
+// fprintf (stderr, "out : %016lx\n", *(uint64_t*)pt);
+// fprintf (stderr, "mem : " ); for (i=0; i < 16; i++) fprintf (stderr, "%02x ", pt[i]); fprintf (stderr, "\n");
 
 	int ret = 1;
 	for (i=0; i < 16; i++)

--- a/speck.h
+++ b/speck.h
@@ -19,4 +19,4 @@ int speck_ctr (unsigned char *out, const unsigned char *in,
                const unsigned char *n,
                speck_context_t ctx);
 
-int speck_expand_key (const unsigned char *k, speck_context_t ctx);
+int speck_expand_key (const unsigned char *k, speck_context_t *ctx);

--- a/speck.h
+++ b/speck.h
@@ -1,0 +1,9 @@
+
+#define u64 uint64_t
+
+int speck_ctr (unsigned char *out, const unsigned char *in,
+	       unsigned long long inlen,
+               const unsigned char *n,
+               u64 rk[]);
+
+int speck_expand_key (const unsigned char *k, u64 rk[]);

--- a/speck.h
+++ b/speck.h
@@ -1,9 +1,20 @@
 
 #define u64 uint64_t
 
+#ifdef __SSE4_2__
+ #include <immintrin.h>
+ #define u128 __m128i
+typedef struct {
+        u128 rk[34];
+        u64 key[34];
+} speck_context_t;
+#else
+ typedef u64 speck_context_t [34];
+#endif
+
 int speck_ctr (unsigned char *out, const unsigned char *in,
 	       unsigned long long inlen,
                const unsigned char *n,
-               u64 rk[]);
+               speck_context_t ctx);
 
-int speck_expand_key (const unsigned char *k, u64 rk[]);
+int speck_expand_key (const unsigned char *k, speck_context_t ctx);

--- a/speck.h
+++ b/speck.h
@@ -9,7 +9,9 @@ typedef struct {
         u64 key[34];
 } speck_context_t;
 #else
- typedef u64 speck_context_t [34];
+typedef struct {
+        u64 key[34];
+} speck_context_t;
 #endif
 
 int speck_ctr (unsigned char *out, const unsigned char *in,

--- a/speck.h
+++ b/speck.h
@@ -1,38 +1,51 @@
-
 #define u64 uint64_t
 
 #if defined (__AVX2__)
- #define SPECK_ALIGNED_CTX	32
- #include <immintrin.h>
- #define u256 __m256i
+
+#define SPECK_ALIGNED_CTX	32
+#include <immintrin.h>
+#define u256 __m256i
 typedef struct {
         u256 rk[34];
         u64 key[34];
 } speck_context_t;
+
 #elif defined (__SSE4_2__)
- #define SPECK_ALIGNED_CTX	16
- #include <immintrin.h>
- #define u128 __m128i
+
+#define SPECK_ALIGNED_CTX	16
+#define SPECK_CTX_BYVAL		 1
+#include <immintrin.h>
+#define u128 __m128i
 typedef struct {
         u128 rk[34];
         u64 key[34];
 } speck_context_t;
+
 #elif defined (__ARM_NEON)
- #include <arm_neon.h>
- #define u128 uint64x2_t
+
+#include <arm_neon.h>
+#define u128 uint64x2_t
 typedef struct {
         u128 rk[34];
         u64 key[34];
 } speck_context_t;
+
 #else
+
 typedef struct {
         u64 key[34];
 } speck_context_t;
+
 #endif
 
-int speck_ctr (unsigned char *out, const unsigned char *in,
-	       unsigned long long inlen,
+
+int speck_ctr (unsigned char *out, const unsigned char *in, unsigned long long inlen,
                const unsigned char *n,
-               speck_context_t *ctx);
+#if defined (SPECK_CTX_BYVAL)
+	       speck_context_t ctx);
+#else
+	       speck_context_t *ctx);
+#endif
+
 
 int speck_expand_key (const unsigned char *k, speck_context_t *ctx);

--- a/speck.h
+++ b/speck.h
@@ -1,7 +1,16 @@
 
 #define u64 uint64_t
 
-#if defined (__SSE4_2__)
+#if defined (__AVX2__)
+ #define SPECK_ALIGNED_CTX	32
+ #include <immintrin.h>
+ #define u256 __m256i
+typedef struct {
+        u256 rk[34];
+        u64 key[34];
+} speck_context_t;
+#elif defined (__SSE4_2__)
+ #define SPECK_ALIGNED_CTX	16
  #include <immintrin.h>
  #define u128 __m128i
 typedef struct {

--- a/speck.h
+++ b/speck.h
@@ -1,9 +1,16 @@
 
 #define u64 uint64_t
 
-#ifdef __SSE4_2__
+#if defined (__SSE4_2__)
  #include <immintrin.h>
  #define u128 __m128i
+typedef struct {
+        u128 rk[34];
+        u64 key[34];
+} speck_context_t;
+#elif defined (__ARM_NEON)
+ #include <arm_neon.h>
+ #define u128 uint64x2_t
 typedef struct {
         u128 rk[34];
         u64 key[34];
@@ -17,6 +24,6 @@ typedef struct {
 int speck_ctr (unsigned char *out, const unsigned char *in,
 	       unsigned long long inlen,
                const unsigned char *n,
-               speck_context_t ctx);
+               speck_context_t *ctx);
 
 int speck_expand_key (const unsigned char *k, speck_context_t *ctx);

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -1,6 +1,6 @@
 CC?=gcc
 DEBUG?=-g3
-#OPTIMIZATION?=-O2
+OPTIMIZATION?=-O2 -march=native
 WARN?=-Wall
 
 INSTALL=install

--- a/tools/benchmark.c
+++ b/tools/benchmark.c
@@ -100,6 +100,7 @@ int main(int argc, char * argv[]) {
 #ifdef HAVE_OPENSSL_1_1
   n2n_trans_op_t transop_cc20;
 #endif
+  n2n_trans_op_t transop_speck;
   n2n_edge_conf_t conf;
 
   parseArgs(argc, argv);
@@ -118,6 +119,7 @@ int main(int argc, char * argv[]) {
 #ifdef HAVE_OPENSSL_1_1
   n2n_transop_cc20_init(&conf, &transop_cc20);
 #endif
+  n2n_transop_speck_init(&conf, &transop_speck);
 
   /* Run the tests */
   run_transop_benchmark("transop_null", &transop_null, &conf, pktbuf);
@@ -128,6 +130,7 @@ int main(int argc, char * argv[]) {
 #ifdef N2N_HAVE_AES
   run_transop_benchmark("transop_cc20", &transop_cc20, &conf, pktbuf);
 #endif
+  run_transop_benchmark("transop_speck", &transop_speck, &conf, pktbuf);
 
   /* Cleanup */
   transop_null.deinit(&transop_null);
@@ -138,6 +141,7 @@ int main(int argc, char * argv[]) {
 #ifdef HAVE_OPENSSL_1_1
   transop_cc20.deinit(&transop_cc20);
 #endif
+  transop_speck.deinit(&transop_speck);
 
   return 0;
 }

--- a/transform_speck.c
+++ b/transform_speck.c
@@ -173,7 +173,7 @@ static int setup_speck_key(transop_speck_t *priv, const uint8_t *key, ssize_t ke
   // FOR NOW: USE KEY ITSELF
   memcpy (key_mat_buf, key, ((key_size>32)?32:key_size) );
 
-  speck_expand_key (key_mat_buf, priv->ctx);
+  speck_expand_key (key_mat_buf, &(priv->ctx));
   traceEvent(TRACE_DEBUG, "Speck key setup completed\n");
 
   return(0);

--- a/transform_speck.c
+++ b/transform_speck.c
@@ -1,0 +1,212 @@
+/**
+ * (C) 2007-20 - ntop.org and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not see see <http://www.gnu.org/licenses/>
+ *
+ */
+
+#include "n2n.h"
+#include "n2n_transforms.h"
+#include "speck.h"
+
+#define N2N_SPECK_TRANSFORM_VERSION       1  /* version of the transform encoding */
+#define N2N_SPECK_IVEC_SIZE               16
+
+#define SPECK_KEY_BYTES (256/8)
+
+/* Speck plaintext preamble */
+#define TRANSOP_SPECK_VER_SIZE     1       /* Support minor variants in encoding in one module. */
+#define TRANSOP_SPECK_PREAMBLE_SIZE (TRANSOP_SPECK_VER_SIZE + N2N_SPECK_IVEC_SIZE)
+
+typedef unsigned char n2n_speck_ivec_t[N2N_SPECK_IVEC_SIZE];
+
+typedef struct transop_speck {
+  uint64_t  	      rk[34];	      /* the round keys for payload encryption & decryption */
+} transop_speck_t;
+
+/* ****************************************************** */
+
+static int transop_deinit_speck(n2n_trans_op_t *arg) {
+  transop_speck_t *priv = (transop_speck_t *)arg->priv;
+
+  if(priv)
+    free(priv);
+
+  return 0;
+}
+
+/* ****************************************************** */
+
+static void set_speck_iv(transop_speck_t *priv, n2n_speck_ivec_t ivec) {
+  // keep in mind the following condition: N2N_SPECK_IVEC_SIZE % sizeof(rand_value) == 0 !
+  uint32_t rand_value;
+  for (uint8_t i = 0; i < N2N_SPECK_IVEC_SIZE; i += sizeof(rand_value)) {
+    rand_value = rand(); // CONCERN: rand() is not considered cryptographicly secure, REPLACE later
+    memcpy(ivec + i, &rand_value, sizeof(rand_value));
+  }
+}
+
+/* ****************************************************** */
+
+/** The Speck packet format consists of:
+ *
+ *  - a 8-bit speck encoding version in clear text
+ *  - a 128-bit random IV
+ *  - encrypted payload.
+ *
+ *  [V|IIII|DDDDDDDDDDDDDDDDDDDDD]
+ *         |<---- encrypted ---->|
+ */
+static int transop_encode_speck(n2n_trans_op_t * arg,
+			       uint8_t * outbuf,
+			       size_t out_len,
+			       const uint8_t * inbuf,
+			       size_t in_len,
+			       const uint8_t * peer_mac) {
+  int len=-1;
+  transop_speck_t * priv = (transop_speck_t *)arg->priv;
+
+  if(in_len <= N2N_PKT_BUF_SIZE) {
+    if((in_len + TRANSOP_SPECK_PREAMBLE_SIZE) <= out_len) {
+      size_t idx=0;
+      n2n_speck_ivec_t enc_ivec = {0};
+
+      traceEvent(TRACE_DEBUG, "encode_speck %lu bytes", in_len);
+
+      /* Encode the Speck format version. */
+      encode_uint8(outbuf, &idx, N2N_SPECK_TRANSFORM_VERSION);
+
+      /* Generate and encode the IV. */
+      set_speck_iv(priv, enc_ivec);
+      encode_buf(outbuf, &idx, &enc_ivec, N2N_SPECK_IVEC_SIZE);
+      traceEvent(TRACE_DEBUG, "encode_speck iv=%016llx:%016llx",
+                               htobe64(*(uint64_t*)&enc_ivec[0]),
+                               htobe64(*(uint64_t*)&enc_ivec[8]) );
+
+      /* Encrypt the payload and write the ciphertext after the iv. */
+      /* len is set to the length of the cipher plain text to be encrpyted
+	 which is (in this case) identical to original packet lentgh */
+      len = in_len;
+
+      speck_ctr (outbuf + TRANSOP_SPECK_PREAMBLE_SIZE, inbuf, in_len, enc_ivec, priv->rk);
+      traceEvent(TRACE_DEBUG, "encode_speck: encrypted %u bytes.\n", in_len);
+
+      len += TRANSOP_SPECK_PREAMBLE_SIZE; /* size of data carried in UDP. */
+    } else
+      traceEvent(TRACE_ERROR, "encode_speck outbuf too small.");
+  } else
+    traceEvent(TRACE_ERROR, "encode_speck inbuf too big to encrypt.");
+
+  return len;
+}
+
+/* ****************************************************** */
+
+/* See transop_encode_speck for packet format */
+static int transop_decode_speck(n2n_trans_op_t * arg,
+			       uint8_t * outbuf,
+			       size_t out_len,
+			       const uint8_t * inbuf,
+			       size_t in_len,
+			       const uint8_t * peer_mac) {
+  int len=0;
+  transop_speck_t * priv = (transop_speck_t *)arg->priv;
+
+  if(((in_len - TRANSOP_SPECK_PREAMBLE_SIZE) <= N2N_PKT_BUF_SIZE) /* Cipher text fits in buffer */
+     && (in_len >= TRANSOP_SPECK_PREAMBLE_SIZE) /* Has at least version, iv */
+  )
+  {
+    size_t rem=in_len;
+    size_t idx=0;
+    uint8_t speck_enc_ver=0;
+    n2n_speck_ivec_t dec_ivec = {0};
+
+    /* Get the encoding version to make sure it is supported */
+    decode_uint8(&speck_enc_ver, inbuf, &rem, &idx );
+
+    if(N2N_SPECK_TRANSFORM_VERSION == speck_enc_ver) {
+      traceEvent(TRACE_DEBUG, "decode_speck %lu bytes", in_len);
+      len = (in_len - TRANSOP_SPECK_PREAMBLE_SIZE);
+
+      /* Get the IV */
+      decode_buf((uint8_t *)&dec_ivec, N2N_SPECK_IVEC_SIZE, inbuf, &rem, &idx);
+      traceEvent(TRACE_DEBUG, "decode_speck iv=%016llx:%016llx",
+                               htobe64(*(uint64_t*)&dec_ivec[0]),
+                               htobe64(*(uint64_t*)&dec_ivec[8]) );
+
+      speck_ctr (outbuf, inbuf + TRANSOP_SPECK_PREAMBLE_SIZE, len, dec_ivec, priv->rk);
+      traceEvent(TRACE_DEBUG, "decode_speck: decrypted %u bytes.\n", len);
+
+    } else
+      traceEvent(TRACE_ERROR, "decode_speck unsupported Speck version %u.", speck_enc_ver);
+  } else
+  traceEvent(TRACE_ERROR, "decode_speck inbuf wrong size (%ul) to decrypt.", in_len);
+
+  return len;
+}
+
+/* ****************************************************** */
+
+static int setup_speck_key(transop_speck_t *priv, const uint8_t *key, ssize_t key_size) {
+
+  uint8_t key_mat_buf[32] = { 0x00 };
+
+  /* Clear out any old possibly longer key matter. */
+  memset(&(priv->rk), 0, sizeof(priv->rk) );
+
+  /* TODO: The input key always gets hashed to make a more unpredictable and more complete use of the key space */
+  // REVISIT: Hash the key to keymat (formerly used: SHA)
+  //   SHA256(key, key_size, key_mat_buf)
+  //   memcpy (priv->key, key_mat_buf, SHA256_DIGEST_LENGTH);
+  // ADD: Pearson Hashing
+  // FOR NOW: USE KEY ITSELF
+  memcpy (key_mat_buf, key, ((key_size>32)?32:key_size) );
+
+  speck_expand_key (key_mat_buf, priv->rk);
+  traceEvent(TRACE_DEBUG, "Speck key setup completed\n");
+
+  return(0);
+}
+
+/* ****************************************************** */
+
+static void transop_tick_speck(n2n_trans_op_t * arg, time_t now) { ; }
+
+/* ****************************************************** */
+
+/* Speck initialization function */
+int n2n_transop_speck_init(const n2n_edge_conf_t *conf, n2n_trans_op_t *ttt) {
+  transop_speck_t *priv;
+  const u_char *encrypt_key = (const u_char *)conf->encrypt_key;
+  size_t encrypt_key_len = strlen(conf->encrypt_key);
+
+  memset(ttt, 0, sizeof(*ttt));
+  ttt->transform_id = N2N_TRANSFORM_ID_SPECK;
+
+  ttt->tick = transop_tick_speck;
+  ttt->deinit = transop_deinit_speck;
+  ttt->fwd = transop_encode_speck;
+  ttt->rev = transop_decode_speck;
+
+  priv = (transop_speck_t*) calloc(1, sizeof(transop_speck_t));
+  if(!priv) {
+    traceEvent(TRACE_ERROR, "cannot allocate transop_speck_t memory");
+    return(-1);
+  }
+  ttt->priv = priv;
+
+  /* Setup the cipher and key */
+  return(setup_speck_key(priv, encrypt_key, encrypt_key_len));
+}
+

--- a/transform_speck.c
+++ b/transform_speck.c
@@ -99,7 +99,7 @@ static int transop_encode_speck(n2n_trans_op_t * arg,
 	 which is (in this case) identical to original packet lentgh */
       len = in_len;
 
-      speck_ctr (outbuf + TRANSOP_SPECK_PREAMBLE_SIZE, inbuf, in_len, enc_ivec, priv->ctx);
+      speck_ctr (outbuf + TRANSOP_SPECK_PREAMBLE_SIZE, inbuf, in_len, enc_ivec, &(priv->ctx));
       traceEvent(TRACE_DEBUG, "encode_speck: encrypted %u bytes.\n", in_len);
 
       len += TRANSOP_SPECK_PREAMBLE_SIZE; /* size of data carried in UDP. */
@@ -145,7 +145,7 @@ static int transop_decode_speck(n2n_trans_op_t * arg,
                                htobe64(*(uint64_t*)&dec_ivec[0]),
                                htobe64(*(uint64_t*)&dec_ivec[8]) );
 
-      speck_ctr (outbuf, inbuf + TRANSOP_SPECK_PREAMBLE_SIZE, len, dec_ivec, priv->ctx);
+      speck_ctr (outbuf, inbuf + TRANSOP_SPECK_PREAMBLE_SIZE, len, dec_ivec, &(priv->ctx));
       traceEvent(TRACE_DEBUG, "decode_speck: decrypted %u bytes.\n", len);
 
     } else

--- a/transform_speck.c
+++ b/transform_speck.c
@@ -102,7 +102,12 @@ static int transop_encode_speck(n2n_trans_op_t * arg,
 	 which is (in this case) identical to original packet lentgh */
       len = in_len;
 
-      speck_ctr (outbuf + TRANSOP_SPECK_PREAMBLE_SIZE, inbuf, in_len, enc_ivec, &(priv->ctx));
+      speck_ctr (outbuf + TRANSOP_SPECK_PREAMBLE_SIZE, inbuf, in_len, enc_ivec,
+#if defined (SPECK_CTX_BYVAL)
+	         (priv->ctx));
+#else
+	         &(priv->ctx));
+#endif
       traceEvent(TRACE_DEBUG, "encode_speck: encrypted %u bytes.\n", in_len);
 
       len += TRANSOP_SPECK_PREAMBLE_SIZE; /* size of data carried in UDP. */
@@ -148,7 +153,12 @@ static int transop_decode_speck(n2n_trans_op_t * arg,
                                htobe64(*(uint64_t*)&dec_ivec[0]),
                                htobe64(*(uint64_t*)&dec_ivec[8]) );
 
-      speck_ctr (outbuf, inbuf + TRANSOP_SPECK_PREAMBLE_SIZE, len, dec_ivec, &(priv->ctx));
+      speck_ctr (outbuf, inbuf + TRANSOP_SPECK_PREAMBLE_SIZE, len, dec_ivec,
+#if defined (SPECK_CTX_BYVAL)
+		 (priv->ctx));
+#else
+		 &(priv->ctx));
+#endif
       traceEvent(TRACE_DEBUG, "decode_speck: decrypted %u bytes.\n", len);
 
     } else


### PR DESCRIPTION
This pull request adds SPECK cipher at 128-bit block size and 256-bit key size in CTR mode to the code. It compiles well and can be used using `-A5` (__5__ is for __S__ peck). Also, it already gets used in `tools/n2n-benchmark` and performs between Twofish (roughly four times as fast) and hardware-accelerated AES (roughly between 60 % and 80% of its rates). In case hardware-accelerated AES is not available, it performs roughly twice as fast as software-based AES – as just seen on Raspberry Pi 3B.

It builds on the patterns used in #235. SPECK is implemented along the official Implementation guide. It does not require external libraries and thus could make a permanently available option. 

This pull request is not complete yet, I will rework it for some optimization, key-setup and big-endian testing ~~– __is there anyone who could compile and run `speck.c`'s commented `main` on a big-endian machine, please?__~~ [_done_] Take it more as a first test and impression and do not use it for productive networks yet as the random numbers are still from C's `rand()`.

Also, I wanted to get more comfortable with the cipher I plan to use for header encryption (#198) and thought I could already share it. Think of it as AES' little sister. How does it work for you?