### PR TITLE
fixed A/z parameter handling

### DIFF
--- a/edge.c
+++ b/edge.c
@@ -188,7 +188,7 @@ static void help() {
          "                         | causes connections stall when not properly supported.\n");
 #endif
   printf("-r                       | Enable packet forwarding through n2n community.\n");
-  printf("-A1                      | Disable payload encryption. Do not use with key -- defaulting to Twofish otherwise.\n");
+  printf("-A1                      | Disable payload encryption. Do not use with key (defaulting to Twofish then).\n");
   printf("-A2                      | Use Twofish  for payload encryption (default). Requires a key.\n");
 #ifdef N2N_HAVE_AES
   printf("-A3 or -A (deprecated)   | Use AES-CBC  for payload encryption. Requires a key.\n");


### PR DESCRIPTION
This pull request fixes parameter handling as follows:
- Properly allow `-A_` and  `-z_` be used in `.conf`-files. All, `-A_`, `-A=_` as well as `-A` syntax work in `.conf` files now. However, command line requires `-A_` or `-A` and `-z_` or `-z` respectively.
- Restore a former default behavior of defaulting to Twofish if only a key but no cipher was provided.
- Use the more general term _key_ instead of the more special _-k_ way to provide a key (environment N2N_KEY is another option to provide a key)