### PR TITLE
call lzo_init() only if required

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -233,10 +233,11 @@ n2n_edge_t* edge_init(const tuntap_dev *dev, const n2n_edge_conf_t *conf, int *r
   eee->pending_peers  = NULL;
   eee->sup_attempts = N2N_EDGE_SUP_ATTEMPTS;
 
-  if(lzo_init() != LZO_E_OK) {
-    traceEvent(TRACE_ERROR, "LZO compression error");
-    goto edge_init_error;
-  }
+  if(eee->conf.compression == N2N_COMPRESSION_ID_LZO)
+    if(lzo_init() != LZO_E_OK) {
+      traceEvent(TRACE_ERROR, "LZO compression error");
+      goto edge_init_error;
+    }
 
 #ifdef N2N_HAVE_ZSTD
   // zstd does not require initialization. if it were required, this would be a good place


### PR DESCRIPTION
I encountered failing calls to `lzo_init()` on one of my older x86 machines and was not able to track it down. I never saw it before, not even on that machine. 

As of now, `lzo_init()` gets called no matter if lzo compression (`-z` or `-z1`) is enabled. So, this pull request makes sure that `lzo_init()` gets called only if lzo compression is enabled.