### PR TITLE
Avoid leaking memory if the buffer is uncompressable

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1600,6 +1600,9 @@ void edge_send_packet2net(n2n_edge_t * eee,
 
       memcpy (tap_pkt, compression_buffer, compression_len);
       len = compression_len;
+    }
+
+    if(compression_buffer) {
       free (compression_buffer);
     }
   }


### PR DESCRIPTION
See also #390 for 2.8-stable