### PR TITLE
changed aes transform to cipher text stealing mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(n2n STATIC
         src/transform_aes.c
         src/transform_cc20.c
         src/transform_speck.c
+        src/aes.c
         src/speck.c
         src/random_numbers.c
         src/pearson.c

--- a/include/aes.h
+++ b/include/aes.h
@@ -1,0 +1,63 @@
+/**
+ * (C) 2007-20 - ntop.org and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not see see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+#ifdef N2N_HAVE_AES
+
+#ifndef AES_H
+#define AES_H
+
+#include <stdint.h>
+
+#include <openssl/aes.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+
+#define AES256_KEY_BYTES (256/8)
+#define AES192_KEY_BYTES (192/8)
+#define AES128_KEY_BYTES (128/8)
+
+
+typedef struct aes_context_t {
+#ifdef HAVE_OPENSSL_1_1
+  EVP_CIPHER_CTX      *enc_ctx;                /* openssl's reusable evp_* en/de-cryption context */
+  EVP_CIPHER_CTX      *dec_ctx;                /* openssl's reusable evp_* en/de-cryption context */
+  const EVP_CIPHER    *cipher;                 /* cipher to use: e.g. EVP_aes_128_cbc */
+  uint8_t             key[AES256_KEY_BYTES];   /* the pure key data for payload encryption & decryption */
+  AES_KEY             ecb_dec_key;             /* one step ecb decryption key */
+#else
+  AES_KEY             enc_key;                 /* tx key */
+  AES_KEY             dec_key;                 /* tx key */
+#endif
+} aes_context_t;
+
+
+int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,
+                     const unsigned char *iv, aes_context_t *ctx);
+
+int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
+                     const unsigned char *iv, aes_context_t *ctx);
+
+int aes_ecb_decrypt (unsigned char *out, const unsigned char *in, aes_context_t *ctx);
+
+int aes_init (const unsigned char *key, size_t key_size, aes_context_t **ctx);
+
+
+#endif // AES_H
+
+#endif // N2N_HAVE_AES

--- a/include/aes.h
+++ b/include/aes.h
@@ -28,6 +28,10 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
+
+#define AES_BLOCK_SIZE           16
+#define AES_IV_SIZE             (AES_BLOCK_SIZE)
+
 #define AES256_KEY_BYTES (256/8)
 #define AES192_KEY_BYTES (192/8)
 #define AES128_KEY_BYTES (128/8)
@@ -48,10 +52,10 @@ typedef struct aes_context_t {
 
 
 int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     unsigned char *iv, aes_context_t *ctx);
+                     const unsigned char *iv, aes_context_t *ctx);
 
 int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     unsigned char *iv, aes_context_t *ctx);
+                     const unsigned char *iv, aes_context_t *ctx);
 
 int aes_ecb_decrypt (unsigned char *out, const unsigned char *in, aes_context_t *ctx);
 

--- a/include/aes.h
+++ b/include/aes.h
@@ -48,10 +48,10 @@ typedef struct aes_context_t {
 
 
 int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     const unsigned char *iv, aes_context_t *ctx);
+                     unsigned char *iv, aes_context_t *ctx);
 
 int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     const unsigned char *iv, aes_context_t *ctx);
+                     unsigned char *iv, aes_context_t *ctx);
 
 int aes_ecb_decrypt (unsigned char *out, const unsigned char *in, aes_context_t *ctx);
 

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -159,6 +159,7 @@ typedef struct ether_hdr ether_hdr_t;
 #include "random_numbers.h"
 #include "pearson.h"
 #include "portable_endian.h"
+#include "aes.h"
 #include "speck.h"
 #include "n2n_regex.h"
 

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -221,6 +221,15 @@ int decode_uint32( uint32_t * out,
                    size_t * rem,
                    size_t * idx );
 
+int encode_uint64( uint8_t * base,
+                   size_t * idx,
+                   const uint64_t v );
+
+int decode_uint64( uint64_t * out,
+                   const uint8_t * base,
+                   size_t * rem,
+                   size_t * idx );
+
 int encode_buf( uint8_t * base,
                 size_t * idx,
                 const void * p,

--- a/src/aes.c
+++ b/src/aes.c
@@ -45,7 +45,7 @@ static char *openssl_err_as_string (void) {
 /* ****************************************************** */
 
 int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     const unsigned char *iv, aes_context_t *ctx) {
+                     unsigned char *iv, aes_context_t *ctx) {
 
 #ifdef HAVE_OPENSSL_1_1
   int evp_len;
@@ -81,13 +81,14 @@ int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,
                   &(ctx->enc_key),
                   iv,
                   AES_ENCRYPT);
+  memset(iv, 0, AES_BLOCK_SIZE);
 #endif
 }
 
 /* ****************************************************** */
 
 int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     const unsigned char *iv, aes_context_t *ctx) {
+                     unsigned char *iv, aes_context_t *ctx) {
 
 #ifdef HAVE_OPENSSL_1_1
   int evp_len;
@@ -123,6 +124,7 @@ int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
                   &(ctx->dec_key),
                   iv,
                   AES_DECRYPT);
+    memset(iv, 0, AES_BLOCK_SIZE);
 #endif
 
   return 0;

--- a/src/aes.c
+++ b/src/aes.c
@@ -45,7 +45,7 @@ static char *openssl_err_as_string (void) {
 /* ****************************************************** */
 
 int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     unsigned char *iv, aes_context_t *ctx) {
+                     const unsigned char *iv, aes_context_t *ctx) {
 
 #ifdef HAVE_OPENSSL_1_1
   int evp_len;
@@ -75,20 +75,21 @@ int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,
 
   EVP_CIPHER_CTX_reset(ctx->enc_ctx);
 #else
+  uint8_t tmp_iv[AES_IV_SIZE];
+  memcpy (tmp_iv, iv, AES_IV_SIZE);
   AES_cbc_encrypt(in,                // source
                   out,               // destination
                   in_len,            // enc size
                   &(ctx->enc_key),
-                  iv,
+                  tmp_iv,
                   AES_ENCRYPT);
-  memset(iv, 0, AES_BLOCK_SIZE);
 #endif
 }
 
 /* ****************************************************** */
 
 int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     unsigned char *iv, aes_context_t *ctx) {
+                     const unsigned char *iv, aes_context_t *ctx) {
 
 #ifdef HAVE_OPENSSL_1_1
   int evp_len;
@@ -118,13 +119,14 @@ int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
 
   EVP_CIPHER_CTX_reset(ctx->dec_ctx);
 #else
+  uint8_t tmp_iv[AES_IV_SIZE];
+  memcpy (tmp_iv, iv, AES_IV_SIZE);
   AES_cbc_encrypt(in,                // source
                   out,               // destination
                   in_len,            // enc size
                   &(ctx->dec_key),
-                  iv,
+                  tmp_iv,
                   AES_DECRYPT);
-    memset(iv, 0, AES_BLOCK_SIZE);
 #endif
 
   return 0;

--- a/src/aes.c
+++ b/src/aes.c
@@ -1,0 +1,201 @@
+/**
+ * (C) 2007-20 - ntop.org and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not see see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+#include "n2n.h"
+
+#ifdef N2N_HAVE_AES
+
+/* ****************************************************** */
+
+#ifdef HAVE_OPENSSL_1_1
+// get any erorr message out of openssl
+// taken from https://en.wikibooks.org/wiki/OpenSSL/Error_handling
+static char *openssl_err_as_string (void) {
+
+  BIO *bio = BIO_new (BIO_s_mem ());
+  ERR_print_errors (bio);
+  char *buf = NULL;
+  size_t len = BIO_get_mem_data (bio, &buf);
+  char *ret = (char *) calloc (1, 1 + len);
+
+  if(ret)
+    memcpy (ret, buf, len);
+
+  BIO_free (bio);
+  return ret;
+}
+#endif
+
+/* ****************************************************** */
+
+int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,
+                     const unsigned char *iv, aes_context_t *ctx) {
+
+#ifdef HAVE_OPENSSL_1_1
+  int evp_len;
+  int evp_ciphertext_len;
+
+  if(1 == EVP_EncryptInit_ex(ctx->enc_ctx, ctx->cipher, NULL, ctx->key, iv)) {
+    if(1 == EVP_CIPHER_CTX_set_padding(ctx->enc_ctx, 0)) {
+      if(1 == EVP_EncryptUpdate(ctx->enc_ctx, out, &evp_len, in, in_len)) {
+        evp_ciphertext_len = evp_len;
+        if(1 == EVP_EncryptFinal_ex(ctx->enc_ctx, out + evp_len, &evp_len)) {
+          evp_ciphertext_len += evp_len;
+          if(evp_ciphertext_len != in_len)
+            traceEvent(TRACE_ERROR, "aes_cbc_encrypt openssl encryption: encrypted %u bytes where %u were expected",
+                                    evp_ciphertext_len, in_len);
+        } else
+          traceEvent(TRACE_ERROR, "aes_cbc_encrypt openssl final encryption: %s",
+                                  openssl_err_as_string());
+      } else
+        traceEvent(TRACE_ERROR, "aes_cbc_encrypt openssl encrpytion: %s",
+                                openssl_err_as_string());
+    } else
+      traceEvent(TRACE_ERROR, "aes_cbc_encrypt openssl padding setup: %s",
+                              openssl_err_as_string());
+  } else
+    traceEvent(TRACE_ERROR, "aes_cbc_encrypt openssl init: %s",
+                            openssl_err_as_string());
+
+  EVP_CIPHER_CTX_reset(ctx->enc_ctx);
+#else
+  AES_cbc_encrypt(in,                // source
+                  out,               // destination
+                  in_len,            // enc size
+                  &(ctx->enc_key),
+                  iv,
+                  AES_ENCRYPT);
+#endif
+}
+
+/* ****************************************************** */
+
+int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
+                     const unsigned char *iv, aes_context_t *ctx) {
+
+#ifdef HAVE_OPENSSL_1_1
+  int evp_len;
+  int evp_plaintext_len;
+
+  if(1 == EVP_DecryptInit_ex(ctx->dec_ctx, ctx->cipher, NULL, ctx->key, iv)) {
+    if(1 == EVP_CIPHER_CTX_set_padding(ctx->dec_ctx, 0)) {
+      if(1 == EVP_DecryptUpdate(ctx->dec_ctx, out, &evp_len, in, in_len)) {
+        evp_plaintext_len = evp_len;
+        if(1 == EVP_DecryptFinal_ex(ctx->dec_ctx, out + evp_len, &evp_len)) {
+          evp_plaintext_len += evp_len;
+          if(evp_plaintext_len != in_len)
+            traceEvent(TRACE_ERROR, "aes_cbc_decrypt openssl decryption: decrypted %u bytes where %u were expected",
+                                    evp_plaintext_len, in_len);
+        } else
+          traceEvent(TRACE_ERROR, "aes_cbc_decrypt openssl final decryption: %s",
+                                  openssl_err_as_string());
+      } else
+        traceEvent(TRACE_ERROR, "aes_cbc_decrypt openssl decrpytion: %s",
+                                openssl_err_as_string());
+    } else
+      traceEvent(TRACE_ERROR, "aes_cbc_decrypt openssl padding setup: %s",
+                              openssl_err_as_string());
+  } else
+    traceEvent(TRACE_ERROR, "aes_cbc_decrypt openssl init: %s",
+                            openssl_err_as_string());
+
+  EVP_CIPHER_CTX_reset(ctx->dec_ctx);
+#else
+  AES_cbc_encrypt(in,                // source
+                  out,               // destination
+                  in_len,            // enc size
+                  &(ctx->dec_key),
+                  iv,
+                  AES_DECRYPT);
+#endif
+
+  return 0;
+}
+
+/* ****************************************************** */
+
+int aes_ecb_decrypt (unsigned char *out, const unsigned char *in, aes_context_t *ctx) {
+
+#ifdef HAVE_OPENSSL_1_1
+  AES_ecb_encrypt(in, out, &(ctx->ecb_dec_key), AES_DECRYPT);
+#else
+  AES_ecb_encrypt(in, out, &(ctx->dec_key), AES_DECRYPT);
+#endif
+}
+
+/* ****************************************************** */
+
+int aes_init (const unsigned char *key, size_t key_size, aes_context_t **ctx) {
+
+  // allocate context...
+  *ctx = (aes_context_t*) calloc(1, sizeof(aes_context_t));
+  if (!(*ctx))
+    return -1;
+  // ...and fill her up
+
+  // initialize data structures
+#ifdef HAVE_OPENSSL_1_1
+  if(!((*ctx)->enc_ctx = EVP_CIPHER_CTX_new())) {
+    traceEvent(TRACE_ERROR, "aes_init openssl's evp_* encryption context creation failed: %s",
+                            openssl_err_as_string());
+    return(-1);
+  }
+  if(!((*ctx)->dec_ctx = EVP_CIPHER_CTX_new())) {
+    traceEvent(TRACE_ERROR, "aes_init openssl's evp_* decryption context creation failed: %s",
+                            openssl_err_as_string());
+    return(-1);
+  }
+#endif
+
+  // check key size and make key size (given in bytes) dependant settings
+  switch(key_size) {
+    case AES128_KEY_BYTES:    // 128 bit key size
+#ifdef HAVE_OPENSSL_1_1
+      (*ctx)->cipher = EVP_aes_128_cbc();
+#endif
+      break;
+    case AES192_KEY_BYTES:    // 192 bit key size
+#ifdef HAVE_OPENSSL_1_1
+      (*ctx)->cipher = EVP_aes_192_cbc();
+#endif
+      break;
+    case AES256_KEY_BYTES:    // 256 bit key size
+#ifdef HAVE_OPENSSL_1_1
+      (*ctx)->cipher = EVP_aes_256_cbc();
+#endif
+      break;
+    default:
+       traceEvent(TRACE_ERROR, "aes_init invalid key size %u\n", key_size);
+       return -1;
+  }
+
+  // key materiel handling
+#ifdef HAVE_OPENSSL_1_1
+  memcpy((*ctx)->key, key, key_size);
+  AES_set_decrypt_key(key, key_size * 8, &((*ctx)->ecb_dec_key));
+#else
+  AES_set_encrypt_key(key, key_size * 8, &((*ctx)->enc_key));
+  AES_set_decrypt_key(key, key_size * 8, &((*ctx)->dec_key));
+#endif
+
+  return 0;
+}
+
+
+#endif // N2N_HAVE_AES

--- a/src/transform_aes.c
+++ b/src/transform_aes.c
@@ -22,8 +22,6 @@
 #ifdef N2N_HAVE_AES
 
 
-#define AES_BLOCK_SIZE           16
-
 // size of random value prepended to plaintext defaults to AES BLOCK_SIZE;
 // gradually abandoning security, lower values could be chosen;
 // however, minimum transmission size with cipher text stealing scheme is one
@@ -31,11 +29,9 @@
 // might encounter an issue with lower values here
 #define AES_PREAMBLE_SIZE       (AES_BLOCK_SIZE)
 
-#define AES_IV_SIZE             (AES_BLOCK_SIZE)
-
 // cbc mode is being used with random value prepended to plaintext
 // instead of iv so, actual iv is null_iv
-uint8_t null_iv[AES_IV_SIZE] = {0};
+const uint8_t null_iv[AES_IV_SIZE] = {0};
 
 typedef struct transop_aes {
   aes_context_t       *ctx;

--- a/src/transform_aes.c
+++ b/src/transform_aes.c
@@ -35,7 +35,7 @@
 
 // cbc mode is being used with random value prepended to plaintext
 // instead of iv so, actual iv is null_iv
-const uint8_t null_iv[AES_IV_SIZE] = {0};
+uint8_t null_iv[AES_IV_SIZE] = {0};
 
 typedef struct transop_aes {
   aes_context_t       *ctx;

--- a/src/wire.c
+++ b/src/wire.c
@@ -103,6 +103,28 @@ int decode_uint32( uint32_t * out,
     return 4;
 }
 
+int encode_uint64( uint8_t * base,
+                   size_t * idx,
+                   const uint64_t v )
+{
+    *(uint64_t*)(base + *idx) = htobe64(v);
+    *idx += 8;
+    return 8;
+}
+
+int decode_uint64( uint64_t * out,
+                   const uint8_t * base,
+                   size_t * rem,
+                   size_t * idx )
+{
+    if (*rem < 8 ) { return 0; }
+
+    *out = be64toh(*(uint64_t*)base + *idx);
+    *idx += 8;
+    *rem -= 8;
+    return 8;
+}
+
 int encode_buf( uint8_t * base,
                 size_t * idx,
                 const void * p,


### PR DESCRIPTION
This pull request changes (rewrites) the aes transform from _cbc with padding_ to _cipher text stealing_ using the underlying cbc and ecb modes straight forward along [this](https://en.wikipedia.org/wiki/Ciphertext_stealing#CBC_implementation_notes) scheme. It still relies on openSSL.

The aes cipher's internals now are gathered in the new file `aes.c` whereas the cts-scheme considered higher-level logic residing in `transform_aes.c`.

A random number (128 bit, block sized) is prepended to the plaintext instead of using the IV (using a zeroed IV) to make sure that the minimum packet size of one block is reached (a requirement of cipher text stealing scheme). The regular packet size however will probably never fall below this limit as they carry header and stuff. So, it is debatable to **shorten the random number's length, maybe to 64 bit saving another 8 bytes per packet** – open an _Issue_ if you feel we should discuss. Just be aware, low level programmer, should you ever work with shorter packets.

Slight cipher-bound speed-ups in the 10 to 20 percent range are observed  as determined by `tools/n2n-benchmark`.

This pull request breaks compatibility to current _dev_ – breaking changes are limited to aes transform.

Fixes #378.
Fixes #238.