### PR TITLE
Added DHCP function embedded in sn.

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -36,8 +36,6 @@
 
 /* Moved here to define _CRT_SECURE_NO_WARNINGS before all the including takes place */
 #ifdef WIN32
-#include "win32/n2n_win32.h"
-
 #ifdef _MSC_VER
 #include "config.h" /* Visual C++ */
 #else
@@ -171,12 +169,13 @@ typedef struct ether_hdr ether_hdr_t;
 
 #ifndef WIN32
 typedef struct tuntap_dev {
-  int           fd;
-  int 		if_idx;
-  uint8_t       mac_addr[6];
-  uint32_t      ip_addr, device_mask;
-  uint16_t      mtu;
-  char          dev_name[N2N_IFNAMSIZ];
+	int             fd;
+	int             if_idx;
+	n2n_mac_t       mac_addr;
+	uint32_t        ip_addr;
+	uint32_t        device_mask;
+	uint16_t        mtu;
+	char            dev_name[N2N_IFNAMSIZ];
 } tuntap_dev;
 
 #define SOCKET int
@@ -192,26 +191,31 @@ typedef char ipstr_t[32];
 /** Common type used to hold stringified MAC addresses. */
 #define N2N_MACSTR_SIZE 32
 typedef char macstr_t[N2N_MACSTR_SIZE];
+typedef char dec_ip_str_t[N2N_NETMASK_STR_SIZE];
+typedef char dec_ip_bit_str_t[N2N_NETMASK_STR_SIZE + 4];
+
 
 struct peer_info {
-  n2n_mac_t           mac_addr;
-  n2n_sock_t          sock;
-  int                 timeout;
-  time_t              last_seen;
-  time_t              last_p2p;
-  time_t              last_sent_query;
-  uint64_t            last_valid_time_stamp;
+	n2n_mac_t        mac_addr;
+	n2n_ip_subnet_t  dev_addr;
+	n2n_sock_t       sock;
+	int              timeout;
+	time_t           last_seen;
+	time_t           last_p2p;
+	time_t           last_sent_query;
+	uint64_t         last_valid_time_stamp;
 
-  UT_hash_handle hh; /* makes this structure hashable */
+	UT_hash_handle   hh; /* makes this structure hashable */
 };
+
 
 typedef struct speck_context_t he_context_t;
 typedef char n2n_sn_name_t[N2N_EDGE_SN_HOST_SIZE];
 
 typedef struct n2n_route {
-  in_addr_t net_addr;
-  int net_bitlen;
-  in_addr_t gateway;
+	in_addr_t        net_addr;
+	uint8_t          net_bitlen;
+	in_addr_t        gateway;
 } n2n_route_t;
 
 typedef struct n2n_edge n2n_edge_t;
@@ -253,8 +257,8 @@ typedef struct n2n_edge_callbacks {
 typedef struct n2n_tuntap_priv_config {
 	char                tuntap_dev_name[N2N_IFNAMSIZ];
 	char                ip_mode[N2N_IF_MODE_SIZE];
-	char                ip_addr[N2N_NETMASK_STR_SIZE];
-	char                netmask[N2N_NETMASK_STR_SIZE];
+	dec_ip_str_t        ip_addr;
+	dec_ip_str_t        netmask;
 	char                device_mac[N2N_MACNAMSIZ];
 	int                 mtu;
 	uint8_t             got_s;
@@ -267,29 +271,31 @@ typedef struct n2n_tuntap_priv_config {
 
 /* *************************************************** */
 
+
 typedef struct n2n_edge_conf {
-  n2n_sn_name_t       sn_ip_array[N2N_EDGE_NUM_SUPERNODES];
-  n2n_route_t	      *routes;		      /**< Networks to route through n2n */
-  n2n_community_t     community_name;         /**< The community. 16 full octets. */
-  uint8_t	      header_encryption;      /**< Header encryption indicator. */
-  he_context_t	      *header_encryption_ctx; /**< Header encryption cipher context. */
-  he_context_t        *header_iv_ctx;	      /**< Header IV ecnryption cipher context, REMOVE as soon as seperte fileds for checksum and replay protection available */
-  n2n_transform_t     transop_id;             /**< The transop to use. */
-  uint16_t	      compression;	      /**< Compress outgoing data packets before encryption */
-  uint16_t	      num_routes;	      /**< Number of routes in routes */
-  uint8_t             dyn_ip_mode;            /**< Interface IP address is dynamically allocated, eg. DHCP. */
-  uint8_t             allow_routing;          /**< Accept packet no to interface address. */
-  uint8_t             drop_multicast;         /**< Multicast ethernet addresses. */
-  uint8_t             disable_pmtu_discovery; /**< Disable the Path MTU discovery. */
-  uint8_t             allow_p2p;              /**< Allow P2P connection */
-  uint8_t             sn_num;                 /**< Number of supernode addresses defined. */
-  uint8_t             tos;                    /** TOS for sent packets */
-  char                *encrypt_key;
-  int                 register_interval;      /**< Interval for supernode registration, also used for UDP NAT hole punching. */
-  int                 register_ttl;           /**< TTL for registration packet when UDP NAT hole punching through supernode. */
-  int                 local_port;
-  int                 mgmt_port;
+	n2n_sn_name_t       sn_ip_array[N2N_EDGE_NUM_SUPERNODES];
+	n2n_route_t         *routes;                /**< Networks to route through n2n */
+	n2n_community_t     community_name;         /**< The community. 16 full octets. */
+	uint8_t	            header_encryption;      /**< Header encryption indicator. */
+	he_context_t        *header_encryption_ctx; /**< Header encryption cipher context. */
+	he_context_t        *header_iv_ctx;         /**< Header IV ecnryption cipher context, REMOVE as soon as seperte fileds for checksum and replay protection available */
+	n2n_transform_t     transop_id;             /**< The transop to use. */
+	uint16_t            compression;            /**< Compress outgoing data packets before encryption */
+	uint16_t            num_routes;	            /**< Number of routes in routes */
+	uint8_t             tuntap_ip_mode;         /**< Interface IP address allocated mode, eg. DHCP. */
+	uint8_t             allow_routing;          /**< Accept packet no to interface address. */
+	uint8_t             drop_multicast;         /**< Multicast ethernet addresses. */
+	uint8_t             disable_pmtu_discovery; /**< Disable the Path MTU discovery. */
+	uint8_t             allow_p2p;              /**< Allow P2P connection */
+	uint8_t             sn_num;                 /**< Number of supernode addresses defined. */
+	uint8_t             tos;                    /** TOS for sent packets */
+	char                *encrypt_key;
+	int                 register_interval;      /**< Interval for supernode registration, also used for UDP NAT hole punching. */
+	int                 register_ttl;           /**< TTL for registration packet when UDP NAT hole punching through supernode. */
+	int                 local_port;
+	int                 mgmt_port;
 } n2n_edge_conf_t;
+
 
 struct n2n_edge_stats {
 	uint32_t tx_p2p;
@@ -304,43 +310,44 @@ struct n2n_edge {
 	n2n_edge_conf_t     conf;
 
 	/* Status */
-	uint8_t             sn_idx;                 /**< Currently active supernode. */
-	uint8_t             sn_wait;                /**< Whether we are waiting for a supernode response. */
-	size_t              sup_attempts;           /**< Number of remaining attempts to this supernode. */
-	tuntap_dev          device;                 /**< All about the TUNTAP device */
-	n2n_trans_op_t      transop;                /**< The transop to use when encoding */
-	n2n_cookie_t        last_cookie;            /**< Cookie sent in last REGISTER_SUPER. */
-	n2n_route_t         *sn_route_to_clean;     /**< Supernode route to clean */
-	n2n_edge_callbacks_t cb;	            /**< API callbacks */
-	void 	            *user_data;             /**< Can hold user data */
-        uint64_t            sn_last_valid_time_stamp;/*< last valid time stamp from supernode */
+	uint8_t             sn_idx;                  /**< Currently active supernode. */
+	uint8_t             sn_wait;                 /**< Whether we are waiting for a supernode response. */
+	size_t              sup_attempts;            /**< Number of remaining attempts to this supernode. */
+	tuntap_dev          device;                  /**< All about the TUNTAP device */
+	n2n_trans_op_t      transop;                 /**< The transop to use when encoding */
+	n2n_cookie_t        last_cookie;             /**< Cookie sent in last REGISTER_SUPER. */
+	n2n_route_t         *sn_route_to_clean;      /**< Supernode route to clean */
+	n2n_edge_callbacks_t cb;                     /**< API callbacks */
+	void 	            *user_data;              /**< Can hold user data */
+	uint64_t            sn_last_valid_time_stamp;/**< last valid time stamp from supernode */
 
 	/* Sockets */
 	n2n_sock_t          supernode;
 	int                 udp_sock;
-	int                 udp_mgmt_sock;          /**< socket for status info. */
+	int                 udp_mgmt_sock;           /**< socket for status info. */
 
 #ifndef SKIP_MULTICAST_PEERS_DISCOVERY
-	n2n_sock_t          multicast_peer;         /**< Multicast peer group (for local edges) */
-	int                 udp_multicast_sock;     /**< socket for local multicast registrations. */
-	int                 multicast_joined;       /**< 1 if the group has been joined.*/
+	n2n_sock_t          multicast_peer;          /**< Multicast peer group (for local edges) */
+	int                 udp_multicast_sock;      /**< socket for local multicast registrations. */
+	int                 multicast_joined;        /**< 1 if the group has been joined.*/
 #endif
 
 	/* Peers */
-	struct peer_info *  known_peers;            /**< Edges we are connected to. */
-	struct peer_info *  pending_peers;          /**< Edges we have tried to register with. */
+	struct peer_info *  known_peers;             /**< Edges we are connected to. */
+	struct peer_info *  pending_peers;           /**< Edges we have tried to register with. */
 
 	/* Timers */
-	time_t              last_register_req;      /**< Check if time to re-register with super*/
-	time_t              last_p2p;               /**< Last time p2p traffic was received. */
-	time_t              last_sup;               /**< Last time a packet arrived from supernode. */
-	time_t              start_time;             /**< For calculating uptime */
+	time_t              last_register_req;       /**< Check if time to re-register with super*/
+	time_t              last_p2p;                /**< Last time p2p traffic was received. */
+	time_t              last_sup;                /**< Last time a packet arrived from supernode. */
+	time_t              start_time;              /**< For calculating uptime */
 
-	/* Statistics */
-	struct n2n_edge_stats stats;
-  /* Tuntap config */
-  n2n_tuntap_priv_config_t tuntap_priv_conf;
+
+	struct n2n_edge_stats stats;                 /**< Statistics */
+
+	n2n_tuntap_priv_config_t tuntap_priv_conf;   /**< Tuntap config */
 };
+
 
 typedef struct sn_stats
 {
@@ -365,21 +372,21 @@ struct sn_community
   UT_hash_handle hh; /* makes this structure hashable */
 };
 
-typedef struct n2n_sn
-{
-    time_t start_time; /* Used to measure uptime. */
-    sn_stats_t stats;
-    int daemon;           /* If non-zero then daemonise. */
-    uint16_t lport;       /* Local UDP port to bind to. */
-    uint16_t mport;       /* Management UDP port to bind to. */
-    int sock;             /* Main socket for UDP traffic with edges. */
-    int mgmt_sock;        /* management socket. */
+typedef struct n2n_sn {
+	time_t start_time;         /* Used to measure uptime. */
+	sn_stats_t stats;
+	int daemon;                /* If non-zero then daemonise. */
+	uint16_t lport;            /* Local UDP port to bind to. */
+	uint16_t mport;            /* Management UDP port to bind to. */
+	int sock;                  /* Main socket for UDP traffic with edges. */
+	int mgmt_sock;             /* management socket. */
+	n2n_ip_subnet_t dhcp_addr; /* Address range of dhcp service. */
 #ifndef WIN32
 	uid_t userid;
 	gid_t groupid;
 #endif
-    int lock_communities; /* If true, only loaded communities can be used. */
-    struct sn_community *communities;
+	int lock_communities;      /* If true, only loaded communities can be used. */
+	struct sn_community *communities;
 } n2n_sn_t;
 
 /* ************************************** */
@@ -426,6 +433,8 @@ void tuntap_get_address(struct tuntap_dev *tuntap);
 
 /* Utils */
 char* intoa(uint32_t addr, char* buf, uint16_t buf_len);
+uint32_t bitlen2mask(uint8_t bitlen);
+uint8_t mask2bitlen(uint32_t mask);
 char* macaddr_str(macstr_t buf, const n2n_mac_t mac);
 int str2mac( uint8_t * outmac /* 6 bytes */, const char * s );
 uint8_t is_multi_broadcast(const uint8_t * dest_mac);
@@ -438,6 +447,7 @@ void print_edge_stats(const n2n_edge_t *eee);
 /* Sockets */
 char* sock_to_cstr( n2n_sock_str_t out,
                             const n2n_sock_t * sock );
+char * ip_subnet_to_str(dec_ip_bit_str_t buf, const n2n_ip_subnet_t *ipaddr);
 SOCKET open_socket(int local_port, int bind_any);
 int sock_equal( const n2n_sock_t * a,
                        const n2n_sock_t * b );
@@ -461,7 +471,9 @@ const n2n_edge_conf_t* edge_get_conf(const n2n_edge_t *eee);
 void edge_term_conf(n2n_edge_conf_t *conf);
 
 /* Public functions */
-n2n_edge_t* edge_init(const tuntap_dev *dev, const n2n_edge_conf_t *conf, int *rv);
+n2n_edge_t* edge_init(const n2n_edge_conf_t *conf, int *rv);
+void update_supernode_reg(n2n_edge_t * eee, time_t nowTime);
+void readFromIPSocket(n2n_edge_t * eee, int in_sock);
 void edge_term(n2n_edge_t *eee);
 void edge_set_callbacks(n2n_edge_t *eee, const n2n_edge_callbacks_t *callbacks);
 void edge_set_userdata(n2n_edge_t *eee, void *user_data);

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -97,6 +97,15 @@
 #define N2N_SN_PKTBUF_SIZE   2048
 
 
+/* The way TUNTAP allocated IP. */
+#define TUNTAP_IP_MODE_SN_ASSIGN 0
+#define TUNTAP_IP_MODE_STATIC 1
+#define TUNTAP_IP_MODE_DHCP 2
+
+/* Default network segment of the dhcp service provided by sn. */
+#define N2N_SN_DHCP_NET_ADDR_DEFAULT "172.17.12.0"
+#define N2N_SN_DHCP_NET_BIT_DEFAULT 24
+
 /* ************************************** */
 
 #define SUPERNODE_IP    "127.0.0.1"

--- a/src/example_edge_embed.c
+++ b/src/example_edge_embed.c
@@ -33,7 +33,7 @@ int main()
     snprintf((char *)conf.community_name, sizeof(conf.community_name), "%s", "mycommunity"); // Community to connect to
     conf.disable_pmtu_discovery = 1;                                                         // Whether to disable the path MTU discovery
     conf.drop_multicast = 0;                                                                 // Whether to disable multicast
-    conf.dyn_ip_mode = 0;                                                                    // Whether the IP address is set dynamically (see IP mode; 0 if static, 1 if dynamic)
+    conf.tuntap_ip_mode = TUNTAP_IP_MODE_SN_ASSIGN;                                          // How to set the IP address
     conf.encrypt_key = "mysecret";                                                           // Secret to decrypt & encrypt with
     conf.local_port = 0;                                                                     // What port to use (0 = any port)
     conf.mgmt_port = N2N_EDGE_MGMT_PORT;                                                     // Edge management port (5644 by default)
@@ -59,7 +59,7 @@ int main()
         return -1;
     }
 
-    eee = edge_init(&tuntap, &conf, &rc);
+    eee = edge_init(&conf, &rc);
     if (eee == NULL)
     {
         exit(1);

--- a/src/wire.c
+++ b/src/wire.c
@@ -289,129 +289,134 @@ int decode_REGISTER( n2n_REGISTER_t * reg,
     return retval;
 }
 
-int encode_REGISTER_SUPER( uint8_t * base,
-                           size_t * idx,
-                           const n2n_common_t * common,
-                           const n2n_REGISTER_SUPER_t * reg )
-{
-    int retval=0;
-    retval += encode_common( base, idx, common );
-    retval += encode_buf( base, idx, reg->cookie, N2N_COOKIE_SIZE );
-    retval += encode_mac( base, idx, reg->edgeMac );
-    retval += encode_uint16( base, idx, 0 ); /* NULL auth scheme */
-    retval += encode_uint16( base, idx, 0 ); /* No auth data */
 
-    return retval;
+int encode_REGISTER_SUPER(uint8_t *base,
+                          size_t *idx,
+                          const n2n_common_t *common,
+                          const n2n_REGISTER_SUPER_t *reg) {
+	int retval = 0;
+	retval += encode_common(base, idx, common);
+	retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
+	retval += encode_mac(base, idx, reg->edgeMac);
+	retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
+	retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
+	retval += encode_uint16(base, idx, 0); /* NULL auth scheme */
+	retval += encode_uint16(base, idx, 0); /* No auth data */
+
+	return retval;
 }
 
-int decode_REGISTER_SUPER( n2n_REGISTER_SUPER_t * reg,
-                           const n2n_common_t * cmn, /* info on how to interpret it */
-                           const uint8_t * base,
-                           size_t * rem,
-                           size_t * idx )
-{
-    size_t retval=0;
-    memset( reg, 0, sizeof(n2n_REGISTER_SUPER_t) );
-    retval += decode_buf( reg->cookie, N2N_COOKIE_SIZE, base, rem, idx );
-    retval += decode_mac( reg->edgeMac, base, rem, idx );
-    retval += decode_uint16( &(reg->auth.scheme), base, rem, idx );
-    retval += decode_uint16( &(reg->auth.toksize), base, rem, idx );
-    retval += decode_buf( reg->auth.token, reg->auth.toksize, base, rem, idx );
-    return retval;
+
+int decode_REGISTER_SUPER(n2n_REGISTER_SUPER_t *reg,
+                          const n2n_common_t *cmn, /* info on how to interpret it */
+                          const uint8_t *base,
+                          size_t *rem,
+                          size_t *idx) {
+	size_t retval = 0;
+	memset(reg, 0, sizeof(n2n_REGISTER_SUPER_t));
+	retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+	retval += decode_mac(reg->edgeMac, base, rem, idx);
+	retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
+	retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
+	retval += decode_uint16(&(reg->auth.scheme), base, rem, idx);
+	retval += decode_uint16(&(reg->auth.toksize), base, rem, idx);
+	retval += decode_buf(reg->auth.token, reg->auth.toksize, base, rem, idx);
+	return retval;
 }
 
-int encode_REGISTER_ACK( uint8_t * base,
-                         size_t * idx,
-                         const n2n_common_t * common,
-                         const n2n_REGISTER_ACK_t * reg )
-{
-    int retval=0;
-    retval += encode_common( base, idx, common );
-    retval += encode_buf( base, idx, reg->cookie, N2N_COOKIE_SIZE );
-    retval += encode_mac( base, idx, reg->dstMac );
-    retval += encode_mac( base, idx, reg->srcMac );
 
-    /* The socket in REGISTER_ACK is the socket from which the REGISTER
-     * arrived. This is sent back to the sender so it knows what its public
-     * socket is. */
-    if ( 0 != reg->sock.family )
-    {
-        retval += encode_sock( base, idx, &(reg->sock) );
-    }
+int encode_REGISTER_ACK(uint8_t *base,
+                        size_t *idx,
+                        const n2n_common_t *common,
+                        const n2n_REGISTER_ACK_t *reg) {
+	int retval = 0;
+	retval += encode_common(base, idx, common);
+	retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
+	retval += encode_mac(base, idx, reg->dstMac);
+	retval += encode_mac(base, idx, reg->srcMac);
 
-    return retval;
+	/* The socket in REGISTER_ACK is the socket from which the REGISTER
+	 * arrived. This is sent back to the sender so it knows what its public
+	 * socket is. */
+	if (0 != reg->sock.family) {
+		retval += encode_sock(base, idx, &(reg->sock));
+	}
+
+	return retval;
 }
 
-int decode_REGISTER_ACK( n2n_REGISTER_ACK_t * reg,
-                         const n2n_common_t * cmn, /* info on how to interpret it */
-                         const uint8_t * base,
-                         size_t * rem,
-                         size_t * idx )
-{
-    size_t retval=0;
-    memset( reg, 0, sizeof(n2n_REGISTER_ACK_t) );
-    retval += decode_buf( reg->cookie, N2N_COOKIE_SIZE, base, rem, idx );
-    retval += decode_mac( reg->dstMac, base, rem, idx );
-    retval += decode_mac( reg->srcMac, base, rem, idx );
 
-    /* The socket in REGISTER_ACK is the socket from which the REGISTER
-     * arrived. This is sent back to the sender so it knows what its public
-     * socket is. */
-    if ( cmn->flags & N2N_FLAGS_SOCKET )
-    {
-        retval += decode_sock( &(reg->sock), base, rem, idx );
-    }
+int decode_REGISTER_ACK(n2n_REGISTER_ACK_t *reg,
+                        const n2n_common_t *cmn, /* info on how to interpret it */
+                        const uint8_t *base,
+                        size_t *rem,
+                        size_t *idx) {
+	size_t retval = 0;
+	memset(reg, 0, sizeof(n2n_REGISTER_ACK_t));
+	retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+	retval += decode_mac(reg->dstMac, base, rem, idx);
+	retval += decode_mac(reg->srcMac, base, rem, idx);
 
-    return retval;
+	/* The socket in REGISTER_ACK is the socket from which the REGISTER
+	 * arrived. This is sent back to the sender so it knows what its public
+	 * socket is. */
+	if (cmn->flags & N2N_FLAGS_SOCKET) {
+		retval += decode_sock(&(reg->sock), base, rem, idx);
+	}
+
+	return retval;
 }
 
-int encode_REGISTER_SUPER_ACK( uint8_t * base,
-                               size_t * idx,
-                               const n2n_common_t * common,
-                               const n2n_REGISTER_SUPER_ACK_t * reg )
-{
-    int retval=0;
-    retval += encode_common( base, idx, common );
-    retval += encode_buf( base, idx, reg->cookie, N2N_COOKIE_SIZE );
-    retval += encode_mac( base, idx, reg->edgeMac );
-    retval += encode_uint16( base, idx, reg->lifetime );
-    retval += encode_sock( base, idx, &(reg->sock) );
-    retval += encode_uint8( base, idx, reg->num_sn );
-    if ( reg->num_sn > 0 )
-    {
-        /* We only support 0 or 1 at this stage */
-        retval += encode_sock( base, idx, &(reg->sn_bak) );
-    }
 
-    return retval;
+int encode_REGISTER_SUPER_ACK(uint8_t *base,
+                              size_t *idx,
+                              const n2n_common_t *common,
+                              const n2n_REGISTER_SUPER_ACK_t *reg) {
+	int retval = 0;
+	retval += encode_common(base, idx, common);
+	retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
+	retval += encode_mac(base, idx, reg->edgeMac);
+	retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
+	retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
+	retval += encode_uint16(base, idx, reg->lifetime);
+	retval += encode_sock(base, idx, &(reg->sock));
+	retval += encode_uint8(base, idx, reg->num_sn);
+	if (reg->num_sn > 0) {
+		/* We only support 0 or 1 at this stage */
+		retval += encode_sock(base, idx, &(reg->sn_bak));
+	}
+
+	return retval;
 }
 
-int decode_REGISTER_SUPER_ACK( n2n_REGISTER_SUPER_ACK_t * reg,
-                               const n2n_common_t * cmn, /* info on how to interpret it */
-                               const uint8_t * base,
-                               size_t * rem,
-                               size_t * idx )
-{
-    size_t retval=0;
 
-    memset( reg, 0, sizeof(n2n_REGISTER_SUPER_ACK_t) );
-    retval += decode_buf( reg->cookie, N2N_COOKIE_SIZE, base, rem, idx );
-    retval += decode_mac( reg->edgeMac, base, rem, idx );
-    retval += decode_uint16( &(reg->lifetime), base, rem, idx );
+int decode_REGISTER_SUPER_ACK(n2n_REGISTER_SUPER_ACK_t *reg,
+                              const n2n_common_t *cmn, /* info on how to interpret it */
+                              const uint8_t *base,
+                              size_t *rem,
+                              size_t *idx) {
+	size_t retval = 0;
 
-    /* Socket is mandatory in this message type */
-    retval += decode_sock( &(reg->sock), base, rem, idx );
+	memset(reg, 0, sizeof(n2n_REGISTER_SUPER_ACK_t));
+	retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+	retval += decode_mac(reg->edgeMac, base, rem, idx);
+	retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
+	retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
+	retval += decode_uint16(&(reg->lifetime), base, rem, idx);
 
-    /* Following the edge socket are an array of backup supernodes. */
-    retval += decode_uint8( &(reg->num_sn), base, rem, idx );
-    if ( reg->num_sn > 0 )
-    {
-        /* We only support 0 or 1 at this stage */
-        retval += decode_sock( &(reg->sn_bak), base, rem, idx );
-    }
+	/* Socket is mandatory in this message type */
+	retval += decode_sock(&(reg->sock), base, rem, idx);
 
-    return retval;
+	/* Following the edge socket are an array of backup supernodes. */
+	retval += decode_uint8(&(reg->num_sn), base, rem, idx);
+	if (reg->num_sn > 0) {
+		/* We only support 0 or 1 at this stage */
+		retval += decode_sock(&(reg->sn_bak), base, rem, idx);
+	}
+
+	return retval;
 }
+
 
 int fill_sockaddr( struct sockaddr * addr,
                    size_t addrlen,
@@ -475,34 +480,35 @@ int decode_PACKET( n2n_PACKET_t * pkt,
     return retval;
 }
 
-int encode_PEER_INFO( uint8_t * base,
-                      size_t * idx,
-                      const n2n_common_t * common,
-                      const n2n_PEER_INFO_t * pkt )
-{
-    int retval=0;
-    retval += encode_common( base, idx, common );
-    retval += encode_uint16( base, idx, pkt->aflags );
-    retval += encode_mac( base, idx, pkt->mac );
-    retval += encode_sock( base, idx, &pkt->sock );
 
-    return retval;
+int encode_PEER_INFO(uint8_t *base,
+                     size_t *idx,
+                     const n2n_common_t *common,
+                     const n2n_PEER_INFO_t *pkt) {
+	int retval = 0;
+	retval += encode_common(base, idx, common);
+	retval += encode_uint16(base, idx, pkt->aflags);
+	retval += encode_mac(base, idx, pkt->mac);
+	retval += encode_sock(base, idx, &pkt->sock);
+
+	return retval;
 }
 
-int decode_PEER_INFO( n2n_PEER_INFO_t * pkt,
-                           const n2n_common_t * cmn, /* info on how to interpret it */
-                           const uint8_t * base,
-                           size_t * rem,
-                           size_t * idx )
-{
-    size_t retval=0;
-    memset( pkt, 0, sizeof(n2n_PEER_INFO_t) );
-    retval += decode_uint16( &(pkt->aflags), base, rem, idx );
-    retval += decode_mac( pkt->mac, base, rem, idx );
-    retval += decode_sock( &pkt->sock, base, rem, idx );
 
-    return retval;
+int decode_PEER_INFO(n2n_PEER_INFO_t *pkt,
+                     const n2n_common_t *cmn, /* info on how to interpret it */
+                     const uint8_t *base,
+                     size_t *rem,
+                     size_t *idx) {
+	size_t retval = 0;
+	memset(pkt, 0, sizeof(n2n_PEER_INFO_t));
+	retval += decode_uint16(&(pkt->aflags), base, rem, idx);
+	retval += decode_mac(pkt->mac, base, rem, idx);
+	retval += decode_sock(&pkt->sock, base, rem, idx);
+
+	return retval;
 }
+
 
 int encode_QUERY_PEER( uint8_t * base,
                       size_t * idx,

--- a/win32/n2n_win32.h
+++ b/win32/n2n_win32.h
@@ -98,13 +98,14 @@ struct ip {
 /* ************************************* */
 
 typedef struct tuntap_dev {
-	HANDLE device_handle;
-	char *device_name;
-	char *ifName;
-	OVERLAPPED overlap_read, overlap_write;
-	uint8_t      mac_addr[6];
-	uint32_t     ip_addr, device_mask;
-	unsigned int mtu;
+	HANDLE          device_handle;
+	char            *device_name;
+	char            *ifName;
+	OVERLAPPED      overlap_read, overlap_write;
+	n2n_mac_t       mac_addr;
+	uint32_t        ip_addr;
+	uint32_t        device_mask;
+	unsigned int    mtu;
 } tuntap_dev;
 
 #define index(a, b) strchr(a, b)

--- a/win32/winconfig.h
+++ b/win32/winconfig.h
@@ -1,8 +1,15 @@
 /* winconfig.h.  Win32 replacement for file generated from config.h.in by configure.  */
 
 /* OS name */
+#ifndef PACKAGE_OSNAME
 #define PACKAGE_OSNAME N2N_OSNAME
+#endif
 
 /* Define to the version of this package. */
+#ifndef PACKAGE_VERSION
 #define PACKAGE_VERSION N2N_VERSION
+#endif
+#ifndef GIT_RELEASE
 #define GIT_RELEASE N2N_VERSION
+#endif
+


### PR DESCRIPTION
Fulfill the requirement #228

1. Automatically assign IP addresses to the edge through the DHCP function that comes with sn, the default IP address pool is 172.17.12.0/24.
2. The -d parameter is added to sn, and the IP address pool of the embedded DHCP can be customized.
3. Now edge does not need to add -a and -s parameters to automatically obtain the IP address.
4. The IP automatically obtained by the cross-community edge can be the same, because the communities are isolated from each other and do not interfere with each other.
5. On the management side of sn (127.0.0.1:5645), you can now view the IP address of the tutap adapter of each edge.
6. Fix many bugs that have a certain chance of causing memory leaks.
7. Note: This version is not fully compatible with the previous version.