### PR TITLE
fix build warning of edge_init_routes

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2419,6 +2419,7 @@ static int edge_init_routes(n2n_edge_t *eee, n2n_route_t *routes, uint16_t num_r
 #ifdef WIN32
   return  edge_init_routes_win(eee, routes, num_routes);
 #endif
+  return 0;
 }
 
 /* ************************************** */


### PR DESCRIPTION
Compiling on non-linux and non-windows will trigger a warning on `edge_init_routes` function.

Just like this:

`src/edge_utils.c:2422:1: warning: control reaches end of non-void function [-Wreturn-type]`