### PR TITLE
Add new federation flag to community structure

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -358,6 +358,7 @@ typedef struct sn_stats
 struct sn_community
 {
   char community[N2N_COMMUNITY_SIZE];
+  uint8_t             is_federation;          /* if not-zero, then the current community is the federation of supernodes */
   uint8_t             purgeable;              /* indicates purgeable community (fixed-name, predetermined (-c parameter) communties usually are unpurgeable) */
   uint8_t	      header_encryption;      /* Header encryption indicator. */
   he_context_t        *header_encryption_ctx; /* Header encryption cipher context. */
@@ -491,6 +492,7 @@ int quick_edge_init(char *device_name, char *community_name,
 		    char *local_ip_address,
 		    char *supernode_ip_address_port,
 		    int *keep_on_running);
+int comm_init(struct sn_community *comm, char *cmn);
 int sn_init(n2n_sn_t *sss);
 void sn_term(n2n_sn_t *sss);
 int run_sn_loop(n2n_sn_t *sss, int *keep_running);

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -63,6 +63,10 @@
 #define N2N_COMPRESSION_ID_ZSTD		3	/* set if '-z2' cli option is present, available only if compiled with zstd lib */
 #define ZSTD_COMPRESSION_LEVEL		7	/* 1 (faster) ... 22 (more compression) */
 
+/* Federation name and indicators */
+#define FEDERATION_NAME "*Federation"
+enum federation{IS_NO_FEDERATION = 0,IS_FEDERATION = 1};
+
 /* (un)purgeable community indicator (supernode) */
 #define COMMUNITY_UNPURGEABLE		0
 #define COMMUNITY_PURGEABLE		1

--- a/src/sn.c
+++ b/src/sn.c
@@ -45,6 +45,7 @@ static int load_allowed_sn_community(n2n_sn_t *sss, char *path) {
   }
 
   HASH_ITER(hh, sss->communities, s, tmp) {
+    if(s->is_federation) continue;
     HASH_DEL(sss->communities, s);
     if (NULL != s->header_encryption_ctx)
       free (s->header_encryption_ctx);
@@ -89,11 +90,9 @@ static int load_allowed_sn_community(n2n_sn_t *sss, char *path) {
       }
     }
 
-    s = (struct sn_community*)calloc(1,sizeof(struct sn_community));
+    comm_init(s,cmn_str);
 
     if(s != NULL) {
-      strncpy((char*)s->community, cmn_str, N2N_COMMUNITY_SIZE-1);
-      s->community[N2N_COMMUNITY_SIZE-1] = '\0';
       /* loaded from file, this community is unpurgeable */
       s->purgeable = COMMUNITY_UNPURGEABLE;
       /* we do not know if header encryption is used in this community,

--- a/src/sn.c
+++ b/src/sn.c
@@ -90,6 +90,7 @@ static int load_allowed_sn_community(n2n_sn_t *sss, char *path) {
       }
     }
 
+    s = (struct sn_community*)calloc(1,sizeof(struct sn_community));
     comm_init(s,cmn_str);
 
     if(s != NULL) {

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -204,9 +204,6 @@ static int try_broadcast(n2n_sn_t * sss,
 
 /** Initialise some fields of the community structure **/
 int comm_init(struct sn_community *comm, char *cmn){
-	
-	comm = (struct sn_community*)malloc(sizeof(struct sn_community));
-	memset(comm, 0, sizeof(struct sn_community));
 
 	strncpy((char*)comm->community, cmn, N2N_COMMUNITY_SIZE-1);
 	comm->community[N2N_COMMUNITY_SIZE-1] = '\0';
@@ -983,6 +980,7 @@ static int process_udp(n2n_sn_t * sss,
 
       if(!comm && (!sss->lock_communities || (match == 1))) {
 	      
+	comm = (struct sn_community*)calloc(1,sizeof(struct sn_community));
 	comm_init(comm,(char *)cmn.community);
 
 	if(comm) {

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -202,6 +202,19 @@ static int try_broadcast(n2n_sn_t * sss,
   return 0;
 }
 
+/** Initialise some fields of the community structure **/
+int comm_init(struct sn_community *comm, char *cmn){
+	
+	comm = (struct sn_community*)malloc(sizeof(struct sn_community));
+	memset(comm, 0, sizeof(struct sn_community));
+
+	strncpy((char*)comm->community, cmn, N2N_COMMUNITY_SIZE-1);
+	comm->community[N2N_COMMUNITY_SIZE-1] = '\0';
+	comm->is_federation = IS_NO_FEDERATION;
+
+	return 0; /* OK */
+}
+
 
 /** Initialise the supernode structure */
 int sn_init(n2n_sn_t *sss) {
@@ -969,11 +982,10 @@ static int process_udp(n2n_sn_t * sss,
       }
 
       if(!comm && (!sss->lock_communities || (match == 1))) {
-	comm = calloc(1, sizeof(struct sn_community));
+	      
+	comm_init(comm,(char *)cmn.community);
 
 	if(comm) {
-	  strncpy(comm->community, (char*)cmn.community, N2N_COMMUNITY_SIZE-1);
-	  comm->community[N2N_COMMUNITY_SIZE-1] = '\0';
 	  /* new communities introduced by REGISTERs could not have had encrypted header... */
 	  comm->header_encryption = HEADER_ENCRYPTION_NONE;
 	  comm->header_encryption_ctx = NULL;


### PR DESCRIPTION
Communities have now a new `is_federation` flag to check if a specific community is the federation of supernodes. 
If `is_supernode == IS_FEDERATION` the current community is the federation, otherwise it's a regular community. 
When a new community is added to the communities list, some fields of this new community are initialized with `comm_init()` function, that initialize also `is_federation` flag.
This PR solves #433 .