### PR TITLE
delete android define and log code

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -115,11 +115,6 @@ typedef struct ether_hdr ether_hdr_t;
 #endif
 
 #ifdef __ANDROID_NDK__
-#undef N2N_HAVE_DAEMON
-#undef N2N_HAVE_SETUID
-#undef N2N_CAN_NAME_IFACE
-#include <tun2tap/tun2tap.h>
-#include <edge_jni/edge_jni.h>
 #define ARP_PERIOD_INTERVAL             (10) /* sec */
 #endif /* #ifdef __ANDROID_NDK__ */
 
@@ -377,9 +372,6 @@ typedef struct n2n_sn
 #include "header_encryption.h"
 #include "twofish.h"
 
-#ifdef __ANDROID_NDK__
-#include <android/log.h>
-#endif /* #ifdef __ANDROID_NDK__ */
 #ifndef TRACE_ERROR
 #define TRACE_ERROR     0, __FILE__, __LINE__
 #define TRACE_WARNING   1, __FILE__, __LINE__

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -398,6 +398,7 @@ void setTraceLevel(int level);
 void setUseSyslog(int use_syslog);
 void setTraceFile(FILE *f);
 int getTraceLevel();
+void closeTraceFile();
 void traceEvent(int eventTraceLevel, char* file, int line, char * format, ...);
 
 /* Tuntap API */

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1982,6 +1982,8 @@ void edge_term(n2n_edge_t * eee) {
 
   edge_cleanup_routes(eee);
 
+  closeTraceFile();
+
   free(eee);
 }
 

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -129,32 +129,8 @@ void traceEvent(int eventTraceLevel, char* file, int line, char * format, ...) {
     } else {
 		for(i=strlen(file)-1; i>0; i--) if(file[i] == '/') { i++; break; };
 		snprintf(out_buf, sizeof(out_buf), "%s [%s:%d] %s%s", theDate, &file[i], line, extra_msg, buf);
-#ifdef __ANDROID_NDK__
-        switch (eventTraceLevel) {
-            case 0:         // ERROR
-                eventTraceLevel = ANDROID_LOG_ERROR;
-                break;
-            case 1:         // WARNING
-                eventTraceLevel = ANDROID_LOG_WARN;
-                break;
-            case 2:         // NORMAL
-                eventTraceLevel = ANDROID_LOG_INFO;
-                break;
-            case 3:         // INFO
-                eventTraceLevel = ANDROID_LOG_DEBUG;
-                break;
-            case 4:         // DEBUG
-                eventTraceLevel = ANDROID_LOG_VERBOSE;
-                break;
-            default:        // NORMAL
-                eventTraceLevel = ANDROID_LOG_INFO;
-                break;
-        }
-        __android_log_write(eventTraceLevel, "n2n", out_buf);
-#else
       fprintf(traceFile, "%s\n", out_buf);
       fflush(traceFile);
-#endif /* #ifdef __ANDROID_NDK__ */
     }
 #else
     /* this is the WIN32 code */

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -82,6 +82,12 @@ void setTraceFile(FILE *f) {
   traceFile = f;
 }
 
+void closeTraceFile() {
+  if (traceFile != NULL && traceFile != stdout) {
+    fclose(traceFile);
+  }
+}
+
 #define N2N_TRACE_DATESIZE 32
 void traceEvent(int eventTraceLevel, char* file, int line, char * format, ...) {
   va_list va_ap;


### PR DESCRIPTION
- delete android define and log code

- close trace file if needed

Close trace file is needed by hin2n. Hin2n use `traceFile` to write logs. And Need to close trace file when try to stop app.
