### PR TITLE
Implement purge-and-re-registration process for supernodes

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -467,7 +467,7 @@ int time_stamp_verify_and_update (uint64_t stamp, uint64_t * previous_stamp, int
 size_t purge_peer_list( struct peer_info ** peer_list,
                         time_t purge_before );
 size_t clear_peer_list( struct peer_info ** peer_list );
-size_t purge_expired_registrations( struct peer_info ** peer_list, time_t* p_last_purge );
+size_t purge_expired_registrations( struct peer_info ** peer_list, time_t* p_last_purge, int timeout );
 
 /* Edge conf */
 void edge_init_conf_defaults(n2n_edge_conf_t *conf);

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -40,13 +40,14 @@
 #define SOCKET_TIMEOUT_INTERVAL_SECS    10
 #define REGISTER_SUPER_INTERVAL_DFL     20 /* sec, usually UDP NAT entries in a firewall expire after 30 seconds */
 #define ALLOWED_TIME			20 /* sec, indicates supernodes that are proven to be alive */
-#define TEST_TIME		(SORT_COMMUNITIES_INTERVAL - ALLOWED_TIME)/2 /* sec, indicates supernodes with unsure status, must be tested to check if they are alive */
+#define TEST_TIME		(PURGE_FEDERATION_NODE_INTERVAL - ALLOWED_TIME)/2 /* sec, indicates supernodes with unsure status, must be tested to check if they are alive */
 
 #define IFACE_UPDATE_INTERVAL           (30) /* sec. How long it usually takes to get an IP lease. */
 #define TRANSOP_TICK_INTERVAL           (10) /* sec */
 
 #define PURGE_REGISTRATION_FREQUENCY   30
 #define REGISTRATION_TIMEOUT           60
+#define PURGE_FEDERATION_NODE_INTERVAL 90
 
 #define SORT_COMMUNITIES_INTERVAL      90 /* sec. until supernode sorts communities' hash list again */
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2139,8 +2139,8 @@ int run_edge_loop(n2n_edge_t * eee, int *keep_running) {
     /* Finished processing select data. */
     update_supernode_reg(eee, nowTime);
 
-    numPurged =  purge_expired_registrations(&eee->known_peers, &last_purge_known);
-    numPurged += purge_expired_registrations(&eee->pending_peers, &last_purge_pending);
+    numPurged =  purge_expired_registrations(&eee->known_peers, &last_purge_known, PURGE_REGISTRATION_FREQUENCY);
+    numPurged += purge_expired_registrations(&eee->pending_peers, &last_purge_pending, PURGE_REGISTRATION_FREQUENCY);
 
     if(numPurged > 0) {
       traceEvent(TRACE_INFO, "%u peers removed. now: pending=%u, operational=%u",

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -280,11 +280,11 @@ void print_n2n_version() {
 
 /* *********************************************** */ 
 
-size_t purge_expired_registrations(struct peer_info ** peer_list, time_t* p_last_purge) {
+size_t purge_expired_registrations(struct peer_info ** peer_list, time_t* p_last_purge, int timeout) {
   time_t now = time(NULL);
   size_t num_reg = 0;
 
-  if((now - (*p_last_purge)) < PURGE_REGISTRATION_FREQUENCY) return 0;
+  if((now - (*p_last_purge)) < timeout) return 0;
 
   traceEvent(TRACE_DEBUG, "Purging old registrations");
 


### PR DESCRIPTION
I've added a specific case in `process_udp()` function to handle REGISTER_SUPER_ACK reception. I've used `decode_REGISTER_SUPER_ACK()` and then I've checked if the message carries informations about supernodes in the federation (`ack.num_sn > 0`).

After that, I've created `add_sn_to_federation_from_register_super_ack()`: this function iterates through REGISTER_SUPER_ACK payload and adds missing supernodes to the federation.

Moreover, I've defined another function `re_register_and_purge_supernodes()` because the payload in REGISTER_SUPER_ACK should not directly be trusted to be valid. In fact, a supernode in this list could have gone in the meanwhile, so we have to consider a purge and re-registration strategy in order to mantain the list up-to-date. Basing on `now-last_seen`, we will have 3 different "types" of nodes:
- current: `now-last_seen < ALLOWED_TIME`, it can stay in the list
- unsure: `ALLOWED_TIME < now-last_seen < PURGE_NODE_REGISTRATION_INTERVAL`, its status is unsure, we have to re-register sending a REGISTER_SUPER message (using the existing code in `src/edge_utils.c`)
- too old: `now-last_seen > PURGE_NODE_REGISTRATION_INTERVAL`, these supernodes are too old, must be purged uisng the existing `purge_expired_registrations()` function in `src/n2n.c`

This PR solves #436.