### PR TITLE
compression scheme name fix

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -58,10 +58,8 @@
 #define N2N_COMPRESSION_ID_INVALID	0
 #define N2N_COMPRESSION_ID_NONE		1	/* default, see edge_init_conf_defaults(...) in edge_utils.c */
 #define N2N_COMPRESSION_ID_LZO		2	/* set if '-z1' or '-z' cli option is present, see setOption(...) in edge.c */
-#ifdef N2N_HAVE_ZSTD
 #define N2N_COMPRESSION_ID_ZSTD		3	/* set if '-z2' cli option is present, available only if compiled with zstd lib */
 #define ZSTD_COMPRESSION_LEVEL		7	/* 1 (faster) ... 22 (more compression) */
-#endif
 
 /* (un)purgeable community indicator (supernode) */
 #define COMMUNITY_UNPURGEABLE		0

--- a/src/edge.c
+++ b/src/edge.c
@@ -215,7 +215,9 @@ static void setPayloadCompression(n2n_edge_conf_t *conf, int compression) {
   default:
     {
       conf->compression = N2N_COMPRESSION_ID_NONE;
-      traceEvent(TRACE_NORMAL, "the %s compression given by -z_ option is not supported in this version.", compression_str(compression));
+      // internal comrpession scheme numbering differs from cli counting by one, hence plus one
+      // (internal: 0 == invalid, 1 == none, 2 == lzo, 3 == zstd)
+      traceEvent(TRACE_NORMAL, "the %s compression given by -z_ option is not supported in this version.", compression_str(compression + 1));
       exit(1); // to make the user aware
     }
   }

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -115,10 +115,7 @@ const char* compression_str(uint8_t cmpr) {
   switch(cmpr) {
   case N2N_COMPRESSION_ID_NONE:  return("none");
   case N2N_COMPRESSION_ID_LZO:   return("lzo1x");
-
-#ifdef HAVE_LIBZSTD
   case N2N_COMPRESSION_ID_ZSTD:  return("zstd");
-#endif
   default:                       return("invalid");
   };
 }


### PR DESCRIPTION
This pull requests lets n2n know about the zstd compression scheme **name** even if it is not compiled to correctly answer a cli-provided `-z2` when zstd support is not compiled.

Also, it fixes the mapping between internal compression scheme numbering and cli-bound counting in `edge.c`, too (plus one).