### PR TITLE
fix(openwrt): move config to `/etc/n2n` (2.8-stable)

### DIFF
--- a/packages/openwrt/Makefile
+++ b/packages/openwrt/Makefile
@@ -56,7 +56,7 @@ define Build/Configure
 endef
 
 define Package/n2n-edge/conffiles
-/etc/config/n2n-edge.conf
+/etc/n2n/edge.conf
 endef
 
 define Package/n2n-edge/install
@@ -64,12 +64,12 @@ define Package/n2n-edge/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/edge $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/etc/init.d/edge $(1)/etc/init.d/edge
-	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/etc/n2n/edge.conf.sample $(1)/etc/config/n2n-edge.conf
+	$(INSTALL_DIR) $(1)/etc/n2n
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/etc/n2n/edge.conf.sample $(1)/etc/n2n/edge.conf
 endef
 
 define Package/n2n-supernode/conffiles
-/etc/config/n2n-supernode.conf
+/etc/n2n/supernode.conf
 endef
 
 define Package/n2n-supernode/install
@@ -77,8 +77,8 @@ define Package/n2n-supernode/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/supernode $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/etc/init.d/supernode $(1)/etc/init.d/supernode
-	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/etc/n2n/supernode.conf.sample $(1)/etc/config/n2n-supernode.conf
+	$(INSTALL_DIR) $(1)/etc/n2n
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/etc/n2n/supernode.conf.sample $(1)/etc/n2n/supernode.conf
 endef
 
 $(eval $(call BuildPackage,n2n-edge))

--- a/packages/openwrt/README.md
+++ b/packages/openwrt/README.md
@@ -33,7 +33,7 @@ copied to the target device, and installed with `opkg install`.
 ## Configuration
 
 The edge node can be started with `/etc/init.d/edge start`.
-Its configuration file is `/etc/config/n2n-edge.conf`.
+Its configuration file is `/etc/n2n/edge.conf`.
 
 The supernode can be started with `/etc/init.d/supernode start`.
-Its configuration file is `/etc/config/n2n-supernode.conf`.
+Its configuration file is `/etc/n2n/supernode.conf`.

--- a/packages/openwrt/etc/init.d/edge
+++ b/packages/openwrt/etc/init.d/edge
@@ -4,7 +4,7 @@ STOP=10
 
 USE_PROCD=1
 PROG=/usr/bin/edge
-CONFIGFILE=/etc/config/n2n-edge.conf
+CONFIGFILE=/etc/n2n/edge.conf
 
 start_service() {
 	procd_open_instance

--- a/packages/openwrt/etc/init.d/supernode
+++ b/packages/openwrt/etc/init.d/supernode
@@ -4,7 +4,7 @@ STOP=10
 
 USE_PROCD=1
 PROG=/usr/bin/supernode
-CONFIGFILE=/etc/config/n2n-supernode.conf
+CONFIGFILE=/etc/n2n/supernode.conf
 
 start_service() {
 	procd_open_instance


### PR DESCRIPTION
The `/etc/config` directory should only store the "UCI" configuration files.

Reference: https://openwrt.org/docs/guide-user/base-system/uci