### PR TITLE
fix(win): "config.h: No such file or directory"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(CheckFunctionExists)
 SET(CMAKE_VERBOSE_MAKEFILE ON)
 
 # N2n release information
-set(N2N_VERSION "2.7.0")
+set(N2N_VERSION "2.8.0")
 set(N2N_OSNAME ${CMAKE_SYSTEM})
 execute_process(
         COMMAND git --version

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -38,7 +38,7 @@
 #ifdef WIN32
 #include "win32/n2n_win32.h"
 
-#ifdef _MSC_VER
+#ifndef CMAKE_BUILD
 #include "config.h" /* Visual C++ */
 #else
 #include "win32/winconfig.h"


### PR DESCRIPTION
This pull request use CMAKE_BUILD instead of _MSC_VER to make the compilation pass. 
And update N2N_VERSION in CMakeLists.txt.

Fixes #366.