### PR TITLE
Add new federation flag to community structure

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -359,7 +359,7 @@ typedef struct sn_stats
 struct sn_community
 {
   char community[N2N_COMMUNITY_SIZE];
-  int  is_federation;     		      /* if not-zero, then the current community is the federation of supernodes */
+  uint8_t             is_federation;          /* if not-zero, then the current community is the federation of supernodes */
   uint8_t             purgeable;              /* indicates purgeable community (fixed-name, predetermined (-c parameter) communties usually are unpurgeable) */
   uint8_t	      header_encryption;      /* Header encryption indicator. */
   he_context_t        *header_encryption_ctx; /* Header encryption cipher context. */

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -493,6 +493,7 @@ int quick_edge_init(char *device_name, char *community_name,
 		    char *local_ip_address,
 		    char *supernode_ip_address_port,
 		    int *keep_on_running);
+int comm_init(struct sn_community *comm, char* cmn);
 int sn_init(n2n_sn_t *sss);
 void sn_term(n2n_sn_t *sss);
 int run_sn_loop(n2n_sn_t *sss, int *keep_running);

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -359,6 +359,7 @@ typedef struct sn_stats
 struct sn_community
 {
   char community[N2N_COMMUNITY_SIZE];
+  int  is_federation;     		      /* if not-zero, then the current community is the federation of supernodes */
   uint8_t             purgeable;              /* indicates purgeable community (fixed-name, predetermined (-c parameter) communties usually are unpurgeable) */
   uint8_t	      header_encryption;      /* Header encryption indicator. */
   he_context_t        *header_encryption_ctx; /* Header encryption cipher context. */

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -63,8 +63,9 @@
 #define N2N_COMPRESSION_ID_ZSTD		3	/* set if '-z2' cli option is present, available only if compiled with zstd lib */
 #define ZSTD_COMPRESSION_LEVEL		7	/* 1 (faster) ... 22 (more compression) */
 
-/* Federation indicator */
-#define FEDERATION_ENABLED     1 
+/* Federation indicators */
+#define IS_FEDERATION        1
+#define IS_NO_FEDERATION     0 
 
 /* (un)purgeable community indicator (supernode) */
 #define COMMUNITY_UNPURGEABLE		0

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -64,8 +64,8 @@
 #define ZSTD_COMPRESSION_LEVEL		7	/* 1 (faster) ... 22 (more compression) */
 
 /* Federation indicators */
-#define IS_FEDERATION        1
-#define IS_NO_FEDERATION     0 
+enum federation{IS_FEDERATION = 1,IS_NO_FEDERATION = 0};
+
 
 /* (un)purgeable community indicator (supernode) */
 #define COMMUNITY_UNPURGEABLE		0

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -63,6 +63,9 @@
 #define N2N_COMPRESSION_ID_ZSTD		3	/* set if '-z2' cli option is present, available only if compiled with zstd lib */
 #define ZSTD_COMPRESSION_LEVEL		7	/* 1 (faster) ... 22 (more compression) */
 
+/* Federation indicator */
+#define FEDERATION_ENABLED     1 
+
 /* (un)purgeable community indicator (supernode) */
 #define COMMUNITY_UNPURGEABLE		0
 #define COMMUNITY_PURGEABLE		1

--- a/src/sn.c
+++ b/src/sn.c
@@ -89,12 +89,9 @@ static int load_allowed_sn_community(n2n_sn_t *sss, char *path) {
       }
     }
 
-    s = (struct sn_community*)calloc(1,sizeof(struct sn_community));
+    comm_init(s,cmn_str);
 
     if(s != NULL) {
-      strncpy((char*)s->community, cmn_str, N2N_COMMUNITY_SIZE-1);
-      s->community[N2N_COMMUNITY_SIZE-1] = '\0';
-      s->is_federation = IS_NO_FEDERATION;
       /* loaded from file, this community is unpurgeable */
       s->purgeable = COMMUNITY_UNPURGEABLE;
       /* we do not know if header encryption is used in this community,

--- a/src/sn.c
+++ b/src/sn.c
@@ -94,6 +94,7 @@ static int load_allowed_sn_community(n2n_sn_t *sss, char *path) {
     if(s != NULL) {
       strncpy((char*)s->community, cmn_str, N2N_COMMUNITY_SIZE-1);
       s->community[N2N_COMMUNITY_SIZE-1] = '\0';
+      s->is_federation = IS_NO_FEDERATION;
       /* loaded from file, this community is unpurgeable */
       s->purgeable = COMMUNITY_UNPURGEABLE;
       /* we do not know if header encryption is used in this community,

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -974,6 +974,7 @@ static int process_udp(n2n_sn_t * sss,
 	if(comm) {
 	  strncpy(comm->community, (char*)cmn.community, N2N_COMMUNITY_SIZE-1);
 	  comm->community[N2N_COMMUNITY_SIZE-1] = '\0';
+	  comm->is_federation = IS_NO_FEDERATION;
 	  /* new communities introduced by REGISTERs could not have had encrypted header... */
 	  comm->header_encryption = HEADER_ENCRYPTION_NONE;
 	  comm->header_encryption_ctx = NULL;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -969,12 +969,9 @@ static int process_udp(n2n_sn_t * sss,
       }
 
       if(!comm && (!sss->lock_communities || (match == 1))) {
-	comm = calloc(1, sizeof(struct sn_community));
+	comm_init(comm,(char *)cmn.community);
 
 	if(comm) {
-	  strncpy(comm->community, (char*)cmn.community, N2N_COMMUNITY_SIZE-1);
-	  comm->community[N2N_COMMUNITY_SIZE-1] = '\0';
-	  comm->is_federation = IS_NO_FEDERATION;
 	  /* new communities introduced by REGISTERs could not have had encrypted header... */
 	  comm->header_encryption = HEADER_ENCRYPTION_NONE;
 	  comm->header_encryption_ctx = NULL;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -204,6 +204,8 @@ static int try_broadcast(n2n_sn_t * sss,
 
 /** Initialise some fields of the community structure **/
 int comm_init(struct sn_community *comm, char* cmn){
+	
+	comm = (struct sn_community*)malloc(sizeof(struct sn_community));
 	memset(comm, 0, sizeof(struct sn_community));
 
 	strncpy((char*)comm->community, cmn, N2N_COMMUNITY_SIZE-1);

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -202,6 +202,16 @@ static int try_broadcast(n2n_sn_t * sss,
   return 0;
 }
 
+/** Initialise some fields of the community structure **/
+int comm_init(struct sn_community *comm, char* cmn){
+	memset(comm, 0, sizeof(struct sn_community));
+
+	strncpy((char*)comm->community, cmn, N2N_COMMUNITY_SIZE-1);
+	comm->community[N2N_COMMUNITY_SIZE-1] = '\0';
+	comm->is_federation = IS_NO_FEDERATION;
+
+	return 0; /* OK */
+}
 
 /** Initialise the supernode structure */
 int sn_init(n2n_sn_t *sss) {


### PR DESCRIPTION
Communities have now a new `is_federation` flag to check if a specific community is the federation of supernodes. 
If `is_supernode == FEDERATION_ENABLED` then the current community is the federation, otherwise it's a regular community.
This pr solves #433.