### PR TITLE
increase packet version to 3

### DIFF
--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #endif
 
-#define N2N_PKT_VERSION                 2
+#define N2N_PKT_VERSION                 3
 #define N2N_DEFAULT_TTL                 2       /* can be forwarded twice at most */
 #define N2N_COMMUNITY_SIZE              16
 #define N2N_MAC_SIZE                    6

--- a/src/cc20.c
+++ b/src/cc20.c
@@ -99,7 +99,7 @@ static void cc20_init_block(cc20_context_t *ctx, const uint8_t nonce[]) {
 #define ADD _mm_add_epi32
 #define ROL(X,r) (XOR(SL(X,r),SR(X,(32-r))))
 
-#if defined (__SSE4_1__) // --- SSE3 (__SSE3__ is not a reliable macro, better use __SSE_4_1__)
+#if defined (__SSE3__) // --- SSE3
 #define L8  _mm_set_epi32(0x0e0d0c0fL, 0x0a09080bL, 0x06050407L, 0x02010003L)
 #define L16 _mm_set_epi32(0x0d0c0f0eL, 0x09080b0aL, 0x05040706L, 0x01000302L)
 #define ROL8(X)  ( _mm_shuffle_epi8(X, L8))  /* SSE 3 */

--- a/src/cc20.c
+++ b/src/cc20.c
@@ -99,7 +99,7 @@ static void cc20_init_block(cc20_context_t *ctx, const uint8_t nonce[]) {
 #define ADD _mm_add_epi32
 #define ROL(X,r) (XOR(SL(X,r),SR(X,(32-r))))
 
-#if defined (__SSE3__) // --- SSE3
+#if defined (__SSE4_1__) // --- SSE3 (__SSE3__ is not a reliable macro, better use __SSE_4_1__)
 #define L8  _mm_set_epi32(0x0e0d0c0fL, 0x0a09080bL, 0x06050407L, 0x02010003L)
 #define L16 _mm_set_epi32(0x0d0c0f0eL, 0x09080b0aL, 0x05040706L, 0x01000302L)
 #define ROL8(X)  ( _mm_shuffle_epi8(X, L8))  /* SSE 3 */


### PR DESCRIPTION
This pull request increases the packet version to 3. **All edges and supernodes of your network** need to be updated in order to be able to communicate (again).

Fixes #375 

_______

~~Also, an SSE related version correction is included to allow correct compilation on older CPUs (it was meant to go in a separate pull request, but, well, git and me, you know…): Sometimes, `__SSE3__` is indicated even though the CPU does not have SSE3-support. That's why we need to check for `__SSE4_1`__ instead.~~ _will go into another pull request_