### PR TITLE
Extra Device Description in P2P Connection and Register to Super Node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 2.6)
 include(CheckFunctionExists)
 SET(CMAKE_VERBOSE_MAKEFILE ON)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # N2n release information
 set(N2N_VERSION "2.9.0")
 set(N2N_OSNAME ${CMAKE_SYSTEM})

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -197,6 +197,7 @@ typedef char n2n_sn_name_t[N2N_EDGE_SN_HOST_SIZE];
 struct peer_info {
   n2n_mac_t        mac_addr;
   n2n_ip_subnet_t  dev_addr;
+  n2n_desc_t       dev_desc;
   n2n_sock_t       sock;
   int              timeout;
   uint8_t          purgeable;
@@ -273,6 +274,7 @@ typedef struct n2n_edge_conf {
   n2n_sn_name_t       sn_ip_array[N2N_EDGE_NUM_SUPERNODES];
   n2n_route_t         *routes;                /**< Networks to route through n2n */
   n2n_community_t     community_name;         /**< The community. 16 full octets. */
+  n2n_desc_t          dev_desc;               /**< The device description (hint) */
   uint8_t	            header_encryption;      /**< Header encryption indicator. */
   he_context_t        *header_encryption_ctx; /**< Header encryption cipher context. */
   he_context_t        *header_iv_ctx;         /**< Header IV ecnryption cipher context, REMOVE as soon as seperte fileds for checksum and replay protection available */

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -30,6 +30,7 @@
 #define N2N_COMMUNITY_SIZE              16
 #define N2N_MAC_SIZE                    6
 #define N2N_COOKIE_SIZE                 4
+#define N2N_DESC_SIZE                   16
 #define N2N_PKT_BUF_SIZE                2048
 #define N2N_SOCKBUF_SIZE                64      /* string representation of INET or INET6 sockets */
 
@@ -39,6 +40,8 @@
 typedef uint8_t n2n_community_t[N2N_COMMUNITY_SIZE];
 typedef uint8_t n2n_mac_t[N2N_MAC_SIZE];
 typedef uint8_t n2n_cookie_t[N2N_COOKIE_SIZE];
+
+typedef uint8_t n2n_desc_t[N2N_DESC_SIZE];
 
 typedef char    n2n_sock_str_t[N2N_SOCKBUF_SIZE];       /* tracing string buffer */
 
@@ -149,6 +152,7 @@ typedef struct n2n_PACKET
 typedef struct n2n_REGISTER_SUPER {
   n2n_cookie_t        cookie;         /**< Link REGISTER_SUPER and REGISTER_SUPER_ACK */
   n2n_mac_t           edgeMac;        /**< MAC to register with edge sending socket */
+  n2n_desc_t          dev_desc;       /**< Hint description correlated with the edge */
   n2n_ip_subnet_t     dev_addr;       /**< IP address of the tuntap adapter. */
   n2n_auth_t          auth;           /**< Authentication scheme and tokens */
 } n2n_REGISTER_SUPER_t;

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -129,6 +129,7 @@ typedef struct n2n_REGISTER
   n2n_mac_t            dstMac;         /**< MAC of target edge */
   n2n_sock_t           sock;           /**< REVISIT: unused? */
   n2n_ip_subnet_t      dev_addr;       /**< IP address of the tuntap adapter. */
+  n2n_desc_t           dev_desc;       /**< Hint description correlated with the edge */
 } n2n_REGISTER_t;
 
 typedef struct n2n_REGISTER_ACK
@@ -152,8 +153,8 @@ typedef struct n2n_PACKET
 typedef struct n2n_REGISTER_SUPER {
   n2n_cookie_t        cookie;         /**< Link REGISTER_SUPER and REGISTER_SUPER_ACK */
   n2n_mac_t           edgeMac;        /**< MAC to register with edge sending socket */
-  n2n_desc_t          dev_desc;       /**< Hint description correlated with the edge */
   n2n_ip_subnet_t     dev_addr;       /**< IP address of the tuntap adapter. */
+  n2n_desc_t          dev_desc;       /**< Hint description correlated with the edge */
   n2n_auth_t          auth;           /**< Authentication scheme and tokens */
 } n2n_REGISTER_SUPER_t;
 

--- a/src/edge.c
+++ b/src/edge.c
@@ -154,6 +154,7 @@ static void help() {
   printf("-k <encrypt key>         | Encryption key (ASCII) - also N2N_KEY=<encrypt key>.\n");
   printf("-l <supernode host:port> | Supernode IP:port\n");
   printf("-i <reg_interval>        | Registration interval, for NAT hole punching (default 20 seconds)\n");
+  printf("-I <device description>  | Annotate the edge's description (hint), identified in the manage port\n");
   printf("-L <reg_ttl>             | TTL for registration packet when UDP NAT hole punching through supernode (default 0 for not set )\n");
   printf("-p <local port>          | Fixed local UDP port.\n");
 #ifndef WIN32

--- a/src/edge.c
+++ b/src/edge.c
@@ -422,6 +422,14 @@ static int setOption(int optkey, char *optargument, n2n_tuntap_priv_config_t *ec
     }
 #endif
 
+  case 'I': /* Device Description (hint) */
+    {
+      memset(conf->dev_desc, 0, N2N_DESC_SIZE);
+      /* reserve possible last char as null terminator. */
+      strncpy((char *)conf->dev_desc, optargument, N2N_DESC_SIZE-1);
+      break;
+    }
+
   case 'p':
     {
       conf->local_port = atoi(optargument);
@@ -530,7 +538,7 @@ static int loadFromCLI(int argc, char *argv[], n2n_edge_conf_t *conf, n2n_tuntap
   u_char c;
 
   while ((c = getopt_long(argc, argv,
-                          "k:a:bc:Eu:g:m:M:s:d:l:p:fvhrt:i:SDL:z::A::Hn:"
+                          "k:a:bc:Eu:g:m:M:s:d:l:p:fvhrt:i:I:SDL:z::A::Hn:"
 #ifdef __linux__
                           "T:"
 #endif

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -792,6 +792,7 @@ static void send_register(n2n_edge_t * eee,
   }
   reg.dev_addr.net_addr = ntohl(eee->device.ip_addr);
   reg.dev_addr.net_bitlen = mask2bitlen(ntohl(eee->device.device_mask));
+  memcpy(reg.dev_desc, eee->conf.dev_desc, N2N_DESC_SIZE);
 
 
   idx=0;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -339,6 +339,7 @@ static int update_edge(n2n_sn_t *sss,
     memcpy(&(scan->mac_addr), reg->edgeMac, sizeof(n2n_mac_t));
     scan->dev_addr.net_addr = reg->dev_addr.net_addr;
     scan->dev_addr.net_bitlen = reg->dev_addr.net_bitlen;
+    memcpy((char*)scan->dev_desc, reg->dev_desc, N2N_DESC_SIZE);
     memcpy(&(scan->sock), sender_sock, sizeof(n2n_sock_t));
     scan->last_valid_time_stamp = initial_time_stamp();
 
@@ -647,9 +648,9 @@ static int process_mgmt(n2n_sn_t *sss,
   traceEvent(TRACE_DEBUG, "process_mgmt");
 
   ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
-		      "    id    tun_tap             MAC                edge                   last_seen\n");
+		      "    id    tun_tap             MAC                edge                   hint             last_seen\n");
   ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
-		      "---------------------------------------------------------------------------------\n");
+		      "-------------------------------------------------------------------------------------------------\n");
   HASH_ITER(hh, sss->communities, community, tmp) {
     num_edges += HASH_COUNT(community->edges);
     ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
@@ -660,17 +661,19 @@ static int process_mgmt(n2n_sn_t *sss,
     num = 0;
     HASH_ITER(hh, community->edges, peer, tmpPeer) {
       ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
-			  "    %-4u  %-18s  %-17s  %-21s  %lu\n",
+			  "    %-4u  %-18s  %-17s  %-21s  %-15s  %lu\n",
 			  ++num, ip_subnet_to_str(ip_bit_str, &peer->dev_addr),
 			  macaddr_str(mac_buf, peer->mac_addr),
-			  sock_to_cstr(sockbuf, &(peer->sock)), now - peer->last_seen);
+			  sock_to_cstr(sockbuf, &(peer->sock)),
+        peer->dev_desc,
+        now - peer->last_seen);
 
       sendto_mgmt(sss, sender_sock, (const uint8_t *) resbuf, ressize);
       ressize = 0;
     }
   }
   ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
-		      "---------------------------------------------------------------------------------\n");
+		      "-------------------------------------------------------------------------------------------------\n");
 
   ressize += snprintf(resbuf + ressize, N2N_SN_PKTBUF_SIZE - ressize,
 		      "uptime %lu | ", (now - sss->start_time));

--- a/src/wire.c
+++ b/src/wire.c
@@ -322,6 +322,7 @@ int encode_REGISTER_SUPER(uint8_t *base,
   retval += encode_common(base, idx, common);
   retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
   retval += encode_mac(base, idx, reg->edgeMac);
+  retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
   retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
   retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
   retval += encode_uint16(base, idx, 0); /* NULL auth scheme */
@@ -340,6 +341,7 @@ int decode_REGISTER_SUPER(n2n_REGISTER_SUPER_t *reg,
   memset(reg, 0, sizeof(n2n_REGISTER_SUPER_t));
   retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
   retval += decode_mac(reg->edgeMac, base, rem, idx);
+  retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);
   retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
   retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
   retval += decode_uint16(&(reg->auth.scheme), base, rem, idx);

--- a/src/wire.c
+++ b/src/wire.c
@@ -288,6 +288,7 @@ int encode_REGISTER(uint8_t *base,
   }
   retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
   retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
+  retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
 
   return retval;
 }
@@ -309,6 +310,7 @@ int decode_REGISTER(n2n_REGISTER_t *reg,
   }
   retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
   retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
+  retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);
 
   return retval;
 }
@@ -322,9 +324,9 @@ int encode_REGISTER_SUPER(uint8_t *base,
   retval += encode_common(base, idx, common);
   retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
   retval += encode_mac(base, idx, reg->edgeMac);
-  retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
   retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
   retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
+  retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
   retval += encode_uint16(base, idx, 0); /* NULL auth scheme */
   retval += encode_uint16(base, idx, 0); /* No auth data */
 
@@ -341,9 +343,9 @@ int decode_REGISTER_SUPER(n2n_REGISTER_SUPER_t *reg,
   memset(reg, 0, sizeof(n2n_REGISTER_SUPER_t));
   retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
   retval += decode_mac(reg->edgeMac, base, rem, idx);
-  retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);
   retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
   retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
+  retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);
   retval += decode_uint16(&(reg->auth.scheme), base, rem, idx);
   retval += decode_uint16(&(reg->auth.toksize), base, rem, idx);
   retval += decode_buf(reg->auth.token, reg->auth.toksize, base, rem, idx);


### PR DESCRIPTION
According to the discussion in #473, I have added the extra description field (named `dev_desc` in source code) and tested some simple case by myself. There are three points worth noting generally:

### 1. Command Parser

I added the extra command line parser: `-I` in the edge option parser, which refers to the `community_name` field parsing and checking logic. The `dev_desc` is added into the `conf` struct like `community_name` and generated by the **machine hostname** by default, non-over the max-length 16 or will be truncated. Users can set another server name (aka description, hint) for whatever they want with the `-I {server name}` option.

### 2. Edge Node Register into Super Node

- Both the supernode source and edge files are changed via the struct: `n2n_REGISTER_SUPER`. Add an extra `dev_desc` field in the struct and the corresponding struct encoder and decoder in `src/wire/c`.
- Change the exposing field via super node's manage port, show the extra device name in the details table.

### 3. Edge Node Register into Edge Node

- As section 2 indicates, peer to peer connection is via the struct: `n2n_REGISTER`.
- Show the extra device name in the details table from the edge node's manage port.

Some questions:

the two functions: `register_with_new_peer` and `check_peer_registration_needed` in `edge_util.c` are passing a lot of edge node's parameters recursively. And why not pack it into the `n2n_REGISTER` struct to make it more elegant, currently, I have to add an extra parameter: `dev_desc` in these functions. I have watched the `n2n_REGISTER` has an **unused** filed: `sock` coincidently, to be honest, I think it's better to unify the two process logics.

```
typedef struct n2n_REGISTER
{
  n2n_cookie_t         cookie;         /**< Link REGISTER and REGISTER_ACK */
  n2n_mac_t            srcMac;         /**< MAC of registering party */
  n2n_mac_t            dstMac;         /**< MAC of target edge */
  n2n_sock_t           sock;           /**< REVISIT: unused? */
  n2n_ip_subnet_t      dev_addr;       /**< IP address of the tuntap adapter. */
  n2n_desc_t           dev_desc;       /**< Hint description correlated with the edge */
} n2n_REGISTER_t;
```

Welcome to review.



