### PR TITLE
Packet Checksum

### DIFF
--- a/include/header_encryption.h
+++ b/include/header_encryption.h
@@ -22,7 +22,7 @@ uint32_t packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
 
 
 int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_t * ctx,
-                               uint16_t checksum);
+                               he_context_t * ctx_iv, uint16_t checksum);
 
 
 void packet_header_setup_key (const char * community_name, he_context_t ** ctx,

--- a/include/header_encryption.h
+++ b/include/header_encryption.h
@@ -21,7 +21,10 @@ uint32_t packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
                                 char * community_name, he_context_t * ctx);
 
 
-int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_t * ctx);
+int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_t * ctx,
+                               uint16_t checksum);
 
 
-void packet_header_setup_key (const char * community_name, he_context_t ** ctx);
+void packet_header_setup_key (const char * community_name, he_context_t ** ctx,
+                                                           he_context_t ** ctx_iv);
+

--- a/include/header_encryption.h
+++ b/include/header_encryption.h
@@ -18,8 +18,8 @@
 
 
 uint32_t packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
-                                char * community_name, he_context_t * ctx);
-
+                                char * community_name, he_context_t * ctx,
+                                he_context_t * ctx_iv, uint16_t * checksum);
 
 int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_t * ctx,
                                he_context_t * ctx_iv, uint16_t checksum);

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -221,6 +221,7 @@ typedef struct n2n_edge_conf {
   n2n_community_t     community_name;         /**< The community. 16 full octets. */
   uint8_t	      header_encryption;      /**< Header encryption indicator. */
   he_context_t	      *header_encryption_ctx; /**< Header encryption cipher context. */
+  he_context_t        *header_iv_ctx;	      /**< Header IV ecnryption cipher context, REMOVE as soon as seperte fileds for checksum and replay protection available */
   n2n_transform_t     transop_id;             /**< The transop to use. */
   uint16_t	      compression;	      /**< Compress outgoing data packets before encryption */
   uint16_t	      num_routes;	      /**< Number of routes in routes */
@@ -255,7 +256,8 @@ struct sn_community
 {
   char community[N2N_COMMUNITY_SIZE];
   uint8_t	      header_encryption;      /* Header encryption indicator. */
-  he_context_t      *header_encryption_ctx; /* Header encryption cipher context. */
+  he_context_t        *header_encryption_ctx; /* Header encryption cipher context. */
+  he_context_t        *header_iv_ctx;	      /* Header IV ecnryption cipher context, REMOVE as soon as seperte fileds for checksum and replay protection available */
   struct peer_info *edges; 		      /* Link list of registered edges. */
 
   UT_hash_handle hh; /* makes this structure hashable */

--- a/include/pearson.h
+++ b/include/pearson.h
@@ -19,3 +19,5 @@
 void pearson_hash_256 (uint8_t *out, const uint8_t *in, size_t len);
 
 void pearson_hash_128 (uint8_t *out, const uint8_t *in, size_t len);
+
+uint16_t pearson_hash_16 (const uint8_t *in, size_t len);

--- a/include/speck.h
+++ b/include/speck.h
@@ -68,4 +68,13 @@ int speck_he (unsigned char *out, const unsigned char *in, unsigned long long in
 int speck_expand_key_he (const unsigned char *k, speck_context_t *ctx);
 
 
+int speck_he_iv_encrypt (unsigned char *inout, speck_context_t *ctx);
+
+
+int speck_he_iv_decrypt (unsigned char *inout, speck_context_t *ctx);
+
+
+int speck_expand_key_he_iv (const unsigned char *k, speck_context_t *ctx);
+
+
 #endif

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -744,7 +744,7 @@ static void send_register_super(n2n_edge_t * eee,
 
   if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED)
     packet_header_encrypt (pktbuf, idx, eee->conf.header_encryption_ctx,
-                                        pearson_hash_16 (pktbuf, idx));
+                                        eee->conf.header_iv_ctx, pearson_hash_16 (pktbuf, idx));
 
   /* sent = */ sendto_sock(eee->udp_sock, pktbuf, idx, supernode);
 }
@@ -776,7 +776,7 @@ static void send_query_peer( n2n_edge_t * eee,
 
   if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED)
     packet_header_encrypt (pktbuf, idx, eee->conf.header_encryption_ctx,
-                                        pearson_hash_16 (pktbuf, idx));
+                                        eee->conf.header_iv_ctx, pearson_hash_16 (pktbuf, idx));
 
   sendto_sock( eee->udp_sock, pktbuf, idx, &(eee->supernode) );
 }
@@ -823,7 +823,7 @@ static void send_register(n2n_edge_t * eee,
 
   if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED)
     packet_header_encrypt (pktbuf, idx, eee->conf.header_encryption_ctx,
-                                        pearson_hash_16 (pktbuf, idx));
+                                        eee->conf.header_iv_ctx, pearson_hash_16 (pktbuf, idx));
 
   /* sent = */ sendto_sock(eee->udp_sock, pktbuf, idx, remote_peer);
 }
@@ -866,7 +866,7 @@ static void send_register_ack(n2n_edge_t * eee,
 
   if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED)
     packet_header_encrypt (pktbuf, idx, eee->conf.header_encryption_ctx,
-                                        pearson_hash_16 (pktbuf, idx));
+                                        eee->conf.header_iv_ctx, pearson_hash_16 (pktbuf, idx));
 
   /* sent = */ sendto_sock(eee->udp_sock, pktbuf, idx, remote_peer);
 }
@@ -1474,7 +1474,7 @@ static void send_packet2net(n2n_edge_t * eee,
 
   if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED)
     packet_header_encrypt (pktbuf, headerIdx, eee->conf.header_encryption_ctx,
-                                              pearson_hash_16 (pktbuf, idx));
+                                              eee->conf.header_iv_ctx, pearson_hash_16 (pktbuf, idx));
 
 #ifdef MTU_ASSERT_VALUE
   {

--- a/src/header_encryption.c
+++ b/src/header_encryption.c
@@ -24,7 +24,8 @@
 /* ********************************************************************** */
 
 uint32_t packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
-			        char * community_name, he_context_t * ctx) {
+			        char * community_name, he_context_t * ctx,
+				he_context_t * ctx_iv, uint16_t * checksum) {
 
   // assemble IV
   // the last four are ASCII "n2n!" and do not get overwritten
@@ -33,6 +34,10 @@ uint32_t packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
   // the first 96 bits of the packet get padded with ASCII "n2n!"
   // to full 128 bit IV
   memcpy (iv, packet, 12);
+
+  // extract checksum (last 16 bit) blended in IV
+  speck_he_iv_decrypt (packet, (speck_context_t*)ctx_iv);
+  *checksum = be16toh (((uint16_t*)packet)[5]);
 
   // try community name as possible key and check for magic bytes
   uint32_t magic = 0x6E326E00; // ="n2n_"

--- a/src/header_encryption.c
+++ b/src/header_encryption.c
@@ -57,7 +57,7 @@ uint32_t packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
 /* ********************************************************************** */
 
 int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_t * ctx,
-                               uint16_t checksum) {
+                               he_context_t * ctx_iv, uint16_t checksum) {
 
   uint8_t iv[16];
   uint16_t *iv16 = (uint16_t*)&iv;
@@ -76,6 +76,8 @@ int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_
   iv16[4] = n2n_rand ();
   iv16[5] = htobe16 (checksum);
   iv32[3] = htobe32 (magic);
+  // blend checksum into 96-bit IV
+  speck_he_iv_encrypt (iv, (speck_context_t*)ctx_iv);
 
   memcpy (packet, iv, 16);
   packet[15] = header_len;

--- a/src/header_encryption.c
+++ b/src/header_encryption.c
@@ -56,9 +56,11 @@ uint32_t packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
 
 /* ********************************************************************** */
 
-int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_t * ctx) {
+int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_t * ctx,
+                               uint16_t checksum) {
 
   uint8_t iv[16];
+  uint16_t *iv16 = (uint16_t*)&iv;
   uint32_t *iv32 = (uint32_t*)&iv;
   uint64_t *iv64 = (uint64_t*)&iv;
   const uint32_t magic = 0x6E326E21; // = ASCII "n2n!"
@@ -71,7 +73,8 @@ int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_
   memcpy (&packet[16], &packet[00], 4);
 
   iv64[0] = n2n_rand ();
-  iv32[2] = n2n_rand ();
+  iv16[4] = n2n_rand ();
+  iv16[5] = htobe16 (checksum);
   iv32[3] = htobe32 (magic);
 
   memcpy (packet, iv, 16);
@@ -83,11 +86,18 @@ int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_
 
 /* ********************************************************************** */
 
-void packet_header_setup_key (const char * community_name, he_context_t ** ctx) {
+void packet_header_setup_key (const char * community_name, he_context_t ** ctx,
+                                                           he_context_t ** ctx_iv) {
 
   uint8_t key[16];
   pearson_hash_128 (key, (uint8_t*)community_name, N2N_COMMUNITY_SIZE);
 
   *ctx = (he_context_t*)calloc(1, sizeof (speck_context_t));
   speck_expand_key_he (key, (speck_context_t*)*ctx);
+
+  // hash again and use last 96 bit (skipping 4 bytes) as key for IV encryption
+  // REMOVE as soon as checksum and replay protection get their own fields
+  pearson_hash_128 (key, key, sizeof (key));
+  *ctx_iv = (he_context_t*)calloc(1, sizeof (speck_context_t));
+  speck_expand_key_he_iv (&key[4], (speck_context_t*)*ctx_iv);
 }

--- a/src/pearson.c
+++ b/src/pearson.c
@@ -219,3 +219,23 @@ void pearson_hash_128 (uint8_t *out, const uint8_t *in, size_t len) {
   o = (uint64_t*)&out[8];
   *o = lower_hash;
 }
+
+
+// 16-bit hash: the return value has to be interpreted as uint16_t and
+// follows machine-specific endianess in memory
+uint16_t pearson_hash_16 (const uint8_t *in, size_t len) {
+
+	uint16_t hash = 0;
+        uint16_t hash_mask = 0x0100;
+
+        for (size_t i = 0; i < len; i++) {
+                // broadcast the character, xor into hash, make them different permutations
+                uint16_t c = (uint8_t)in[i];
+                c |= c <<  8;
+                hash ^= c ^ hash_mask;
+                // table lookup
+		hash = t[(uint8_t)hash] + (t[hash >> 8] << 8);
+        }
+        // output
+        return hash;
+}

--- a/src/sn.c
+++ b/src/sn.c
@@ -491,7 +491,13 @@ static int process_udp(n2n_sn_t * sss,
       /* skip the definitely unencrypted communities */
       if (comm->header_encryption == HEADER_ENCRYPTION_NONE)
         continue;
-      if ( (ret = packet_header_decrypt (udp_buf, udp_size, comm->community, comm->header_encryption_ctx)) ) {
+      uint16_t checksum = 0;
+      if ( (ret = packet_header_decrypt (udp_buf, udp_size, comm->community, comm->header_encryption_ctx,
+                                         comm->header_iv_ctx, &checksum)) ) {
+        if (checksum != pearson_hash_16 (udp_buf, udp_size)) {
+          traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
+          return -1;
+        }
         if (comm->header_encryption == HEADER_ENCRYPTION_UNKNOWN) {
 	  traceEvent (TRACE_INFO, "process_udp locked community '%s' to using "
                                   "encrypted headers.", comm->community);
@@ -650,7 +656,7 @@ static int process_udp(n2n_sn_t * sss,
 
 	/* Re-encode the header. */
 	encode_REGISTER(encbuf, &encx, &cmn2, &reg);
-// !!! does this ever happen? does REGISTER ever come with a payload ??? !!!
+
 	/* Copy the original payload unchanged */
 	encode_buf(encbuf, &encx, (udp_buf + idx), (udp_size - idx));
       } else {

--- a/src/sn.c
+++ b/src/sn.c
@@ -587,7 +587,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (rec_buf, oldEncx, comm->header_encryption_ctx,
-                                                 pearson_hash_16 (rec_buf, encx));
+                                                 comm->header_iv_ctx, pearson_hash_16 (rec_buf, encx));
     } else {
       /* Already from a supernode. Nothing to modify, just pass to
        * destination. */
@@ -599,7 +599,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (rec_buf, idx, comm->header_encryption_ctx,
-                                             pearson_hash_16 (rec_buf, udp_size));
+                                             comm->header_iv_ctx, pearson_hash_16 (rec_buf, udp_size));
     }
 
     /* Common section to forward the final product. */
@@ -663,7 +663,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (rec_buf, encx, comm->header_encryption_ctx,
-                                              pearson_hash_16 (rec_buf, encx));
+                                              comm->header_iv_ctx, pearson_hash_16 (rec_buf, encx));
 
 
       try_forward(sss, comm, &cmn, reg.dstMac, rec_buf, encx); /* unicast only */
@@ -736,7 +736,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (ackbuf, encx, comm->header_encryption_ctx,
-                                             pearson_hash_16 (ackbuf, encx));
+                                             comm->header_iv_ctx, pearson_hash_16 (ackbuf, encx));
 
       sendto(sss->sock, ackbuf, encx, 0,
 	     (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in));
@@ -784,7 +784,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (encbuf, encx, comm->header_encryption_ctx,
-                                             pearson_hash_16 (encbuf, encx));
+                                             comm->header_iv_ctx, pearson_hash_16 (encbuf, encx));
 
       sendto( sss->sock, encbuf, encx, 0,
 	      (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in) );

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -513,7 +513,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (rec_buf, oldEncx, comm->header_encryption_ctx,
-                                                 pearson_hash_16 (rec_buf, encx));
+                                                 comm->header_iv_ctx, pearson_hash_16 (rec_buf, encx));
 
     } else {
       /* Already from a supernode. Nothing to modify, just pass to
@@ -526,7 +526,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (rec_buf, idx, comm->header_encryption_ctx,
-                                             pearson_hash_16 (rec_buf, udp_size));
+                                             comm->header_iv_ctx, pearson_hash_16 (rec_buf, udp_size));
     }
 
     /* Common section to forward the final product. */
@@ -590,7 +590,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (rec_buf, encx, comm->header_encryption_ctx,
-                                             pearson_hash_16 (rec_buf, encx));
+                                             comm->header_iv_ctx, pearson_hash_16 (rec_buf, encx));
 
       try_forward(sss, comm, &cmn, reg.dstMac, rec_buf, encx); /* unicast only */
     } else
@@ -662,7 +662,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (ackbuf, encx, comm->header_encryption_ctx,
-                                             pearson_hash_16 (ackbuf, encx));
+                                             comm->header_iv_ctx, pearson_hash_16 (ackbuf, encx));
 
       sendto(sss->sock, ackbuf, encx, 0,
 	     (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in));
@@ -710,7 +710,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
         packet_header_encrypt (encbuf, encx, comm->header_encryption_ctx,
-                                             pearson_hash_16 (encbuf, encx));
+                                             comm->header_iv_ctx, pearson_hash_16 (encbuf, encx));
 
       sendto( sss->sock, encbuf, encx, 0,
 	      (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in) );


### PR DESCRIPTION
This pull request adds a full packet checksum. For compatibility reasons, the checksum is only calculated and verified for communities having header encryption enabled (`-H` at the edge) as no dedicated field available otherwise. Failing checksum verification – which is performed at the edges _and_ the supernode (even for forwarded only packets) – results in immediately dropping the packet.

The checksum (16 bit) is blended into header encryption's IV (96 bit) by a quick 96-bit block cipher step. The checksum length is that low because we do not know how many more bits of IV will be required for replay prevention which is the next feature to go on. As soon as that is implemented, the checksum length will adopt, i.e. most probably be extended.

Solves #82.