### PR TITLE
On Windows, the Edge node exits when the network card is disabled and…

### DIFF
--- a/src/edge.c
+++ b/src/edge.c
@@ -887,9 +887,9 @@ int main(int argc, char* argv[]) {
     traceEvent(TRACE_WARNING, "Community and encryption key must differ, otherwise security will be compromised");
 
 	if(tuntap_open(&tuntap, ec.tuntap_dev_name, ec.ip_mode, ec.ip_addr, ec.netmask, ec.device_mac, ec.mtu) < 0)
-		return(-1);
+    exit(1);
 
-	if((eee = edge_init(&tuntap, &conf, &rc)) == NULL) {
+  if((eee = edge_init(&tuntap, &conf, &rc)) == NULL) {
 		traceEvent(TRACE_ERROR, "Failed in edge_init");
 		exit(1);
 	}

--- a/win32/wintap.c
+++ b/win32/wintap.c
@@ -241,7 +241,7 @@ int open_wintap(struct tuntap_dev *device,
       printf("No Windows tap devices found, did you run tapinstall.exe?\n");
     else
       printf("Cannot find tap device \"%s\"\n", devname);
-    exit(EXIT_FAILURE);
+    return -1;
   }
 
   /* ************************************** */


### PR DESCRIPTION
On Windows, the Edge node exits when the network card is disabled and opened again.
this pull request fix its bug.
