### PR TITLE
simplified twofish's key handling

### DIFF
--- a/include/twofish.h
+++ b/include/twofish.h
@@ -62,7 +62,6 @@ typedef uint8_t  uint8_t;
 
 /* Constants */
 
-#define TwoFish_DEFAULT_PW		"SnortHas2FishEncryptionRoutines!" /* default password (not more than 32 chars) */
 #define TwoFish_DEFAULT_PW_LEN		32
 #define TwoFish_MAGIC			"TwoFish"			/* to indentify a successful decryption */
 
@@ -133,13 +132,13 @@ typedef struct
  *	This routine generates a global data structure for use with TwoFish,
  *	initializes important values (such as subkeys, sBoxes), generates subkeys
  *	and precomputes the MDS matrix if not already done.
- *	
- *	Input:	User supplied password (will be appended by default password of 'SnortHas2FishEncryptionRoutines!')
  *
- *  Output:	Pointer to TWOFISH structure. This data structure contains key dependent data.
+ *      Input:  User supplied key of correct length (TwoFish_KEY_LENGTH, 256 bits = 32 bytes by default)
+ *
+ *      Output:	Pointer to TWOFISH structure. This data structure contains key dependent data.
  *			This pointer is used with all other crypt functions.
  */
-TWOFISH *TwoFishInit(const uint8_t *userkey, uint32_t keysize );
+TWOFISH *TwoFishInit(const uint8_t *userkey);
 
 
 /*	TwoFish Destroy

--- a/src/transform_tf.c
+++ b/src/transform_tf.c
@@ -180,6 +180,7 @@ int n2n_transop_twofish_init(const n2n_edge_conf_t *conf, n2n_trans_op_t *ttt) {
   transop_tf_t *priv;
   const u_char *encrypt_key = (const u_char *)conf->encrypt_key;
   size_t encrypt_key_len = strlen(conf->encrypt_key);
+  uint8_t key_hash[32];
 
   memset(ttt, 0, sizeof(*ttt));
   ttt->transform_id = N2N_TRANSFORM_ID_TWOFISH;
@@ -197,8 +198,9 @@ int n2n_transop_twofish_init(const n2n_edge_conf_t *conf, n2n_trans_op_t *ttt) {
   ttt->priv = priv;
 
   /* This is a preshared key setup. Both Tx and Rx are using the same security association. */
-  priv->enc_tf = TwoFishInit(encrypt_key, encrypt_key_len);
-  priv->dec_tf = TwoFishInit(encrypt_key, encrypt_key_len);
+  pearson_hash_256 (key_hash, encrypt_key, encrypt_key_len);
+  priv->enc_tf = TwoFishInit(key_hash);
+  priv->dec_tf = TwoFishInit(key_hash);
 
   if((!priv->enc_tf) || (!priv->dec_tf)) {
     if(priv->enc_tf) TwoFishDestroy(priv->enc_tf);

--- a/src/twofish.c
+++ b/src/twofish.c
@@ -123,39 +123,19 @@ uint8_t TwoFish__b(uint32_t x,int n)
  *	initializes important values (such as subkeys, sBoxes), generates subkeys
  *	and precomputes the MDS matrix if not already done.
  *
- *	Input:	User supplied password (will be appended by default password of 'SnortHas2FishEncryptionRoutines!')
+ *	Input:	User supplied key of correct length (TwoFish_KEY_LENGTH, 256 bits = 32 bytes by default)
  *
  *      Output: Pointer to TWOFISH structure. This data structure contains key dependent data.
  *		This pointer is used with all other crypt functions.
  */
 
-TWOFISH *TwoFishInit(const uint8_t *userkey, uint32_t keysize)
+TWOFISH *TwoFishInit(const uint8_t *userkey)
 {  TWOFISH *tfdata;
-  int i,x,m;
-  uint8_t tkey[TwoFish_KEY_LENGTH+40];
 
-  memset( tkey, 0, TwoFish_KEY_LENGTH+40 );
   tfdata=(TWOFISH *)malloc(sizeof(TWOFISH));			/* allocate the TwoFish structure */
   if(tfdata!=NULL)
   {
-
-      /* Changes here prevented a dangerous random key segment for keys of length < TwoFish_KEY_LENGTH */
-      if(keysize > 0)
-      {
-          memcpy( tkey, userkey, keysize ); /* The rest will be zeros */
-      }
-      else
-      {
-          memcpy( tkey, TwoFish_DEFAULT_PW, TwoFish_DEFAULT_PW_LEN ); /* if no key defined, use default password */
-      }
-
-      /* This loop is awful - surely a loop on memcpy() would be clearer and more efficient */
-      for(i=0,x=0,m=keysize;i<TwoFish_KEY_LENGTH;i++)	/* copy into data structure */
-      {
-          tfdata->key[i]=tkey[x++];			/* fill the whole keyspace with repeating key. */
-          if(x==m)
-              x=0;
-      }
+      memcpy(tfdata->key, userkey, TwoFish_KEY_LENGTH);
 
       if(!TwoFish_MDSready)
           _TwoFish_PrecomputeMDSmatrix();		/* "Wake Up, Neo" */
@@ -966,9 +946,16 @@ int main(int argc, char* argv[])
     char outbuf[4096];
     char * outp = outbuf;
 
-    uint8_t key[] = { 0xfc, 0x77, 0x1a, 0xda, 0xaa };
-    TWOFISH *tfa = TwoFishInit( key, 5 );
-    TWOFISH *tfb = TwoFishInit( key, 5 );
+    uint8_t key[] = { 0xfc, 0x77, 0x1a, 0xda, 0xaa,
+                      0xfc, 0x77, 0x1a, 0xda, 0xaa,
+                      0xfc, 0x77, 0x1a, 0xda, 0xaa,
+                      0xfc, 0x77, 0x1a, 0xda, 0xaa,
+                      0xfc, 0x77, 0x1a, 0xda, 0xaa,
+                      0xfc, 0x77, 0x1a, 0xda, 0xaa,
+                      0xfc, 0x77 };
+
+    TWOFISH *tfa = TwoFishInit( key );
+    TWOFISH *tfb = TwoFishInit( key );
 
     uint8_t out[2048], out2[2048];
     uint8_t in[TEST_DATA_SIZE];


### PR DESCRIPTION
This pull request changes, i.e. simplifies Twofish's key handling _from_ using the repeated user password as key _to_ using a hash of the user password as key. Hashing happens in the `transform_tf.c` file conforming to the other transforms and also following the idea of having just the pure cipher inside the `twofish.c` file as it would allow for an easier replacement with another implementation if ever required.

Finally, hashing the key can be considered more secure as it makes more unpredictable use of the key space. Just think of the usually reset MSB of common ASCII-coded passwords.

To test this enhancement in current dev branch, all participating edges must be updated because compatibility is not maintained.

_P. S._ This pull request also solves the security related issue of repeating keys being interpreted as equal (due to repetition): Just try Twofish `-A2` with (literally) `-k blablabla` at one edge and `-k bla` (only) at another edge, they will talk to each other!