### PR TITLE
Update purge logic of communities and edges for supernode

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -35,6 +35,9 @@
 #define IFACE_UPDATE_INTERVAL           (30) /* sec. How long it usually takes to get an IP lease. */
 #define TRANSOP_TICK_INTERVAL           (10) /* sec */
 
+#define PURGE_REGISTRATION_FREQUENCY   30
+#define REGISTRATION_TIMEOUT           60
+
 #define ETH_FRAMESIZE 14
 #define IP4_SRCOFFSET 12
 #define IP4_DSTOFFSET 16

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -22,9 +22,6 @@
 
 #include <assert.h>
 
-#define PURGE_REGISTRATION_FREQUENCY   30
-#define REGISTRATION_TIMEOUT           60
-
 static const uint8_t broadcast_addr[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 static const uint8_t multicast_addr[6] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0x00 }; /* First 3 bytes are meaningful */
 static const uint8_t ipv6_multicast_addr[6] = { 0x33, 0x33, 0x00, 0x00, 0x00, 0x00 }; /* First 2 bytes are meaningful */


### PR DESCRIPTION
There are two problems about the purge logic of supernode.

1. It will access the purge code every time, even though the trigger time is not reached.

2. It will update `last_purge_edges` after calling `purge_expired_registrations` function for the first community in the loop , when the trigger time is reached. Then `last_purge_edges` has updated, and `purge_expired_registrations` function will not work for other communities. In fact, the code here is only work for the first community.