### PR TITLE
enabled gratuitous arp packets

### DIFF
--- a/src/edge.c
+++ b/src/edge.c
@@ -647,59 +647,6 @@ static int loadFromFile(const char *path, n2n_edge_conf_t *conf, n2n_tuntap_priv
 
 /* ************************************** */
 
-#if defined(DUMMY_ID_00001) /* Disabled waiting for config option to enable it */
-
-static char gratuitous_arp[] = {
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, /* Dest mac */
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Src mac */
-				0x08, 0x06, /* ARP */
-				0x00, 0x01, /* Ethernet */
-				0x08, 0x00, /* IP */
-				0x06, /* Hw Size */
-				0x04, /* Protocol Size */
-				0x00, 0x01, /* ARP Request */
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Src mac */
-				0x00, 0x00, 0x00, 0x00, /* Src IP */
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Target mac */
-				0x00, 0x00, 0x00, 0x00 /* Target IP */
-};
-
-/* ************************************** */
-
-/** Build a gratuitous ARP packet for a /24 layer 3 (IP) network. */
-static int build_gratuitous_arp(char *buffer, uint16_t buffer_len) {
-  if(buffer_len < sizeof(gratuitous_arp)) return(-1);
-
-  memcpy(buffer, gratuitous_arp, sizeof(gratuitous_arp));
-  memcpy(&buffer[6], device.mac_addr, 6);
-  memcpy(&buffer[22], device.mac_addr, 6);
-  memcpy(&buffer[28], &device.ip_addr, 4);
-
-  /* REVISIT: BbMaj7 - use a real netmask here. This is valid only by accident
-   * for /24 IPv4 networks. */
-  buffer[31] = 0xFF; /* Use a faked broadcast address */
-  memcpy(&buffer[38], &device.ip_addr, 4);
-  return(sizeof(gratuitous_arp));
-}
-
-/* ************************************** */
-
-/** Called from update_supernode_reg to periodically send gratuitous ARP
- *  broadcasts. */
-static void send_grat_arps(n2n_edge_t * eee,) {
-  char buffer[48];
-  size_t len;
-
-  traceEvent(TRACE_NORMAL, "Sending gratuitous ARP...");
-  len = build_gratuitous_arp(buffer, sizeof(buffer));
-  send_packet2net(eee, buffer, len);
-  send_packet2net(eee, buffer, len); /* Two is better than one :-) */
-}
-
-#endif /* #if defined(DUMMY_ID_00001) */
-
-/* ************************************** */
-
 static void daemonize() {
 #ifndef WIN32
   int childpid;

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -850,6 +850,49 @@ static void send_register_ack(n2n_edge_t * eee,
 
 /* ************************************** */
 
+static char gratuitous_arp[] = {
+  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, /* dest MAC */
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* src MAC */
+  0x08, 0x06, /* ARP */
+  0x00, 0x01, /* ethernet */
+  0x08, 0x00, /* IP */
+  0x06, /* hw Size */
+  0x04, /* protocol Size */
+  0x00, 0x02, /* ARP reply */
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* src MAC */
+  0x00, 0x00, 0x00, 0x00, /* src IP */
+  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, /* target MAC */
+  0x00, 0x00, 0x00, 0x00 /* target IP */
+};
+
+// build a gratuitous ARP packet */
+static int build_gratuitous_arp(n2n_edge_t * eee, char *buffer, uint16_t buffer_len) {
+  if(buffer_len < sizeof(gratuitous_arp)) return(-1);
+
+  memcpy(buffer, gratuitous_arp, sizeof(gratuitous_arp));
+  memcpy(&buffer[6], eee->device.mac_addr, 6);
+  memcpy(&buffer[22], eee->device.mac_addr, 6);
+  memcpy(&buffer[28], &(eee->device.ip_addr), 4);
+
+  memcpy(&buffer[38], &(eee->device.ip_addr), 4);
+  return(sizeof(gratuitous_arp));
+}
+
+/** Called from update_supernode_reg to periodically send gratuitous ARP
+ *  broadcasts. */
+static void send_grat_arps(n2n_edge_t * eee) {
+  char buffer[48];
+  size_t len;
+
+  traceEvent(TRACE_DEBUG, "Sending gratuitous ARP...");
+  len = build_gratuitous_arp(eee, buffer, sizeof(buffer));
+
+  edge_send_packet2net(eee, buffer, len);
+  edge_send_packet2net(eee, buffer, len); /* Two is better than one :-) */
+}
+
+/* ************************************** */
+
 /** @brief Check to see if we should re-register with the supernode.
  *
  *  This is frequently called by the main loop.
@@ -907,8 +950,7 @@ void update_supernode_reg(n2n_edge_t * eee, time_t nowTime) {
 
   eee->sn_wait=1;
 
-  /* REVISIT: turn-on gratuitous ARP with config option. */
-  /* send_grat_arps(sock_fd, is_udp_sock); */
+  send_grat_arps(eee);
 
   eee->last_register_req = nowTime;
 }


### PR DESCRIPTION
This pull request fixes and enables the code for sending gratuitous ARP packets. Those are required to immediately announce eventually changed MAC addresses throughout the network.

Also, the supernode better handles changed MAC addresses by not creating a new entry but using the old one if not purged yet.

MAC addresses are assigned randomly if not assigned at start-up (`-m`). In case of a quickly performed edge restart, the remaining edges have not had the new MAC-IP address relation in their ARP tables yet, thus the gratuitous ARP packet.

Plans for future extension are to send gratuitous ARP packets only if required (the supernode can detect and inform the edge via REGISTER_SUPER_ACK) whereas the current version sends them along with every REGISTER_SUPER.