### PR TITLE
Get federation name and supernode's MAC address by command line

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -382,6 +382,7 @@ typedef struct n2n_sn
   time_t start_time; /* Used to measure uptime. */
   sn_stats_t stats;
   int daemon;           /* If non-zero then daemonise. */
+  n2n_mac_t mac_addr;
   uint16_t lport;       /* Local UDP port to bind to. */
   uint16_t mport;       /* Management UDP port to bind to. */
   int sock;             /* Main socket for UDP traffic with edges. */
@@ -395,6 +396,7 @@ typedef struct n2n_sn
   int lock_communities; /* If true, only loaded and matching communities can be used. */
   struct sn_community *communities;
   struct sn_community_regular_expression *rules;
+  char federation[N2N_COMMUNITY_SIZE];
 } n2n_sn_t;
 
 /* ************************************** */

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -234,8 +234,17 @@ int sn_init(n2n_sn_t *sss) {
   sss->max_auto_ip_net.net_addr = inet_addr(N2N_SN_MAX_AUTO_IP_NET_DEFAULT);
   sss->max_auto_ip_net.net_addr = ntohl(sss->max_auto_ip_net.net_addr);
   sss->max_auto_ip_net.net_bitlen = N2N_SN_AUTO_IP_NET_BIT_DEFAULT;
+  strncpy(sss->federation, (char*)FEDERATION_NAME, N2N_COMMUNITY_SIZE-1);
+  sss->federation[N2N_COMMUNITY_SIZE-1] = '\0';
 
   n2n_srand (n2n_seed());
+
+  /* Random MAC address */
+  for(i=0; i<6; i++){
+	sss->mac_addr[i] = n2n_rand();
+  }
+  sss->mac_addr[0] &= ~0x01; /* Clear multicast bit */
+  sss->mac_addr[0] |= 0x02;  /* Set locally-assigned bit */
 
   return 0; /* OK */
 }
@@ -396,6 +405,7 @@ int subnet_available(n2n_sn_t *sss,
 
   HASH_ITER(hh, sss->communities, cmn, tmpCmn) {
     if (cmn == comm) continue;
+    if(cmn->is_federation == IS_FEDERATION) continue;
     if( (net_id <= (cmn->auto_ip_net.net_addr + ~bitlen2mask(cmn->auto_ip_net.net_bitlen)))
       &&(net_id + ~mask >= cmn->auto_ip_net.net_addr) ) {
         success = 0;


### PR DESCRIPTION
I added two new fields to `n2n_sn_t` structure: `mac_addr` and `federation`. These fields are initialized by default in `sn_init()` function:

- `federation` is initialized with `FEDERATION_NAME` value
- `mac_addr` is randomly generated

I created also `add_federation_to_communities()` function to add the federation in the supernode's communities list.
Then, I added two new options to supernode:

- `-F federation_name` provides the federation name
- `-m mac_addr` provides a supernode's MAC address

I managed the two options in `setOption()` function, in their respective `case`s.
This PR solves #435 .