### PR TITLE
shortened help text by two lines

### DIFF
--- a/edge.c
+++ b/edge.c
@@ -190,14 +190,15 @@ static void help() {
 #endif
   printf("-r                       | Enable packet forwarding through n2n community.\n");
   printf("-A1                      | Disable payload encryption. Do not use with key (defaulting to Twofish then).\n");
-  printf("-A2                      | Use Twofish  for payload encryption (default). Requires a key.\n");
+  printf("-A2 ... -A5 or -A        | Choose a cipher for payload encryption, requires a key: -A2 = Twofish (default),\n");
+  printf("                         | "
 #ifdef N2N_HAVE_AES
-  printf("-A3 or -A (deprecated)   | Use AES-CBC  for payload encryption. Requires a key.\n");
+  "-A3 or -A (deprecated) = AES-CBC, "
 #endif
 #ifdef HAVE_OPENSSL_1_1
-  printf("-A4                      | Use ChaCha20 for payload encryption. Requires a key.\n");
+  "-A4 = ChaCha20, "
 #endif
-  printf("-A5                      | Use Speck    for payload encryption. Requires a key.\n");
+  "-A5 = Speck-CTR\n");
   printf("-z1 or -z                | Enable lzo1x compression for outgoing data packets\n");
 #ifdef N2N_HAVE_ZSTD
   printf("-z2                      | Enable zstd compression for outgoing data packets\n");


### PR DESCRIPTION
This pull request shortens the help text by two lines. As the header encryption will add another cli option, this is an attempt to maintain clarity.