### PR TITLE
fix supernode coredump when accessing management socket

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -99,8 +99,6 @@
 #include <immintrin.h>
 #endif
 
-#define SAFE_SNPRINTF(BUF, SIZE, FORMAT, ...) (ssize_t)(SIZE) > 0 ? snprintf(BUF, SIZE, FORMAT, ##__VA_ARGS__) : 0
-
 #define ETH_ADDR_LEN 6
 
 struct ether_hdr

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -99,6 +99,8 @@
 #include <immintrin.h>
 #endif
 
+#define SAFE_SNPRINTF(BUF, SIZE, FORMAT, ...) (ssize_t)(SIZE) > 0 ? snprintf(BUF, SIZE, FORMAT, ##__VA_ARGS__) : 0
+
 #define ETH_ADDR_LEN 6
 
 struct ether_hdr

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -388,7 +388,7 @@ static int sendto_mgmt(n2n_sn_t *sss,
 
   if (r <= 0) {
     ++(sss->stats.errors);
-    traceEvent (TRACE_ERROR, "process_mgmt : sendto failed. %s", strerror (errno));
+    traceEvent (TRACE_ERROR, "sendto_mgmt : sendto failed. %s", strerror (errno));
     return -1;
   }
   return 0;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -15,6 +15,11 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
                            const uint8_t *pktbuf,
                            size_t pktsize);
 
+static int sendto_mgmt(n2n_sn_t *sss,
+                       const struct sockaddr_in *sender_sock,
+                       const uint8_t *mgmt_buf,
+                       size_t mgmt_size);
+
 static int try_broadcast(n2n_sn_t * sss,
 		         const struct sn_community *comm,
 			 const n2n_common_t * cmn,
@@ -295,10 +300,11 @@ static int process_mgmt(n2n_sn_t *sss,
     char resbuf[N2N_SN_PKTBUF_SIZE];
     size_t ressize = 0;
     uint32_t num_edges = 0;
-    ssize_t r;
+    uint32_t num = 0;
     struct sn_community *community, *tmp;
     struct peer_info * peer, *tmpPeer;
     macstr_t mac_buf;
+    n2n_sock_str_t sockbuf;
 
     traceEvent(TRACE_DEBUG, "process_mgmt");
 
@@ -346,30 +352,46 @@ static int process_mgmt(n2n_sn_t *sss,
                         (long unsigned int)(now - sss->stats.last_reg_super));
 
     ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
-                        "cur_cmnts");
+                        "cur_cmnts %u\n", HASH_COUNT(sss->communities));
     HASH_ITER(hh, sss->communities, community, tmp) {
-      ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
-                          " [%s]",
-                          community->community);
+      ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+                          "community: %s\n", community->community);
+      sendto_mgmt(sss, sender_sock, resbuf, ressize);
+      ressize = 0;
+
+      num = 0;
       HASH_ITER(hh, community->edges, peer, tmpPeer) {
-        ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
-                            " {%s}",
-                            macaddr_str(mac_buf, peer->mac_addr));
+        ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+                            "\t[id: %u][MAC: %s][edge: %s][last seen: %lu sec ago]\n",
+                            ++num, macaddr_str(mac_buf, peer->mac_addr),
+                            sock_to_cstr(sockbuf, &(peer->sock)), now-peer->last_seen);
+
+        sendto_mgmt(sss, sender_sock, resbuf, ressize);
+        ressize = 0;
       }
     }
+
     ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
                         "\n");
-
-    r = sendto(sss->mgmt_sock, resbuf, ressize, 0 /*flags*/,
-               (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in));
-
-    if (r <= 0)
-    {
-        ++(sss->stats.errors);
-        traceEvent(TRACE_ERROR, "process_mgmt : sendto failed. %s", strerror(errno));
-    }
+    sendto_mgmt(sss, sender_sock, resbuf, ressize);
 
     return 0;
+}
+
+static int sendto_mgmt(n2n_sn_t *sss,
+                       const struct sockaddr_in *sender_sock,
+                       const uint8_t *mgmt_buf,
+                       size_t mgmt_size)
+{
+  ssize_t r = sendto(sss->mgmt_sock, mgmt_buf, mgmt_size, 0 /*flags*/,
+                     (struct sockaddr *)sender_sock, sizeof (struct sockaddr_in));
+
+  if (r <= 0) {
+    ++(sss->stats.errors);
+    traceEvent (TRACE_ERROR, "process_mgmt : sendto failed. %s", strerror (errno));
+    return -1;
+  }
+  return 0;
 }
 
 /** Examine a datagram and determine what to do with it.

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -302,10 +302,10 @@ static int process_mgmt(n2n_sn_t *sss,
 
     traceEvent(TRACE_DEBUG, "process_mgmt");
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "----------------\n");
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "uptime    %lu\n", (now - sss->start_time));
 
     HASH_ITER(hh, sss->communities, community, tmp)
@@ -313,54 +313,54 @@ static int process_mgmt(n2n_sn_t *sss,
         num_edges += HASH_COUNT(community->edges);
     }
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "edges     %u\n",
                         num_edges);
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "errors    %u\n",
                         (unsigned int)sss->stats.errors);
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "reg_sup   %u\n",
                         (unsigned int)sss->stats.reg_super);
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "reg_nak   %u\n",
                         (unsigned int)sss->stats.reg_super_nak);
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "fwd       %u\n",
                         (unsigned int)sss->stats.fwd);
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "broadcast %u\n",
                         (unsigned int)sss->stats.broadcast);
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "last fwd  %lu sec ago\n",
                         (long unsigned int)(now - sss->stats.last_fwd));
 
-    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "last reg  %lu sec ago\n",
                         (long unsigned int)(now - sss->stats.last_reg_super));
 
-    ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
+    ressize += SAFE_SNPRINTF(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
                         "cur_cmnts");
     HASH_ITER(hh, sss->communities, community, tmp) {
-      ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
+      ressize += SAFE_SNPRINTF(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
                           " [%s]",
                           community->community);
       HASH_ITER(hh, community->edges, peer, tmpPeer) {
-        ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
+        ressize += SAFE_SNPRINTF(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
                             " {%s}",
                             macaddr_str(mac_buf, peer->mac_addr));
       }
     }
-    ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
+    ressize += SAFE_SNPRINTF(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
                         "\n");
 
-    r = sendto(sss->mgmt_sock, resbuf, ressize, 0 /*flags*/,
+    r = sendto(sss->mgmt_sock, resbuf, MIN(ressize, N2N_SN_PKTBUF_SIZE), 0 /*flags*/,
                (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in));
 
     if (r <= 0)

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -302,10 +302,10 @@ static int process_mgmt(n2n_sn_t *sss,
 
     traceEvent(TRACE_DEBUG, "process_mgmt");
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "----------------\n");
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "uptime    %lu\n", (now - sss->start_time));
 
     HASH_ITER(hh, sss->communities, community, tmp)
@@ -313,54 +313,54 @@ static int process_mgmt(n2n_sn_t *sss,
         num_edges += HASH_COUNT(community->edges);
     }
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "edges     %u\n",
                         num_edges);
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "errors    %u\n",
                         (unsigned int)sss->stats.errors);
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "reg_sup   %u\n",
                         (unsigned int)sss->stats.reg_super);
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "reg_nak   %u\n",
                         (unsigned int)sss->stats.reg_super_nak);
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "fwd       %u\n",
                         (unsigned int)sss->stats.fwd);
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "broadcast %u\n",
                         (unsigned int)sss->stats.broadcast);
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "last fwd  %lu sec ago\n",
                         (long unsigned int)(now - sss->stats.last_fwd));
 
-    ressize += SAFE_SNPRINTF(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
+    ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
                         "last reg  %lu sec ago\n",
                         (long unsigned int)(now - sss->stats.last_reg_super));
 
-    ressize += SAFE_SNPRINTF(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
+    ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
                         "cur_cmnts");
     HASH_ITER(hh, sss->communities, community, tmp) {
-      ressize += SAFE_SNPRINTF(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
+      ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
                           " [%s]",
                           community->community);
       HASH_ITER(hh, community->edges, peer, tmpPeer) {
-        ressize += SAFE_SNPRINTF(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
+        ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
                             " {%s}",
                             macaddr_str(mac_buf, peer->mac_addr));
       }
     }
-    ressize += SAFE_SNPRINTF(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
+    ressize += snprintf(resbuf+ressize, N2N_SN_PKTBUF_SIZE-ressize,
                         "\n");
 
-    r = sendto(sss->mgmt_sock, resbuf, MIN(ressize, N2N_SN_PKTBUF_SIZE), 0 /*flags*/,
+    r = sendto(sss->mgmt_sock, resbuf, ressize, 0 /*flags*/,
                (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in));
 
     if (r <= 0)


### PR DESCRIPTION
When accessing the supernode management port, it is possible that the `resbuf` array is out of bounds due to too many communities and edges.

Use `SAFE_SNPRINTF ` to protect `resbuf`.

Or increasing the length of the `resbuf` array to solve this problem.