### PR TITLE
merged edge's subnet parameter into address parameter

### DIFF
--- a/doc/TapConfiguration.md
+++ b/doc/TapConfiguration.md
@@ -20,7 +20,7 @@ n2n supports several ways to assign an IPv4 address to the virtual ethernet devi
 
 The command line parameter `-a <static:IP address>` assigns a static IP address, e.g. `-a static:192.168.8.5` to the device. The optional `static` keyword (and the delimiting colon) can be omitted, so `-a 192.168.8.5` works as well.
 
-The netmask can optionally be provided using `-s <netmask>`, e.g. `-s 255.255.255.0` which also is the default should `-s` not be provided.
+The netmask in CIDR notation can optionally be appended to the address, e.g. `-a 192.168.8.5/24` for netmask `255.255.255.0` which also is the default should the netmask not be provided.
 
 ### Auto-IP Address
 

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -257,7 +257,6 @@ typedef struct n2n_tuntap_priv_config {
   dec_ip_str_t        netmask;
   char                device_mac[N2N_MACNAMSIZ];
   int                 mtu;
-  uint8_t             got_s;
   uint8_t             daemon;
 #ifndef WIN32
   uid_t               userid;

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -89,6 +89,10 @@
 #define N2N_MACNAMSIZ           18 /* AA:BB:CC:DD:EE:FF + NULL*/
 #define N2N_IF_MODE_SIZE        16 /* static | dhcp */
 
+#define N2N_EDGE_DEFAULT_DEV_NAME  "edge0"
+#define N2N_EDGE_DEFAULT_NETMASK   "255.255.255.0"  /* default netmask for edge ip address... */
+#define N2N_EDGE_DEFAULT_CIDR_NM   24               /* ... also in cidr format                */
+
 #define N2N_SN_LPORT_DEFAULT 7654
 #define N2N_SN_PKTBUF_SIZE   2048
 


### PR DESCRIPTION
In a first attempt to clean-up command line a bit, edge's `-s` (subnet) was merged into `-a` (address) follwoing cidr-style `-a [static:|dhcp:]IP[/nn]` style (keeping /nn optional, defaulting to /24, removing `-s`).

For example, the new `-a 192.168.8.5/16` corresponds to the former `-a 192.168.8.5 -s 255.255.0.0` 

This saves one parameter and one line of help text.