### PR TITLE
no payload with REGISTER

### DIFF
--- a/src/sn.c
+++ b/src/sn.c
@@ -656,9 +656,6 @@ static int process_udp(n2n_sn_t * sss,
 
 	/* Re-encode the header. */
 	encode_REGISTER(encbuf, &encx, &cmn2, &reg);
-
-	/* Copy the original payload unchanged */
-	encode_buf(encbuf, &encx, (udp_buf + idx), (udp_size - idx));
       } else {
 	/* Already from a supernode. Nothing to modify, just pass to
 	 * destination. */

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -583,9 +583,6 @@ static int process_udp(n2n_sn_t * sss,
 
 	/* Re-encode the header. */
 	encode_REGISTER(encbuf, &encx, &cmn2, &reg);
-
-	/* Copy the original payload unchanged */
-	encode_buf(encbuf, &encx, (udp_buf + idx), (udp_size - idx));
       } else {
 	/* Already from a supernode. Nothing to modify, just pass to
 	 * destination. */


### PR DESCRIPTION
This pull request removes a call to `encode_buf()` for payload that once might have been expected with REGISTER but was never observed – neither in assembling REGISTER datagrams nor on-line.

Solves #280.