### PR TITLE
edge.c: fix incorrect bad gateway check

### DIFF
--- a/src/edge.c
+++ b/src/edge.c
@@ -488,7 +488,7 @@ static int setOption(int optkey, char *optargument, n2n_priv_config_t *ec, n2n_e
         break;
       }
 
-      if(route.net_addr == INADDR_NONE) {
+      if(route.gateway == INADDR_NONE) {
         traceEvent(TRACE_WARNING, "Bad gateway '%s' in '%s'", gateway, optargument);
         break;
       }


### PR DESCRIPTION
It seems the previous `route.net_addr == INADDR_NONE` check was incorrect and was probably a result of copy-pasting the previous if statement and not changing the condition.