### PR TITLE
sorting encrypted communities

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -351,8 +351,9 @@ struct sn_community
   char community[N2N_COMMUNITY_SIZE];
   uint8_t	      header_encryption;      /* Header encryption indicator. */
   he_context_t        *header_encryption_ctx; /* Header encryption cipher context. */
-  he_context_t        *header_iv_ctx;	      /* Header IV ecnryption cipher context, REMOVE as soon as seperte fileds for checksum and replay protection available */
+  he_context_t        *header_iv_ctx;	      /* Header IV ecnryption cipher context, REMOVE as soon as seperate fields for checksum and replay protection available */
   struct peer_info *edges; 		      /* Link list of registered edges. */
+  int64_t	      number_enc_packets;     /* Number of encrypted packets handled so far, required for sorting from time to time */
 
   UT_hash_handle hh; /* makes this structure hashable */
 };

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -38,6 +38,8 @@
 #define PURGE_REGISTRATION_FREQUENCY   30
 #define REGISTRATION_TIMEOUT           60
 
+#define SORT_COMMUNITIES_INTERVAL      90 /* sec. until supernode sorts communities' hash list again */
+
 #define ETH_FRAMESIZE 14
 #define IP4_SRCOFFSET 12
 #define IP4_DSTOFFSET 16


### PR DESCRIPTION
This pull request adds a periodical sorting of supernode's communities' hash list by descending order of number of encrypted packets sent during the last period.

This will have the most often used encrypted community iterated first by HASH_ITER and thus especially help to find the community key faster in most cases (which is found by iterating through the communities and trying their hash of name as key).

Period length is defined as `SORT_COMMUNITIES_INTERVAL` in `n2n_define.h` file and defaults to 90 seconds.