### PR TITLE
ifdef'ed openSSL-includes for use with AES present only

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -135,8 +135,10 @@ typedef struct ether_hdr ether_hdr_t;
 #include <assert.h>
 #include <sys/stat.h>
 #include <stdint.h>
+#ifdef N2N_HAVE_AES
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
+#endif
 
 #include "minilzo.h"
 #include "n2n_define.h"


### PR DESCRIPTION
All credits to @skyformat99.

Compiles well in Linux with openSSL 1.1 present. Not tested with openSSL 1.0 (on Mac?).

Fixes #252. 