### PR TITLE
AES-NI speed-up

### DIFF
--- a/src/aes.c
+++ b/src/aes.c
@@ -416,7 +416,79 @@ int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
 
   __m128i ivec = _mm_loadu_si128((__m128i*)iv);
 
-  for(n = in_len / 16; n > 1; n -=2) {
+  for(n = in_len / 16; n > 3; n -=4) {
+    __m128i tmp1 = _mm_loadu_si128((__m128i*)in); in += 16;
+    __m128i tmp2 = _mm_loadu_si128((__m128i*)in); in += 16;
+    __m128i tmp3 = _mm_loadu_si128((__m128i*)in); in += 16;
+    __m128i tmp4 = _mm_loadu_si128((__m128i*)in); in += 16;
+
+    __m128i old_in1 = tmp1;
+    __m128i old_in2 = tmp2;
+    __m128i old_in3 = tmp3;
+    __m128i old_in4 = tmp4;
+
+    tmp1 = _mm_xor_si128       (tmp1, ctx->rk_dec[ 0]); tmp2 = _mm_xor_si128       (tmp2, ctx->rk_dec[ 0]);
+    tmp3 = _mm_xor_si128       (tmp3, ctx->rk_dec[ 0]); tmp4 = _mm_xor_si128       (tmp4, ctx->rk_dec[ 0]);
+
+    tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 1]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 1]);
+    tmp3 = _mm_aesdec_si128    (tmp3, ctx->rk_dec[ 1]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[ 1]);
+
+    tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 2]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 2]);
+    tmp3 = _mm_aesdec_si128    (tmp3, ctx->rk_dec[ 2]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[ 2]);
+
+    tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 3]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 3]);
+    tmp3 = _mm_aesdec_si128    (tmp3, ctx->rk_dec[ 3]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[ 3]);
+
+    tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 4]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 4]);
+    tmp3 = _mm_aesdec_si128    (tmp3, ctx->rk_dec[ 4]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[ 4]);
+
+    tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 5]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 5]);
+    tmp3 = _mm_aesdec_si128    (tmp3, ctx->rk_dec[ 5]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[ 5]);
+
+    tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 6]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 6]);
+    tmp3 = _mm_aesdec_si128    (tmp3, ctx->rk_dec[ 6]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[ 6]);
+
+    tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 7]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 7]);
+    tmp3 = _mm_aesdec_si128    (tmp3, ctx->rk_dec[ 7]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[ 7]);
+
+    tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 8]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 8]);
+    tmp3 = _mm_aesdec_si128    (tmp3, ctx->rk_dec[ 8]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[ 8]);
+
+    tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 9]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 9]);
+    tmp3 = _mm_aesdec_si128    (tmp3, ctx->rk_dec[ 9]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[ 9]);
+
+    if(ctx->Nr > 10) {
+      tmp1 = _mm_aesdec_si128  (tmp1, ctx->rk_dec[10]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[10]);
+      tmp3 = _mm_aesdec_si128  (tmp3, ctx->rk_dec[10]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[10]);
+
+      tmp1 = _mm_aesdec_si128  (tmp1, ctx->rk_dec[11]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[11]);
+      tmp3 = _mm_aesdec_si128  (tmp3, ctx->rk_dec[11]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[11]);
+
+      if(ctx->Nr > 12) {
+        tmp1 = _mm_aesdec_si128(tmp1, ctx->rk_dec[12]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[12]);
+        tmp3 = _mm_aesdec_si128(tmp3, ctx->rk_dec[12]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[12]);
+
+        tmp1 = _mm_aesdec_si128(tmp1, ctx->rk_dec[13]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[13]);
+        tmp3 = _mm_aesdec_si128(tmp3, ctx->rk_dec[13]); tmp4 = _mm_aesdec_si128    (tmp4, ctx->rk_dec[13]);
+      }
+    }
+    tmp1 = _mm_aesdeclast_si128(tmp1, ctx->rk_enc[ 0]); tmp2 = _mm_aesdeclast_si128(tmp2, ctx->rk_enc[ 0]);
+    tmp3 = _mm_aesdeclast_si128(tmp3, ctx->rk_enc[ 0]); tmp4 = _mm_aesdeclast_si128(tmp4, ctx->rk_enc[ 0]);
+
+    tmp1 = _mm_xor_si128 (tmp1, ivec); tmp2 = _mm_xor_si128 (tmp2, old_in1);
+    tmp3 = _mm_xor_si128 (tmp3, old_in2); tmp4 = _mm_xor_si128 (tmp4, old_in3);
+
+    ivec = old_in4;
+
+    _mm_storeu_si128((__m128i*) out, tmp1); out += 16;
+    _mm_storeu_si128((__m128i*) out, tmp2); out += 16;
+    _mm_storeu_si128((__m128i*) out, tmp3); out += 16;
+    _mm_storeu_si128((__m128i*) out, tmp4); out += 16;
+  } // now: less than 4 blocks remaining
+
+  if(n > 1) { // 2 or 3 blocks remaining --> this code handles two of them
+    n-= 2;
+
     __m128i tmp1 = _mm_loadu_si128((__m128i*)in); in += 16;
     __m128i tmp2 = _mm_loadu_si128((__m128i*)in); in += 16;
 
@@ -433,7 +505,6 @@ int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
     tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 7]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 7]);
     tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 8]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 8]);
     tmp1 = _mm_aesdec_si128    (tmp1, ctx->rk_dec[ 9]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[ 9]);
-
     if(ctx->Nr > 10) {
       tmp1 = _mm_aesdec_si128  (tmp1, ctx->rk_dec[10]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[10]);
       tmp1 = _mm_aesdec_si128  (tmp1, ctx->rk_dec[11]); tmp2 = _mm_aesdec_si128    (tmp2, ctx->rk_dec[11]);
@@ -452,7 +523,7 @@ int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
     _mm_storeu_si128((__m128i*) out, tmp2); out += 16;
   }
 
-  if(n) {
+  if(n) { // one block remaining
     __m128i tmp = _mm_loadu_si128((__m128i*)in);
     __m128i old_in = tmp;
 


### PR DESCRIPTION
This pull request speeds-up **AES-NI** (x86 hardware accelerated AES) implementation in the following ways:

- CBC encryption is kept as much as possible in SSE code leading to an encryption speed-up in the one-percent-range (… already a few MB/s!)
- CBC decryption also is kept as much as possible in SSE and was parallelized resulting in the clearly-above-ten-percent-range (… a few more MB/s!)

Check your personal speed-up using `tools/benchmark` and especially `tools/benchmark -d` (combined encryption and decryption).

_P. S._ I found that we do not have a tool to measure decryption speed only… that might be worth an addition to the benchmark tool. Some other day… perhaps.