### PR TITLE
fix(win): "config.h: No such file or directory"

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -36,7 +36,7 @@
 
 /* Moved here to define _CRT_SECURE_NO_WARNINGS before all the including takes place */
 #ifdef WIN32
-#ifdef _MSC_VER
+#ifndef CMAKE_BUILD
 #include "config.h" /* Visual C++ */
 #else
 #include "win32/winconfig.h"


### PR DESCRIPTION
This pull request use CMAKE_BUILD instead of _MSC_VER to make the compilation pass.

Fixes #366.