### PR TITLE
added replay protection

### DIFF
--- a/include/header_encryption.h
+++ b/include/header_encryption.h
@@ -19,10 +19,12 @@
 
 uint32_t packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
                                 char * community_name, he_context_t * ctx,
-                                he_context_t * ctx_iv, uint16_t * checksum);
+                                he_context_t * ctx_iv,
+                                uint64_t * stamp, uint16_t * checksum);
 
 int32_t packet_header_encrypt (uint8_t packet[], uint8_t header_len, he_context_t * ctx,
-                               he_context_t * ctx_iv, uint16_t checksum);
+                               he_context_t * ctx_iv,
+                               uint64_t stamp, uint16_t checksum);
 
 
 void packet_header_setup_key (const char * community_name, he_context_t ** ctx,

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -432,7 +432,8 @@ int sock_equal( const n2n_sock_t * a,
 
 /* Header encryption */
 uint64_t time_stamp(void);
-int time_stamp_verify (uint64_t stamp, uint64_t * previous_stamp);
+uint64_t initial_time_stamp (void);
+int time_stamp_verify_and_update (uint64_t stamp, uint64_t * previous_stamp);
 
 /* Operations on peer_info lists. */
 size_t purge_peer_list( struct peer_info ** peer_list,

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -428,6 +428,10 @@ SOCKET open_socket(int local_port, int bind_any);
 int sock_equal( const n2n_sock_t * a,
                        const n2n_sock_t * b );
 
+/* Header encryption */
+uint64_t time_stamp(void);
+int time_stamp_verify (uint64_t stamp, uint64_t * previous_stamp);
+
 /* Operations on peer_info lists. */
 size_t purge_peer_list( struct peer_info ** peer_list,
                         time_t purge_before );

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -197,6 +197,7 @@ struct peer_info {
   time_t              last_seen;
   time_t              last_p2p;
   time_t              last_sent_query;
+  uint64_t            last_valid_time_stamp;
 
   UT_hash_handle hh; /* makes this structure hashable */
 };
@@ -304,8 +305,9 @@ struct n2n_edge {
 	n2n_trans_op_t      transop;                /**< The transop to use when encoding */
 	n2n_cookie_t        last_cookie;            /**< Cookie sent in last REGISTER_SUPER. */
 	n2n_route_t         *sn_route_to_clean;     /**< Supernode route to clean */
-	n2n_edge_callbacks_t cb;		      /**< API callbacks */
-	void 	              *user_data;             /**< Can hold user data */
+	n2n_edge_callbacks_t cb;	            /**< API callbacks */
+	void 	            *user_data;             /**< Can hold user data */
+        uint64_t            sn_last_valid_time_stamp;/*< last valid time stamp from supernode */
 
 	/* Sockets */
 	n2n_sock_t          supernode;

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1646,17 +1646,19 @@ static void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 
 	  decode_PACKET(&pkt, &cmn, udp_buf, &rem, &idx);
 
-// !!!
-/*   if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED) {
+	  if(is_valid_peer_sock(&pkt.sock))
+	    orig_sender = &(pkt.sock);
 
-    if ( !time_stamp_verify (stamp, &... !!!) ) {
-      traceEvent(TRACE_DEBUG, "readFromIPSocket dropped packet due to time stamp error.");
-      return;
+/*        // sketch for time stamp verification -- to be implemented !!!
+
+          if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED) {
+            // find edge and its specific last time stamp or supernode's one !!!
+            if ( !time_stamp_verify (stamp, &found_time_stamp !!!) ) {
+              traceEvent(TRACE_DEBUG, "readFromIPSocket dropped packet due to time stamp error.");
+              return;
     }
   }
 */
-	  if(is_valid_peer_sock(&pkt.sock))
-	    orig_sender = &(pkt.sock);
 
 	  if(!from_supernode) {
 	    /* This is a P2P packet from the peer. We purge a pending

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -377,3 +377,25 @@ int sock_equal(const n2n_sock_t * a,
   return(1);
 }
 
+/* *********************************************** */
+
+#if defined(WIN32) && !defined(__GNUC__)
+static int gettimeofday(struct timeval *tp, void *tzp)
+{
+  time_t clock;
+  struct tm tm;
+  SYSTEMTIME wtm;
+  GetLocalTime(&wtm);
+  tm.tm_year = wtm.wYear - 1900;
+  tm.tm_mon = wtm.wMonth - 1;
+  tm.tm_mday = wtm.wDay;
+  tm.tm_hour = wtm.wHour;
+  tm.tm_min = wtm.wMinute;
+  tm.tm_sec = wtm.wSecond;
+  tm.tm_isdst = -1;
+  clock = mktime(&tm);
+  tp->tv_sec = clock;
+  tp->tv_usec = wtm.wMilliseconds * 1000;
+  return (0);
+}
+#endif

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -428,12 +428,10 @@ uint64_t time_stamp (void) {
 
 // checks if a provided time stamp is consistent with current time and previously valid time stamps
 // returns the time stamp to store as "last valid time stamp" or zero in case of invalid time stamp
-// uses branchless sign extensio tricks inspired by  https://www.chessprogramming.org/Avoiding_Branches
-// and also  https://hbfs.wordpress.com/2008/08/05/branchless-equivalents-of-simple-functions
 // REVISIT during the years 2035...2038
 uint64_t time_stamp_verify (uint64_t stamp, uint64_t previous_stamp) {
 
-  int64_t diff; // do not change this to unsigned for keeping the following code work
+  int64_t diff; // do not change to unsigned
 
   // is it higher than previous time stamp (including allowed deviation of TIME_STAMP_JITTER)?
   diff = stamp - previous_stamp + TIME_STAMP_JITTER;
@@ -441,16 +439,14 @@ uint64_t time_stamp_verify (uint64_t stamp, uint64_t previous_stamp) {
 
     // is it around current time (+/- allowed deviation TIME_STAMP_FRAME)?
     diff = stamp - time_stamp();
-    // branchless abs()
-    diff = (diff + (diff >> 63)) ^ (diff >> 63);
+    // abs()
+    diff = (diff < 0 ? -diff : diff);
 
     if(diff < TIME_STAMP_FRAME) {
 
       // for not allowing to exploit the allowed TIME_STAMP_JITTER to "turn the clock backwards",
-      // return the higher value making use of branchless max()
-      diff = stamp - previous_stamp;
-      diff = stamp - (diff & (diff >> 63));
-      return ((uint64_t)diff);
+      // return the higher value, max()
+      return (stamp > previous_stamp ? stamp : previous_stamp);
 
     } else {
       traceEvent(TRACE_DEBUG, "time_stamp_verify found a timestamp out of allowed frame.");

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -427,14 +427,14 @@ uint64_t time_stamp (void) {
 
 
 // checks if a provided time stamp is consistent with current time and previously valid time stamps
-// returns the time stamp to store as "last valid time stamp" or zero in case of invalid time stamp
+// and, in case of validity, replaces the "last valid time stamp"
 // REVISIT during the years 2035...2038
-uint64_t time_stamp_verify (uint64_t stamp, uint64_t previous_stamp) {
+int time_stamp_verify (uint64_t stamp, uint64_t * previous_stamp) {
 
   int64_t diff; // do not change to unsigned
 
   // is it higher than previous time stamp (including allowed deviation of TIME_STAMP_JITTER)?
-  diff = stamp - previous_stamp + TIME_STAMP_JITTER;
+  diff = stamp - *previous_stamp + TIME_STAMP_JITTER;
   if(diff > 0) {
 
     // is it around current time (+/- allowed deviation TIME_STAMP_FRAME)?
@@ -445,16 +445,17 @@ uint64_t time_stamp_verify (uint64_t stamp, uint64_t previous_stamp) {
     if(diff < TIME_STAMP_FRAME) {
 
       // for not allowing to exploit the allowed TIME_STAMP_JITTER to "turn the clock backwards",
-      // return the higher value, max()
-      return (stamp > previous_stamp ? stamp : previous_stamp);
+      // set the higher of the values
+      *previous_stamp = (stamp > *previous_stamp ? stamp : *previous_stamp);
+      return (1); // success
 
     } else {
       traceEvent(TRACE_DEBUG, "time_stamp_verify found a timestamp out of allowed frame.");
-      return (0);
+      return (0); // failure
     }
 
   } else {
     traceEvent(TRACE_DEBUG, "time_stamp_verify found a timestamp too old / older than previous.");
-    return (0);
+    return (0); // failure
   }
 }

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -439,6 +439,9 @@ static int process_udp(n2n_sn_t * sss,
       if ( (ret = packet_header_decrypt (udp_buf, udp_size, comm->community, comm->header_encryption_ctx,
                                          comm->header_iv_ctx,
                                          &stamp, &checksum)) ) {
+        // time stamp verification follows in the packet specific section as it requires to determine the
+        // sender from the hash list by its MAC, this all depends on packet type and packet structure
+        // (MAC is not always in the same place)
        if (checksum != pearson_hash_16 (udp_buf, udp_size)) {
          traceEvent(TRACE_DEBUG, "process_udp dropped packet due to checksum error.");
          return -1;

--- a/tools/benchmark.c
+++ b/tools/benchmark.c
@@ -18,26 +18,6 @@
 
 #include "n2n.h"
 
-#if defined(WIN32) && !defined(__GNUC__)
-static int gettimeofday(struct timeval *tp, void *tzp)
-{
-  time_t clock;
-  struct tm tm;
-  SYSTEMTIME wtm;
-  GetLocalTime(&wtm);
-  tm.tm_year = wtm.wYear - 1900;
-  tm.tm_mon = wtm.wMonth - 1;
-  tm.tm_mday = wtm.wDay;
-  tm.tm_hour = wtm.wHour;
-  tm.tm_min = wtm.wMinute;
-  tm.tm_sec = wtm.wSecond;
-  tm.tm_isdst = -1;
-  clock = mktime(&tm);
-  tp->tv_sec = clock;
-  tp->tv_usec = wtm.wMilliseconds * 1000;
-  return (0);
-}
-#endif
 
 uint8_t PKT_CONTENT[]={
   0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15, 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,


### PR DESCRIPTION
This pull request adds a replay protection scheme to n2n. It is time based and requires the clocks of the participating computers (supernode and edges) to be not more than 16 seconds apart (default). This parameter can be adjusted in `n2n.c:28` where the `TIME_STAMP_FRAME` is defined.

Also, this implementation allows for packets that are up to 160 ms older than a previously received one. This might happen whenever a packet takes another direction around the world while another one which might have sent out a bit later has already arrived (observed exactly this in real-life). However, if strictly increasing timestamps are preferred, `n2n.c:29` offers an opportunity to change `TIME_STAMP_JITTER` accordingly. 

With packets from first-time seen and so-far unknown nodes, time stamp verification is impossible and is restricted to the more generous `TIME_STAMP_FRAME`.

The time stamp is encryptedly encoded to the IV of header encryption, next to the packet checksum. Thus, this feature only is available along with enabled header encryption `-H`.

Whenever a packet format update is due, we should consider assigning MACs also to the supernodes and every packet should carry a source MAC as well as a last hop MAC field.

Closes #73.