### PR TITLE
fix build error for supernode when declared N2N_HAVE_DAEMON

### DIFF
--- a/src/sn.c
+++ b/src/sn.c
@@ -356,7 +356,7 @@ int main(int argc, char * const argv[]) {
 
 #if defined(N2N_HAVE_DAEMON)
   if(sss_node.daemon) {
-    useSyslog=1; /* traceEvent output now goes to syslog. */
+    setUseSyslog(1); /* traceEvent output now goes to syslog. */
 
     if(-1 == daemon(0, 0)) {
       traceEvent(TRACE_ERROR, "Failed to become daemon.");


### PR DESCRIPTION
Variable `useSyslog ` is not visible in sn.c. Use `setUseSyslog()` instead of `useSyslog`.