### PR TITLE
added aes-ni support

### DIFF
--- a/include/aes.h
+++ b/include/aes.h
@@ -60,6 +60,16 @@ typedef struct aes_context_t {
   AES_KEY             dec_key;                 /* tx key */
 } aes_context_t;
 
+#elif defined (__AES__) && defined (__SSE2__) // Intel's AES-NI ---------------------------
+
+#include <immintrin.h>
+
+typedef struct aes_context_t {
+  __m128i rk_enc[15];
+  __m128i rk_dec[15];
+  int     Nr;
+} aes_context_t;
+
 #else // plain C --------------------------------------------------------------------------
 
 typedef struct aes_context_t {
@@ -68,7 +78,7 @@ typedef struct aes_context_t {
   int      Nr;            // number of rounds
 } aes_context_t;
 
-#endif
+#endif // ---------------------------------------------------------------------------------
 
 
 int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,


### PR DESCRIPTION
This pull request adds AES-NI support on Intel CPUs if detected¹ at compile time **and** openSSL is not present – or just compiled without or commented the two `HAVE_OPENSSL_1_0` and  `HAVE_OPENSSL_1_0` defines in the `include/config.h` file.

Compared to openSSL 1.1's `evp_*` implementation, the `tools/n2n-benchmark` tool observes a  speed-up of 15 to 22 percent on different computers. So, it is not the worst fall-back solution should openSSL not be available.

```
                    openSSL 1.1           n2n's AES-NI

i7 2860QM             527 MB/s              608 MB/s

i7 7500U              885 MB/s            1,081 MB/s

```

The changes are fully compatible to current _dev_. Just be aware that a CPU _without_ AES-NI support will not be able to run a binary executable which was compiled _with_ AES-NI support.

The code in `src/aes.c` might have potential for optimization as well as clean-up. But that's another night's work.

___________
¹ using `./configure CFLAGS="-march=native"` or even better `./configure CFLAGS="-O3 -march=native"` for configuration