### PR TITLE
adopted aes key-length trigger values

### DIFF
--- a/doc/Crypto.md
+++ b/doc/Crypto.md
@@ -40,6 +40,8 @@ AES also prepends a random value to the plaintext. Its size is adjustable by cha
 
 Apart from n2n's plain C implementation, Intel's AES-NI is supported – again, please have a look at the [Building document](./Building.md). In case of openSSL support its `evp_*` interface gets used which also offers hardware acceleration where available (SSE, AES-NI, …). It however is slower than the following stream ciphers because the CBC mode cannot compete with the optimized stream ciphers.
 
+This cipher's different key-sizes are triggered by the length of the user-provided key: 22 characters or less make n2n use AES-128, between 23 and 32 characters lead to AES-192, and 33 or more characters trigger AES-256.
+
 ### ChaCha20
 
 ChaCha20 was the first stream cipher supported by n2n.

--- a/src/transform_aes.c
+++ b/src/transform_aes.c
@@ -187,10 +187,11 @@ static int setup_aes_key(transop_aes_t *priv, const uint8_t *password, ssize_t p
   pearson_hash_256(key_mat, password, password_len);
 
   // the length-dependant scheme for key setup was discussed on github:
-  // https://github.com/ntop/n2n/issues/101
-  if(password_len >= 65) {
+  // https://github.com/ntop/n2n/issues/101 -- as no iv encryption required
+  //  anymore, the key-size trigger values were roughly halved
+  if(password_len >= 33) {
     key_size = AES256_KEY_BYTES;       // 256 bit
-  } else if(password_len >= 44) {
+  } else if(password_len >= 23) {
     key_size = AES192_KEY_BYTES;       // 192 bit
   } else {
     key_size = AES128_KEY_BYTES;       // 128 bit


### PR DESCRIPTION
This pull request adopts the lengths of user input key (new: 22, 32, and beyond) which trigger AES' internal key length (128, 192, 256 bit).

The old values could roughly be halved as there is no need for additional entropy anymore (formerly required for IV encryption): Assuming 6 bits entropy per input key character, we have

128 / 6 --> 21.3 --> 22 characters
192 / 6 --> 32.0 --> 32 characters

So, input password lengths of up to 22 characters trigger AES-128, from 23 to 32 trigger AES-192, 33 or more trigger AES-256. This behavior now is also documented in Crypto.md.

This pull request breaks compatibility if user provided passwords of more than 22 characters were used (with AES).