### PR TITLE
quick fix for header encryption, temporary disabling checksum check

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1658,8 +1658,8 @@ static void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
       return;
     }
     if (checksum != pearson_hash_16 (udp_buf, recvlen)) {
-      traceEvent(TRACE_DEBUG, "readFromIPSocket dropped packet due to checksum error.");
-      return;
+// !!!      traceEvent(TRACE_DEBUG, "readFromIPSocket dropped packet due to checksum error.");
+// !!!      return;
     }
   }
 

--- a/src/header_encryption.c
+++ b/src/header_encryption.c
@@ -36,8 +36,10 @@ uint32_t packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
   memcpy (iv, packet, 12);
 
   // extract checksum (last 16 bit) blended in IV
-  speck_he_iv_decrypt (packet, (speck_context_t*)ctx_iv);
-  *checksum = be16toh (((uint16_t*)packet)[5]);
+  speck_he_iv_decrypt (iv, (speck_context_t*)ctx_iv);
+  *checksum = be16toh (((uint16_t*)iv)[5]);
+
+  memcpy (iv, packet, 12);
 
   // try community name as possible key and check for magic bytes
   uint32_t magic = 0x6E326E00; // ="n2n_"

--- a/src/pearson.c
+++ b/src/pearson.c
@@ -75,6 +75,7 @@ static uint16_t t16[65536]; // 16-bit look-up table
 #endif
 
 #define ROR64(x,r) (((x)>>(r))|((x)<<(64-(r))))
+#define ROR32(x,r) (((x)>>(r))|((x)<<(32-(r))))
 
 
 void pearson_hash_256 (uint8_t *out, const uint8_t *in, size_t len) {

--- a/src/sn.c
+++ b/src/sn.c
@@ -495,8 +495,8 @@ static int process_udp(n2n_sn_t * sss,
       if ( (ret = packet_header_decrypt (udp_buf, udp_size, comm->community, comm->header_encryption_ctx,
                                          comm->header_iv_ctx, &checksum)) ) {
         if (checksum != pearson_hash_16 (udp_buf, udp_size)) {
-          traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
-          return -1;
+// !!!          traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
+// !!!          return -1;
         }
         if (comm->header_encryption == HEADER_ENCRYPTION_UNKNOWN) {
 	  traceEvent (TRACE_INFO, "process_udp locked community '%s' to using "

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -424,8 +424,8 @@ static int process_udp(n2n_sn_t * sss,
       if ( (ret = packet_header_decrypt (udp_buf, udp_size, comm->community, comm->header_encryption_ctx,
                                          comm->header_iv_ctx, &checksum)) ) {
        if (checksum != pearson_hash_16 (udp_buf, udp_size)) {
-          traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
-          return -1;
+// !!!         traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
+// !!!          return -1;
         }
         if (comm->header_encryption == HEADER_ENCRYPTION_UNKNOWN) {
 	  traceEvent (TRACE_INFO, "process_udp locked community '%s' to using "


### PR DESCRIPTION
This pull request repairs header encryption at supernode if more than one community used encrypted headers (`header_encryption.c`).

Unfortunately, the blended checksum is broken now, still investigating – temporary disabled. More to follow during the weekend.