### PR TITLE
dropped openssl 1.0 support

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -38,13 +38,6 @@ AC_ARG_WITH([openssl],
  [],
  [with_openssl=no])
 if test "x$with_openssl" != xno; then
-  AC_CHECK_LIB([crypto], [AES_cbc_encrypt])
-  if test "x$ac_cv_lib_crypto_AES_cbc_encrypt" != xyes; then
-    AC_MSG_RESULT(OpenSSL not present)
-  else
-    AC_DEFINE([HAVE_OPENSSL_1_0], [], [OpenSSL 1.0 is present])
-    N2N_LIBS="-lcrypto ${N2N_LIBS}"
-  fi
   OLD_CFLAGS="${CFLAGS}"
   OLD_LDFLAGS="${LDFLAGS}"
   CFLAGS="${CFLAGS} -I/usr/local/opt/openssl@1.1/include"
@@ -55,6 +48,7 @@ if test "x$with_openssl" != xno; then
      LDFLAGS="${OLD_LDFLAGS}"
   else
     AC_DEFINE([HAVE_OPENSSL_1_1], [], [OpenSSL 1.1 is present])
+    N2N_LIBS="-lcrypto ${N2N_LIBS}"
   fi
 fi
 

--- a/configure.seed
+++ b/configure.seed
@@ -44,6 +44,7 @@ if test "x$with_openssl" != xno; then
   LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl@1.1/lib/"
   AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_reset])
   if test "x$ac_cv_lib_crypto_EVP_CIPHER_CTX_reset" != xyes; then
+     AC_MSG_RESULT(OpenSSL 1.1 not present)
      CFLAGS="${OLD_CFLAGS}"
      LDFLAGS="${OLD_LDFLAGS}"
   else

--- a/include/aes.h
+++ b/include/aes.h
@@ -17,7 +17,7 @@
  */
 
 
-#include "n2n.h"               // HAVE_OPENSSL_1_1, HAVE_OPENSSL_1_0, traceEvent ...
+#include "n2n.h"               // HAVE_OPENSSL_1_1, traceEvent ...
 
 
 #ifndef AES_H
@@ -49,15 +49,6 @@ typedef struct aes_context_t {
   const EVP_CIPHER    *cipher;                 /* cipher to use: e.g. EVP_aes_128_cbc */
   uint8_t             key[AES256_KEY_BYTES];   /* the pure key data for payload encryption & decryption */
   AES_KEY             ecb_dec_key;             /* one step ecb decryption key */
-} aes_context_t;
-
-#elif defined (HAVE_OPENSSL_1_0) // openSSL 1.0 -------------------------------------------
-
-#include <openssl/aes.h>
-
-typedef struct aes_context_t {
-  AES_KEY             enc_key;                 /* tx key */
-  AES_KEY             dec_key;                 /* tx key */
 } aes_context_t;
 
 #elif defined (__AES__) && defined (__SSE2__) // Intel's AES-NI ---------------------------

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -124,7 +124,7 @@ typedef struct ether_hdr ether_hdr_t;
 #include <assert.h>
 #include <sys/stat.h>
 #include <stdint.h>
-#if defined (HAVE_OPENSSL_1_0) || defined (HAVE_OPENSSL_1_1)
+#if defined (HAVE_OPENSSL_1_1)
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
 #endif

--- a/src/aes.c
+++ b/src/aes.c
@@ -161,80 +161,6 @@ int aes_init (const unsigned char *key, size_t key_size, aes_context_t **ctx) {
 }
 
 
-#elif defined (HAVE_OPENSSL_1_0) // openSSL 1.0 -------------------------------------------
-
-
-int aes_cbc_encrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     const unsigned char *iv, aes_context_t *ctx) {
-
-  uint8_t tmp_iv[AES_IV_SIZE];
-  memcpy (tmp_iv, iv, AES_IV_SIZE);
-  AES_cbc_encrypt(in,                // source
-                  out,               // destination
-                  in_len,            // enc size
-                  &(ctx->enc_key),
-                  tmp_iv,
-                  AES_ENCRYPT);
-
-  return 0;
-}
-
-
-int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
-                     const unsigned char *iv, aes_context_t *ctx) {
-
-  uint8_t tmp_iv[AES_IV_SIZE];
-  memcpy (tmp_iv, iv, AES_IV_SIZE);
-  AES_cbc_encrypt(in,                // source
-                  out,               // destination
-                  in_len,            // enc size
-                  &(ctx->dec_key),
-                  tmp_iv,
-                  AES_DECRYPT);
-
-  return 0;
-}
-
-
-int aes_ecb_decrypt (unsigned char *out, const unsigned char *in, aes_context_t *ctx) {
-
-  AES_ecb_encrypt(in, out, &(ctx->dec_key), AES_DECRYPT);
-
-  return 0;
-}
-
-
-int aes_init (const unsigned char *key, size_t key_size, aes_context_t **ctx) {
-
-  // allocate context...
-  *ctx = (aes_context_t*) calloc(1, sizeof(aes_context_t));
-  if (!(*ctx))
-    return -1;
-  // ...and fill her up
-
-  // initialize data structures
-
-  // check key size and make key size (given in bytes) dependant settings
-  switch(key_size) {
-    case AES128_KEY_BYTES:    // 128 bit key size
-      break;
-    case AES192_KEY_BYTES:    // 192 bit key size
-      break;
-    case AES256_KEY_BYTES:    // 256 bit key size
-      break;
-    default:
-       traceEvent(TRACE_ERROR, "aes_init invalid key size %u\n", key_size);
-       return -1;
-  }
-
-  // key materiel handling
-  AES_set_encrypt_key(key, key_size * 8, &((*ctx)->enc_key));
-  AES_set_decrypt_key(key, key_size * 8, &((*ctx)->dec_key));
-
-  return 0;
-}
-
-
 #elif defined (__AES__) && defined (__SSE2__) // Intel's AES-NI ---------------------------
 
 
@@ -1210,7 +1136,7 @@ int aes_init (const unsigned char *key, size_t key_size, aes_context_t **ctx) {
 }
 
 
-#endif // openSSL 1.1, openSSL 1.0, plain C -----------------------------------------------
+#endif // openSSL 1.1, AES-NI, plain C ----------------------------------------------------
 
 int aes_deinit (aes_context_t *ctx) {
 


### PR DESCRIPTION
As the built-in implementation of AES got faster than OpenSSL **1.0**'s on most (all?) computers, there is no need for OpenSSL 1.0 support anymore. Thus, this pull request removes OpenSSL 1.0 support from n2n.

Optional OpenSSL **1.1** support remains untouched.

Fixes #402.

