### PR TITLE
enabled packet checksum

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1662,8 +1662,8 @@ static void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
       return;
     }
     if (checksum != pearson_hash_16 (udp_buf, recvlen)) {
-// !!!      traceEvent(TRACE_DEBUG, "readFromIPSocket dropped packet due to checksum error.");
-// !!!      return;
+      traceEvent(TRACE_DEBUG, "readFromIPSocket dropped packet due to checksum error.");
+      return;
     }
   }
 

--- a/src/sn.c
+++ b/src/sn.c
@@ -495,8 +495,8 @@ static int process_udp(n2n_sn_t * sss,
       if ( (ret = packet_header_decrypt (udp_buf, udp_size, comm->community, comm->header_encryption_ctx,
                                          comm->header_iv_ctx, &checksum)) ) {
         if (checksum != pearson_hash_16 (udp_buf, udp_size)) {
-// !!!          traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
-// !!!          return -1;
+          traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
+          return -1;
         }
         if (comm->header_encryption == HEADER_ENCRYPTION_UNKNOWN) {
 	  traceEvent (TRACE_INFO, "process_udp locked community '%s' to using "

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -424,8 +424,8 @@ static int process_udp(n2n_sn_t * sss,
       if ( (ret = packet_header_decrypt (udp_buf, udp_size, comm->community, comm->header_encryption_ctx,
                                          comm->header_iv_ctx, &checksum)) ) {
        if (checksum != pearson_hash_16 (udp_buf, udp_size)) {
-// !!!         traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
-// !!!          return -1;
+         traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
+         return -1;
         }
         if (comm->header_encryption == HEADER_ENCRYPTION_UNKNOWN) {
 	  traceEvent (TRACE_INFO, "process_udp locked community '%s' to using "


### PR DESCRIPTION
This pull request (re-)enables packet checksum again.

Turns out that there was nothing wrong with the checksum, just with author's network setup :facepalm: 

If you want to test just make sure that _all_ network edges _and_ the supernode get updated to that version with packet checksum feature and not just one…

Fixes #295.