### PR TITLE
made openssl & zstd support optional (in configuration)

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -25,26 +25,37 @@ else
   N2N_LIBS="-lzstd ${N2N_LIBS}"
 fi
 
-AC_CHECK_LIB([crypto], [AES_cbc_encrypt])
 
-if test "x$ac_cv_lib_crypto_AES_cbc_encrypt" != xyes; then
-  AC_MSG_RESULT(OpenSSL not present)
-else
-  AC_DEFINE([HAVE_OPENSSL_1_0], [], [OpenSSL 1.0 is present])
-  N2N_LIBS="-lcrypto ${N2N_LIBS}"
-fi
+AC_ARG_WITH([openssl],
+ [AS_HELP_STRING([--with-openssl],
+ [enable support for OpenSSL])],
+ [],
+ [with_openssl=no])
 
-OLD_CFLAGS="${CFLAGS}"
-OLD_LDFLAGS="${LDFLAGS}"
+if test "x$with_openssl" != xno; then
 
-CFLAGS="${CFLAGS} -I/usr/local/opt/openssl@1.1/include"
-LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl@1.1/lib/"
-AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_reset])
-if test "x$ac_cv_lib_crypto_EVP_CIPHER_CTX_reset" != xyes; then
-   CFLAGS="${OLD_CFLAGS}"
-   LDFLAGS="${OLD_LDFLAGS}"
-else
-   AC_DEFINE([HAVE_OPENSSL_1_1], [], [OpenSSL 1.1 is present])
+  AC_CHECK_LIB([crypto], [AES_cbc_encrypt])
+
+  if test "x$ac_cv_lib_crypto_AES_cbc_encrypt" != xyes; then
+    AC_MSG_RESULT(OpenSSL not present)
+  else
+    AC_DEFINE([HAVE_OPENSSL_1_0], [], [OpenSSL 1.0 is present])
+    N2N_LIBS="-lcrypto ${N2N_LIBS}"
+  fi
+
+  OLD_CFLAGS="${CFLAGS}"
+  OLD_LDFLAGS="${LDFLAGS}"
+
+  CFLAGS="${CFLAGS} -I/usr/local/opt/openssl@1.1/include"
+  LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl@1.1/lib/"
+  AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_reset])
+  if test "x$ac_cv_lib_crypto_EVP_CIPHER_CTX_reset" != xyes; then
+     CFLAGS="${OLD_CFLAGS}"
+     LDFLAGS="${OLD_LDFLAGS}"
+  else
+    AC_DEFINE([HAVE_OPENSSL_1_1], [], [OpenSSL 1.1 is present])
+  fi
+
 fi
 
 AC_CHECK_LIB([pcap], [pcap_open_live], pcap=true)

--- a/configure.seed
+++ b/configure.seed
@@ -16,36 +16,37 @@ fi
 N2N_LIBS=
 
 AC_PROG_CC
-AC_CHECK_LIB([zstd], [ZSTD_compress])
 
-if test "x$ac_cv_lib_zstd_ZSTD_compress" != xyes; then
-  AC_MSG_RESULT(Building n2n without ZSTD support)
-else
-  AC_DEFINE([N2N_HAVE_ZSTD], [], [Have ZSTD support])
-  N2N_LIBS="-lzstd ${N2N_LIBS}"
+AC_ARG_WITH([zstd],
+ [AS_HELP_STRING([--with-zstd],
+ [enable support for zstd])],
+ [],
+ [with_zstd=no])
+if test "x$with_zstd" != xno; then
+  AC_CHECK_LIB([zstd], [ZSTD_compress])
+  if test "x$ac_cv_lib_zstd_ZSTD_compress" != xyes; then
+    AC_MSG_RESULT(Building n2n without ZSTD support)
+  else
+    AC_DEFINE([N2N_HAVE_ZSTD], [], [Have ZSTD support])
+    N2N_LIBS="-lzstd ${N2N_LIBS}"
+  fi
 fi
-
 
 AC_ARG_WITH([openssl],
  [AS_HELP_STRING([--with-openssl],
  [enable support for OpenSSL])],
  [],
  [with_openssl=no])
-
 if test "x$with_openssl" != xno; then
-
   AC_CHECK_LIB([crypto], [AES_cbc_encrypt])
-
   if test "x$ac_cv_lib_crypto_AES_cbc_encrypt" != xyes; then
     AC_MSG_RESULT(OpenSSL not present)
   else
     AC_DEFINE([HAVE_OPENSSL_1_0], [], [OpenSSL 1.0 is present])
     N2N_LIBS="-lcrypto ${N2N_LIBS}"
   fi
-
   OLD_CFLAGS="${CFLAGS}"
   OLD_LDFLAGS="${LDFLAGS}"
-
   CFLAGS="${CFLAGS} -I/usr/local/opt/openssl@1.1/include"
   LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl@1.1/lib/"
   AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_reset])
@@ -55,7 +56,6 @@ if test "x$with_openssl" != xno; then
   else
     AC_DEFINE([HAVE_OPENSSL_1_1], [], [OpenSSL 1.1 is present])
   fi
-
 fi
 
 AC_CHECK_LIB([pcap], [pcap_open_live], pcap=true)


### PR DESCRIPTION
Given that all ciphers are built-in now, this pull request opts out OpenSSL which from hereon has to explicitly be configured by using

`./configure --with-openssl`

I will adopt the documentation in the other pull request (#409) accordingly.