### PR TITLE
move android arp code to n2n_edge_callbacks

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -233,11 +233,13 @@ typedef struct n2n_edge_callbacks {
   void (*sn_registration_updated)(n2n_edge_t *eee, time_t now, const n2n_sock_t *sn);
 
   /* A packet has been received from a peer. N2N_DROP can be returned to
-   * drop the packet. The packet payload can be modified. */
+   * drop the packet. The packet payload can be modified. This only allows
+   * the packet size to be reduced */
   n2n_verdict (*packet_from_peer)(n2n_edge_t *eee, const n2n_sock_t *peer, uint8_t *payload, uint16_t *payload_size);
 
   /* A packet has been received from the TAP interface. N2N_DROP can be
-   * returned to drop the packet. The packet payload can be modified. */
+   * returned to drop the packet. The packet payload can be modified.
+   * This only allows the packet size to be reduced */
   n2n_verdict (*packet_from_tap)(n2n_edge_t *eee, uint8_t *payload, uint16_t *payload_size);
 
   /* Called whenever the IP address of the TAP interface changes. */

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1498,18 +1498,7 @@ void edge_read_from_tap(n2n_edge_t * eee) {
   macstr_t            mac_buf;
   ssize_t             len;
 
-#ifdef __ANDROID_NDK__
-  if(uip_arp_len != 0) {
-    len = uip_arp_len;
-    memcpy(eth_pkt, uip_arp_buf, MIN(uip_arp_len, N2N_PKT_BUF_SIZE));
-    traceEvent(TRACE_DEBUG, "ARP reply packet to send");
-  } else {
-#endif /* #ifdef __ANDROID_NDK__ */
-      len = tuntap_read( &(eee->device), eth_pkt, N2N_PKT_BUF_SIZE );
-#ifdef __ANDROID_NDK__
-    }
-#endif /* #ifdef __ANDROID_NDK__ */
-
+  len = tuntap_read( &(eee->device), eth_pkt, N2N_PKT_BUF_SIZE );
   if((len <= 0) || (len > N2N_PKT_BUF_SIZE))
     {
       traceEvent(TRACE_WARNING, "read()=%d [%d/%s]",
@@ -1908,13 +1897,6 @@ int run_edge_loop(n2n_edge_t * eee, int *keep_running) {
 	      readFromIPSocket(eee, eee->udp_multicast_sock);
       }
 #endif
-
-#ifdef __ANDROID_NDK__
-      if(uip_arp_len != 0) {
-	edge_read_from_tap(eee);
-	uip_arp_len = 0;
-      }
-#endif /* #ifdef __ANDROID_NDK__ */
 
       if(FD_ISSET(eee->udp_mgmt_sock, &socket_mask)) {
 	/* Read a cooked socket from the internet socket. Writes on the TAP


### PR DESCRIPTION
1. Move android arp code to n2n_edge_callbacks. This will reduce the complexity of n2n code.
2. Add extra comment to n2n_edge_callbacks.