### PR TITLE
Removed quicklz define

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -16,8 +16,6 @@
  *
  */
 
-#define QUICKLZ               1
-
 /* N2N packet header indicators. */
 #define MSG_TYPE_REGISTER               1
 #define MSG_TYPE_DEREGISTER             2


### PR DESCRIPTION
This pull request removes the defined but otherwise unused `#define QUICKLZ`.