### PR TITLE
Update REGISTER_SUPER_ACK handling on edge

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -30,24 +30,28 @@
 #define MSG_TYPE_MAX_TYPE	       10
 
 /* Max available space to add supernodes' informations (sockets and MACs) in REGISTER_SUPER_ACK
- * Field sizes of REGISTER_SUPER_ACK as used in encode/decode fucntions in src/wire.c */
+ * Field sizes of REGISTER_SUPER_ACK as used in encode/decode fucntions in src/wire.c
+ * REVISIT: replace 255 by DEFAULT_MTU as soon as header encryption allows for longer packets to be encrypted. */
 #define MAX_AVAILABLE_SPACE_FOR_ENTRIES \
-	DEFAULT_MTU-(1+1+2+sizeof(n2n_common_t)+sizeof(n2n_cookie_t)+sizeof(n2n_mac_t)+1+2+4+1+sizeof(n2n_sock_t)+1) \
+	(255-(1+1+2+sizeof(n2n_common_t)+sizeof(n2n_cookie_t)+sizeof(n2n_mac_t)+1+2+4+1+sizeof(n2n_sock_t)+1)) \
 
 /* Space needed to store socket and MAC address of a supernode */
-#define ENTRY_SIZE		sizeof(n2n_sock_t)+sizeof(n2n_mac_t)
+#define ENTRY_SIZE		(sizeof(n2n_sock_t)+sizeof(n2n_mac_t))
+
+#define PURGE_REGISTRATION_FREQUENCY   30
+#define RE_REG_AND_PURGE_FREQUENCY     10
+#define REGISTRATION_TIMEOUT           60
+#define PURGE_FEDERATION_NODE_INTERVAL 90
 
 #define SOCKET_TIMEOUT_INTERVAL_SECS    10
 #define REGISTER_SUPER_INTERVAL_DFL     20 /* sec, usually UDP NAT entries in a firewall expire after 30 seconds */
 #define ALLOWED_TIME			20 /* sec, indicates supernodes that are proven to be alive */
 #define TEST_TIME		(PURGE_FEDERATION_NODE_INTERVAL - ALLOWED_TIME)/2 /* sec, indicates supernodes with unsure status, must be tested to check if they are alive */
+#define MAX_PING_TIME    3000  /* millisec, indicates default value for ping_time field in peer_info structure */
+#define SWEEP_TIME       30 /* sec, indicates the value after which we have to sort the hash list of supernodes in edges */
 
 #define IFACE_UPDATE_INTERVAL           (30) /* sec. How long it usually takes to get an IP lease. */
 #define TRANSOP_TICK_INTERVAL           (10) /* sec */
-
-#define PURGE_REGISTRATION_FREQUENCY   30
-#define REGISTRATION_TIMEOUT           60
-#define PURGE_FEDERATION_NODE_INTERVAL 90
 
 #define SORT_COMMUNITIES_INTERVAL      90 /* sec. until supernode sorts communities' hash list again */
 
@@ -83,7 +87,7 @@ enum federation{IS_NO_FEDERATION = 0,IS_FEDERATION = 1};
 #define COMMUNITY_PURGEABLE		1
 
 /* (un)purgeable supernode indicator */
-enum sn_purge{SN_UNPURGEABLE = 0, SN_PURGEABLE = 1};
+enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 
 /* Header encryption indicators */
 #define HEADER_ENCRYPTION_UNKNOWN       0
@@ -102,6 +106,9 @@ enum sn_purge{SN_UNPURGEABLE = 0, SN_PURGEABLE = 1};
 #define N2N_PATHNAME_MAXLEN     256
 #define N2N_EDGE_MGMT_PORT      5644
 #define N2N_SN_MGMT_PORT        5645
+
+/* flag used in add_sn_to_list_by_mac_or_sock */
+enum skip_add{NO_SKIP = 0, SKIP = 1, ADDED = 2};
 
 #define N2N_NETMASK_STR_SIZE    16 /* dotted decimal 12 numbers + 3 dots */
 #define N2N_MACNAMSIZ           18 /* AA:BB:CC:DD:EE:FF + NULL*/

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -181,6 +181,7 @@ typedef struct n2n_REGISTER_SUPER_NAK
 
 typedef struct n2n_PEER_INFO {
   uint16_t             aflags;
+  n2n_mac_t            srcMac;
   n2n_mac_t            mac;
   n2n_sock_t           sock;
 } n2n_PEER_INFO_t;
@@ -190,6 +191,7 @@ typedef struct n2n_QUERY_PEER
 {
   n2n_mac_t           srcMac;
   n2n_mac_t           targetMac;
+  uint8_t             req_data; /* data we want the supernode to send back in the answer's payload (e.g. 0 = no payload, 1 = number of connected nodes ...) */
 } n2n_QUERY_PEER_t;
 
 typedef struct n2n_buf n2n_buf_t;

--- a/src/edge.c
+++ b/src/edge.c
@@ -171,9 +171,11 @@ static void help() {
          "                         | causes connections stall when not properly supported.\n");
 #endif
   printf("-r                       | Enable packet forwarding through n2n community.\n");
-  printf("-A1                      | Disable payload encryption. Do not use with key (defaulting to AES then).\n");
-  printf("-A2 ... -A5 or -A        | Choose a cipher for payload encryption, requires a key: -A2 = Twofish,\n");
-  printf("                         | -A3 or -A (deprecated) = AES (default), -A4 = ChaCha20, -A5 = Speck-CTR.\n");
+  printf("-A1                      | Disable payload encryption. Do not use with key (defaulting to Twofish then).\n");
+  printf("-A2 ... -A5 or -A        | Choose a cipher for payload encryption, requires a key: -A2 = Twofish (default),\n");
+  printf("                         | -A3 or -A (deprecated) = AES, "
+  "-A4 = ChaCha20, "
+  "-A5 = Speck-CTR.\n");
   printf("-H                       | Enable full header encryption. Requires supernode with fixed community.\n");
   printf("-z1 ... -z2 or -z        | Enable compression for outgoing data packets: -z1 or -z = lzo1x"
 #ifdef N2N_HAVE_ZSTD
@@ -386,7 +388,7 @@ static int setOption(int optkey, char *optargument, n2n_tuntap_priv_config_t *ec
   case 'z':
     {
       int compression;
-      
+
       if (optargument) {
         compression = atoi(optargument);
       } else
@@ -425,6 +427,12 @@ static int setOption(int optkey, char *optargument, n2n_tuntap_priv_config_t *ec
   case 'p':
     {
       conf->local_port = atoi(optargument);
+
+			if(conf->local_port == 0){
+	      traceEvent(TRACE_WARNING, "Bad local port format");
+	      break;
+	    }
+
       break;
     }
 
@@ -607,7 +615,7 @@ static int loadFromFile(const char *path, n2n_edge_conf_t *conf, n2n_tuntap_priv
       }
     } else if(line[0] == '-') { /* short opt */
       char *equal;
-      
+
       key = &line[1], line_len--;
 
       equal = strchr(line, '=');
@@ -826,9 +834,9 @@ int main(int argc, char* argv[]) {
 
   if(conf.transop_id == N2N_TRANSFORM_ID_NULL) {
     if(conf.encrypt_key) {
-      /* make sure that AES is default cipher if key only (and no cipher) is specified */
-      traceEvent(TRACE_WARNING, "Switching to AES as key was provided.");
-      conf.transop_id = N2N_TRANSFORM_ID_AES;
+      /* make sure that Twofish is default cipher if key only (and no cipher) is specified */
+      traceEvent(TRACE_WARNING, "Switching to Twofish as key was provided.");
+      conf.transop_id = N2N_TRANSFORM_ID_TWOFISH;
     }
   }
 
@@ -843,7 +851,7 @@ int main(int argc, char* argv[]) {
 #if defined(HAVE_OPENSSL_1_1)
   traceEvent(TRACE_NORMAL, "Using %s", OpenSSL_version(0));
 #endif
-  
+
   traceEvent(TRACE_NORMAL, "Using compression: %s.", compression_str(conf.compression));
   traceEvent(TRACE_NORMAL, "Using %s cipher.", transop_str(conf.transop_id));
 
@@ -853,7 +861,7 @@ int main(int argc, char* argv[]) {
 #ifndef WIN32
   /* If running suid root then we need to setuid before using the force. */
   if(setuid(0) != 0)
-    traceEvent(TRACE_ERROR, "Unable to become root [%u/%s]", errno, strerror(errno)); 
+    traceEvent(TRACE_ERROR, "Unable to become root [%u/%s]", errno, strerror(errno));
   /* setgid(0); */
 #endif
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -61,6 +61,9 @@ int edge_verify_conf(const n2n_edge_conf_t *conf) {
      ((conf->encrypt_key != NULL) && (conf->transop_id == N2N_TRANSFORM_ID_NULL)))
     return(-4);
 
+  if(HASH_COUNT(conf->supernodes) == 0)
+    return(-5);
+
   return(0);
 }
 
@@ -171,7 +174,8 @@ static int is_ip6_discovery(const void * buf, size_t bufsize) {
 n2n_edge_t* edge_init(const n2n_edge_conf_t *conf, int *rv) {
   n2n_transform_t transop_id = conf->transop_id;
   n2n_edge_t *eee = calloc(1, sizeof(n2n_edge_t));
-  int rc = -1, i;
+  int rc = -1, i = 0;
+  struct peer_info *scan, *tmp;
 
   if((rc = edge_verify_conf(conf)) != 0) {
     traceEvent(TRACE_ERROR, "Invalid configuration");
@@ -188,6 +192,8 @@ n2n_edge_t* edge_init(const n2n_edge_conf_t *conf, int *rv) {
 #endif
 
   memcpy(&eee->conf, conf, sizeof(*conf));
+  eee->curr_sn = eee->conf.supernodes;
+  //memcpy(&eee->supernode, &(eee->curr_sn->sock), sizeof(n2n_sock_t));
   eee->start_time = time(NULL);
 
   eee->known_peers    = NULL;
@@ -206,11 +212,11 @@ n2n_edge_t* edge_init(const n2n_edge_conf_t *conf, int *rv) {
   // zstd does not require initialization. if it were required, this would be a good place
 #endif
 
-  for(i=0; i<eee->conf.sn_num; ++i)
-    traceEvent(TRACE_NORMAL, "supernode %u => %s\n", i, (eee->conf.sn_ip_array[i]));
-
-  /* Set the active supernode */
-  supernode2sock(&(eee->supernode), eee->conf.sn_ip_array[eee->sn_idx]);
+  traceEvent(TRACE_NORMAL, "Number of supernodes in the list: %d\n", HASH_COUNT(eee->conf.supernodes));
+  HASH_ITER(hh, eee->conf.supernodes, scan, tmp){
+    traceEvent(TRACE_NORMAL, "supernode %u => %s\n", i, (scan->ip_addr));
+    i++;
+  }
 
   /* Set active transop */
   switch(transop_id) {
@@ -678,8 +684,73 @@ static void check_join_multicast_group(n2n_edge_t *eee) {
 
 /* ************************************** */
 
+/** Send a QUERY_PEER packet to the current supernode. */
+static void send_query_peer( n2n_edge_t * eee,
+                             const n2n_mac_t dstMac) {
+  uint8_t pktbuf[N2N_PKT_BUF_SIZE];
+  size_t idx;
+  n2n_common_t cmn = {0};
+  n2n_QUERY_PEER_t query = {{0}};
+  struct peer_info *peer, *tmp;
+  uint8_t tmp_pkt[N2N_PKT_BUF_SIZE];
+
+  cmn.ttl=N2N_DEFAULT_TTL;
+  cmn.pc = n2n_query_peer;
+  cmn.flags = 0;
+  memcpy( cmn.community, eee->conf.community_name, N2N_COMMUNITY_SIZE );
+
+  idx=0;
+  encode_mac( query.srcMac, &idx, eee->device.mac_addr );
+
+  idx=0;
+  encode_mac( query.targetMac, &idx, dstMac );
+  query.req_data = 0;
+
+  idx=0;
+
+  encode_QUERY_PEER( pktbuf, &idx, &cmn, &query );
+
+  if(memcmp(dstMac, null_mac, sizeof(n2n_mac_t)) != 0){
+
+    traceEvent( TRACE_DEBUG, "send QUERY_PEER to supernode" );
+
+    if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED){
+      packet_header_encrypt (pktbuf, idx, eee->conf.header_encryption_ctx,
+  			   eee->conf.header_iv_ctx,
+  			   time_stamp (), pearson_hash_16 (pktbuf, idx));
+    }
+
+    sendto_sock( eee->udp_sock, pktbuf, idx, &(eee->supernode) );
+
+  } else {
+    traceEvent( TRACE_DEBUG, "send PING to supernodes" );
+
+    memcpy(tmp_pkt, pktbuf, idx);
+
+    HASH_ITER(hh, eee->conf.supernodes, peer, tmp){
+      if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED){
+        /* Re-encrypt the orginal message again for non-repeating IV. */
+        memcpy(pktbuf, tmp_pkt, idx);
+        packet_header_encrypt (pktbuf, idx, eee->conf.header_encryption_ctx,
+    			   eee->conf.header_iv_ctx,
+    			   time_stamp (), pearson_hash_16 (pktbuf, idx));
+      }
+      sendto_sock( eee->udp_sock, pktbuf, idx, &(peer->sock));
+    }
+  }
+}
+
+/* ******************************************************** */
+
+static int ping_time_sort(struct peer_info *a, struct peer_info *b){
+  // comparison function for sorting supernodes in ascending order of their
+  // ping_time-fields
+  return (a->ping_time - b->ping_time);
+}
+
+
 /** Send a REGISTER_SUPER packet to the current supernode. */
-static void send_register_super(n2n_edge_t *eee, const n2n_sock_t *supernode, int sn_idx) {
+static void send_register_super(n2n_edge_t *eee) {
   uint8_t pktbuf[N2N_PKT_BUF_SIZE] = {0};
   size_t idx;
   /* ssize_t sent; */
@@ -695,10 +766,10 @@ static void send_register_super(n2n_edge_t *eee, const n2n_sock_t *supernode, in
   cmn.flags = 0;
   memcpy(cmn.community, eee->conf.community_name, N2N_COMMUNITY_SIZE);
 
-  for (idx = 0; (sn_idx==0) && (idx < N2N_COOKIE_SIZE); ++idx)
-    eee->last_cookie[idx] = n2n_rand() % 0xff;
+  for (idx = 0; idx < N2N_COOKIE_SIZE; ++idx)
+    eee->curr_sn->last_cookie[idx] = n2n_rand() % 0xff;
 
-  memcpy(reg.cookie, eee->last_cookie, N2N_COOKIE_SIZE);
+  memcpy(reg.cookie, eee->curr_sn->last_cookie, N2N_COOKIE_SIZE);
   reg.dev_addr.net_addr = ntohl(eee->device.ip_addr);
   reg.dev_addr.net_bitlen = mask2bitlen(ntohl(eee->device.device_mask));
   reg.auth.scheme = 0; /* No auth yet */
@@ -710,47 +781,47 @@ static void send_register_super(n2n_edge_t *eee, const n2n_sock_t *supernode, in
   encode_REGISTER_SUPER(pktbuf, &idx, &cmn, &reg);
 
   traceEvent(TRACE_DEBUG, "send REGISTER_SUPER to %s",
-	     sock_to_cstr(sockbuf, supernode));
+	     sock_to_cstr(sockbuf, &(eee->curr_sn->sock)));
 
   if (eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED)
     packet_header_encrypt(pktbuf, idx, eee->conf.header_encryption_ctx,
 			  eee->conf.header_iv_ctx,
 			  time_stamp(), pearson_hash_16(pktbuf, idx));
 
-  /* sent = */ sendto_sock(eee->udp_sock, pktbuf, idx, supernode);
+  /* sent = */ sendto_sock(eee->udp_sock, pktbuf, idx, &(eee->curr_sn->sock));
 }
 
-/* ************************************** */
 
-/** Send a QUERY_PEER packet to the current supernode. */
-static void send_query_peer( n2n_edge_t * eee,
-                             const n2n_mac_t dstMac) {
-  uint8_t pktbuf[N2N_PKT_BUF_SIZE];
-  size_t idx;
-  n2n_common_t cmn = {0};
-  n2n_QUERY_PEER_t query = {{0}};
+static int sort_supernodes(n2n_edge_t *eee, time_t now){
+  struct peer_info *scan, *tmp;
 
-  cmn.ttl=N2N_DEFAULT_TTL;
-  cmn.pc = n2n_query_peer;
-  cmn.flags = 0;
-  memcpy( cmn.community, eee->conf.community_name, N2N_COMMUNITY_SIZE );
+ if(eee->curr_sn != eee->conf.supernodes){
+   eee->curr_sn = eee->conf.supernodes;
+   memcpy(&eee->supernode, &(eee->curr_sn->sock), sizeof(n2n_sock_t));
+   eee->sup_attempts = N2N_EDGE_SUP_ATTEMPTS;
 
-  idx=0;
-  encode_mac( query.srcMac, &idx, eee->device.mac_addr );
-  idx=0;
-  encode_mac( query.targetMac, &idx, dstMac );
+   traceEvent(TRACE_INFO, "Registering with supernode [%s][number of supernodes %d][attempts left %u]",
+    supernode_ip(eee), HASH_COUNT(eee->conf.supernodes), (unsigned int)eee->sup_attempts);
 
-  idx=0;
-  encode_QUERY_PEER( pktbuf, &idx, &cmn, &query );
+   send_register_super(eee);
+   eee->sn_wait = 1;
+ }
 
-  traceEvent( TRACE_DEBUG, "send QUERY_PEER to supernode" );
+ if(now - eee->last_sweep > SWEEP_TIME){
+    if(eee->sn_wait == 0){
+      // this routine gets periodically called
+      // it sorts supernodes in ascending order of their ping_time-fields
+        HASH_SORT(eee->conf.supernodes, ping_time_sort);
+        eee->last_sweep = now;
 
-  if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED){
-    packet_header_encrypt (pktbuf, idx, eee->conf.header_encryption_ctx,
-			   eee->conf.header_iv_ctx,
-			   time_stamp (), pearson_hash_16 (pktbuf, idx));
+        HASH_ITER(hh, eee->conf.supernodes, scan, tmp){
+          scan->ping_time = MAX_PING_TIME;
+        }
+    }
+    send_query_peer(eee, null_mac);
   }
-  sendto_sock( eee->udp_sock, pktbuf, idx, &(eee->supernode) );
+
+  return 0; /* OK */
 }
 
 /** Send a REGISTER packet to another edge. */
@@ -855,7 +926,7 @@ static void send_register_ack(n2n_edge_t * eee,
  *  This is frequently called by the main loop.
  */
 void update_supernode_reg(n2n_edge_t * eee, time_t nowTime) {
-  u_int sn_idx;
+  struct peer_info *scan, *tmp;
 
   if(eee->sn_wait && (nowTime > (eee->last_register_req + (eee->conf.register_interval/10)))) {
     /* fall through */
@@ -867,12 +938,10 @@ void update_supernode_reg(n2n_edge_t * eee, time_t nowTime) {
 
   if(0 == eee->sup_attempts) {
     /* Give up on that supernode and try the next one. */
-    ++(eee->sn_idx);
-
-    if(eee->sn_idx >= eee->conf.sn_num) {
-      /* Got to end of list, go back to the start. Also works for list of one entry. */
-      eee->sn_idx=0;
-    }
+    eee->curr_sn->ping_time = MAX_PING_TIME;
+    HASH_SORT(eee->conf.supernodes, ping_time_sort);
+    eee->curr_sn = eee->conf.supernodes;
+    memcpy(&eee->supernode, &(eee->curr_sn->sock), sizeof(n2n_sock_t));
 
     traceEvent(TRACE_WARNING, "Supernode not responding, now trying %s", supernode_ip(eee));
 
@@ -893,15 +962,13 @@ void update_supernode_reg(n2n_edge_t * eee, time_t nowTime) {
   else
     --(eee->sup_attempts);
 
-  for(sn_idx=0; sn_idx<eee->conf.sn_num; sn_idx++) {
-    if(supernode2sock(&(eee->supernode), eee->conf.sn_ip_array[sn_idx]) == 0) {
-      traceEvent(TRACE_INFO, "Registering with supernode [id: %u/%u][%s][attempts left %u]",
-		 sn_idx+1, eee->conf.sn_num,
-		 supernode_ip(eee), (unsigned int)eee->sup_attempts);
+  if(supernode2sock(&(eee->supernode), eee->curr_sn->ip_addr) == 0) {
+    traceEvent(TRACE_INFO, "Registering with supernode [%s][number of supernodes %d][attempts left %u]",
+		 supernode_ip(eee), HASH_COUNT(eee->conf.supernodes), (unsigned int)eee->sup_attempts);
 
-      send_register_super(eee, &(eee->supernode), sn_idx);
-    }
+    send_register_super(eee);
   }
+
 
   register_with_local_peers(eee);
 
@@ -929,7 +996,7 @@ static void send_deregister(n2n_edge_t * eee,
 
 /** Return the IP address of the current supernode in the ring. */
 static const char * supernode_ip(const n2n_edge_t * eee) {
-  return (eee->conf.sn_ip_array)[eee->sn_idx];
+  return (eee->curr_sn->ip_addr);
 }
 
 /* ************************************** */
@@ -1619,9 +1686,6 @@ void edge_read_from_tap(n2n_edge_t * eee) {
 
 /* ************************************** */
 
-
-/* ************************************** */
-
 /** Read a datagram from the main UDP socket to the internet. */
 void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
   n2n_common_t        cmn; /* common fields in the packet header */
@@ -1630,7 +1694,6 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
   n2n_sock_str_t      sockbuf2; /* don't clobber sockbuf1 if writing two addresses to trace */
   macstr_t            mac_buf1;
   macstr_t            mac_buf2;
-
   uint8_t             udp_buf[N2N_PKT_BUF_SIZE];      /* Compete UDP packet */
   ssize_t             recvlen;
   size_t              rem;
@@ -1665,6 +1728,10 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 
   /* REVISIT: when UDP/IPv6 is supported we will need a flag to indicate which
    * IP transport version the packet arrived on. May need to UDP sockets. */
+
+  /* REVISIT: do not endprse use with several supernodes
+  memset(&sender, 0, sizeof(n2n_sock_t)); */
+
   sender.family = AF_INET; /* UDP socket was opened PF_INET v4 */
   sender.port = ntohs(sender_sock.sin_port);
   memcpy(&(sender.addr.v4), &(sender_sock.sin_addr.s_addr), IPV4_SIZE);
@@ -1835,6 +1902,11 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 	char * ip_str = NULL;
 	n2n_REGISTER_SUPER_ACK_t ra;
   uint8_t tmpbuf[MAX_AVAILABLE_SPACE_FOR_ENTRIES];
+  n2n_sock_t *tmp_sock;
+  n2n_mac_t *tmp_mac;
+  int i;
+  int skip_add;
+  struct peer_info *sn;
 
 	memset(&ra, 0, sizeof(n2n_REGISTER_SUPER_ACK_t));
 
@@ -1872,12 +1944,23 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 	      return;
 	    }
 
-	    if(0 == memcmp(ra.cookie, eee->last_cookie, N2N_COOKIE_SIZE))
+	    if(0 == memcmp(ra.cookie, eee->curr_sn->last_cookie, N2N_COOKIE_SIZE))
 	      {
-		if(ra.num_sn > 0)
-		  {
-		    traceEvent(TRACE_NORMAL, "Rx REGISTER_SUPER_ACK payload contains sockets and MACs of supernodes in the federation.");
-		  }
+    tmp_sock = (void*)&tmpbuf;
+    tmp_mac = (void*)&tmpbuf[sizeof(n2n_sock_t)];
+
+    for(i=0; i<ra.num_sn; i++){
+      skip_add = NO_SKIP;
+      sn = add_sn_to_list_by_mac_or_sock(&(eee->conf.supernodes), tmp_sock, tmp_mac, &skip_add);
+      if(skip_add == ADDED){
+        traceEvent(TRACE_NORMAL, "Supernode added to the list of supernodes.");
+      }
+
+      /* REVISIT: find a more elegant expression to increase following pointers. */
+      tmp_sock = (void*)tmp_sock + ENTRY_SIZE;
+      tmp_mac = (void*)tmp_sock + sizeof(n2n_sock_t);
+    }
+
 		eee->last_sup = now;
 		eee->sn_wait=0;
 		eee->sup_attempts = N2N_EDGE_SUP_ATTEMPTS; /* refresh because we got a response */
@@ -1902,6 +1985,8 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 		/* NOTE: the register_interval should be chosen by the edge node
 		 * based on its NAT configuration. */
 		//eee->conf.register_interval = ra.lifetime;
+
+      eee->curr_sn->ping_time = (now - eee->last_register_req)*1000;
 	      }
 	    else
 	      {
@@ -1917,6 +2002,8 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
     case MSG_TYPE_PEER_INFO: {
       n2n_PEER_INFO_t pi;
       struct peer_info *  scan;
+      int skip_add;
+
       decode_PEER_INFO( &pi, &cmn, udp_buf, &rem, &idx );
 
       if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED) {
@@ -1927,24 +2014,35 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
       }
 
       if(!is_valid_peer_sock(&pi.sock)) {
-	traceEvent(TRACE_DEBUG, "Skip invalid PEER_INFO %s [%s]",
-		   sock_to_cstr(sockbuf1, &pi.sock),
-		   macaddr_str(mac_buf1, pi.mac) );
-	break;
+	      traceEvent(TRACE_DEBUG, "Skip invalid PEER_INFO %s [%s]",
+		                sock_to_cstr(sockbuf1, &pi.sock),
+		                macaddr_str(mac_buf1, pi.mac) );
+	      break;
       }
 
-      HASH_FIND_PEER(eee->pending_peers, pi.mac, scan);
-      if(scan) {
-	scan->sock = pi.sock;
-	traceEvent(TRACE_INFO, "Rx PEER_INFO for %s: is at %s",
-		   macaddr_str(mac_buf1, pi.mac),
-		   sock_to_cstr(sockbuf1, &pi.sock));
-	send_register(eee, &scan->sock, scan->mac_addr);
+      if(memcmp(pi.mac, null_mac, sizeof(n2n_mac_t)) == 0){
+        skip_add = SKIP;
+        scan = add_sn_to_list_by_mac_or_sock(&(eee->conf.supernodes), &sender, &pi.srcMac, &skip_add);
+        if(scan != NULL){
+          scan->ping_time = (now - eee->last_sweep)*1000;
+          break;
+        }
       } else {
-	traceEvent(TRACE_INFO, "Rx PEER_INFO unknown peer %s",
-		   macaddr_str(mac_buf1, pi.mac) );
-      }
+        HASH_FIND_PEER(eee->pending_peers, pi.mac, scan);
 
+        if(scan) {
+        	scan->sock = pi.sock;
+        	traceEvent(TRACE_INFO, "Rx PEER_INFO for %s: is at %s",
+        		   macaddr_str(mac_buf1, pi.mac),
+        		   sock_to_cstr(sockbuf1, &pi.sock));
+
+        	send_register(eee, &scan->sock, scan->mac_addr);
+
+        } else {
+        	traceEvent(TRACE_INFO, "Rx PEER_INFO unknown peer %s",
+        		   macaddr_str(mac_buf1, pi.mac) );
+        }
+      }
       break;
     }
     default:
@@ -2095,6 +2193,8 @@ int run_edge_loop(n2n_edge_t * eee, int *keep_running) {
 
     if (eee->cb.main_loop_period)
       eee->cb.main_loop_period(eee, nowTime);
+
+    sort_supernodes(eee, nowTime);
 
   } /* while */
 
@@ -2479,7 +2579,7 @@ static int edge_init_routes_linux(n2n_edge_t *eee, n2n_route_t *routes, uint16_t
 	return(-1);
       }
 
-      if (supernode2sock(&sn, eee->conf.sn_ip_array[0]) < 0)
+      if (supernode2sock(&sn, eee->conf.supernodes->ip_addr) < 0)
 	return(-1);
 
       if (sn.family != AF_INET) {
@@ -2618,7 +2718,7 @@ void edge_init_conf_defaults(n2n_edge_conf_t *conf) {
 
   if (getenv("N2N_KEY")) {
     conf->encrypt_key = strdup(getenv("N2N_KEY"));
-    conf->transop_id = N2N_TRANSFORM_ID_AES;
+    conf->transop_id = N2N_TRANSFORM_ID_TWOFISH;
   }
 }
 
@@ -2638,11 +2738,38 @@ const n2n_edge_conf_t* edge_get_conf(const n2n_edge_t *eee) {
 /* ************************************** */
 
 int edge_conf_add_supernode(n2n_edge_conf_t *conf, const char *ip_and_port) {
-  if(conf->sn_num >= N2N_EDGE_NUM_SUPERNODES)
-    return(-1);
+  struct peer_info *sn;
+  n2n_sock_t *sock;
+  int skip_add;
+  int rv = -1;
 
-  strncpy((conf->sn_ip_array[conf->sn_num]), ip_and_port, N2N_EDGE_SN_HOST_SIZE);
-  traceEvent(TRACE_NORMAL, "Adding supernode[%u] = %s", (unsigned int)conf->sn_num, (conf->sn_ip_array[conf->sn_num]));
+  sock = (n2n_sock_t*)calloc(1,sizeof(n2n_sock_t));
+  rv = supernode2sock(sock, ip_and_port);
+
+  if(rv != 0){
+    traceEvent(TRACE_WARNING, "Invalid socket");
+    free(sock);
+    return(1);
+  }
+
+  skip_add = NO_SKIP;
+  sn = add_sn_to_list_by_mac_or_sock(&(conf->supernodes), sock, (n2n_mac_t *)null_mac, &skip_add);
+
+  if(sn != NULL){
+    sn->ip_addr = calloc(1,N2N_EDGE_SN_HOST_SIZE);
+
+    if(sn->ip_addr != NULL){
+      strncpy(sn->ip_addr, ip_and_port, N2N_EDGE_SN_HOST_SIZE-1);
+      memcpy(&(sn->sock), sock, sizeof(n2n_sock_t));
+      memcpy(&(sn->mac_addr), null_mac, sizeof(n2n_mac_t));
+      sn->purgeable = SN_UNPURGEABLE;
+      sn->last_valid_time_stamp = initial_time_stamp();
+    }
+  }
+
+  free(sock);
+
+  traceEvent(TRACE_NORMAL, "Adding supernode = %s", sn->ip_addr);
   conf->sn_num++;
 
   return(0);
@@ -2663,7 +2790,7 @@ int quick_edge_init(char *device_name, char *community_name,
   /* Setup the configuration */
   edge_init_conf_defaults(&conf);
   conf.encrypt_key = encrypt_key;
-  conf.transop_id = N2N_TRANSFORM_ID_AES;
+  conf.transop_id = N2N_TRANSFORM_ID_TWOFISH;
   conf.compression = N2N_COMPRESSION_ID_NONE;
   snprintf((char*)conf.community_name, sizeof(conf.community_name), "%s", community_name);
   edge_conf_add_supernode(&conf, supernode_ip_address_port);

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -251,6 +251,7 @@ int sn_init(n2n_sn_t *sss) {
     sss->federation->header_encryption = HEADER_ENCRYPTION_ENABLED;
     /*setup the encryption key */
     packet_header_setup_key(sss->federation->community, &(sss->federation->header_encryption_ctx), &(sss->federation->header_iv_ctx));
+		sss->federation->edges = NULL;
   }
 
   n2n_srand (n2n_seed());
@@ -510,9 +511,11 @@ static int find_edge_time_stamp_and_verify (struct peer_info * edges,
   return ( time_stamp_verify_and_update (stamp, previous_stamp, allow_jitter) );
 }
 
-static int re_register_and_purge_supernodes(n2n_sn_t *sss, struct sn_community *comm, time_t now) {
+static int re_register_and_purge_supernodes(n2n_sn_t *sss, struct sn_community *comm, time_t *p_last_re_reg_and_purge, time_t now) {
   time_t time;
   struct peer_info *peer, *tmp;
+
+	if((now - (*p_last_re_reg_and_purge)) < RE_REG_AND_PURGE_FREQUENCY ) return 0;
 
   if(comm != NULL) {
     HASH_ITER(hh,comm->edges,peer,tmp) {
@@ -520,7 +523,7 @@ static int re_register_and_purge_supernodes(n2n_sn_t *sss, struct sn_community *
       if(time <= ALLOWED_TIME) continue;
 
       if((time < PURGE_FEDERATION_NODE_INTERVAL)
-	 || (peer->purgeable == SN_UNPURGEABLE)  /* FIX fcarli3 */
+	 || (peer->purgeable == SN_UNPURGEABLE)
 	 ) {
 	/* re-regitser (send REGISTER_SUPER) */
 	uint8_t pktbuf[N2N_PKT_BUF_SIZE] = {0};
@@ -536,10 +539,10 @@ static int re_register_and_purge_supernodes(n2n_sn_t *sss, struct sn_community *
 
 	cmn.ttl = N2N_DEFAULT_TTL;
 	cmn.pc = n2n_register_super;
-	cmn.flags = 0;
+	cmn.flags = N2N_FLAGS_FROM_SUPERNODE;
 	memcpy(cmn.community, comm->community, N2N_COMMUNITY_SIZE);
 
-	for (idx = 0; idx < N2N_COOKIE_SIZE; ++idx) /* aggiungi sn_idx */
+	for (idx = 0; idx < N2N_COOKIE_SIZE; ++idx)
 	  cookie[idx] = n2n_rand() % 0xff;
 
 	memcpy(reg.cookie, cookie, N2N_COOKIE_SIZE);
@@ -548,7 +551,7 @@ static int re_register_and_purge_supernodes(n2n_sn_t *sss, struct sn_community *
 	reg.auth.scheme = 0; /* No auth yet */
 
 	idx = 0;
-	encode_mac(reg.edgeMac, &idx, peer->mac_addr);
+	encode_mac(reg.edgeMac, &idx, sss->mac_addr);
 
 	idx = 0;
 	encode_REGISTER_SUPER(pktbuf, &idx, &cmn, &reg);
@@ -560,11 +563,13 @@ static int re_register_and_purge_supernodes(n2n_sn_t *sss, struct sn_community *
 			      comm->header_iv_ctx,
 			      time_stamp(), pearson_hash_16(pktbuf, idx));
 
-	/* sent = */ sendto_sock(sss, &(peer->sock), pktbuf, N2N_PKT_BUF_SIZE);
+	/* sent = */ sendto_sock(sss, &(peer->sock), pktbuf, idx);
       }
       if(time >= PURGE_FEDERATION_NODE_INTERVAL) purge_expired_registrations(&(comm->edges),&time,PURGE_FEDERATION_NODE_INTERVAL);/* purge not-seen-long-time supernodes*/
     }
   }
+
+	(*p_last_re_reg_and_purge) = now;
 
   return 0; /* OK */
 }
@@ -731,46 +736,6 @@ static int sendto_mgmt(n2n_sn_t *sss,
   }
   return 0;
 }
-
-
-/** Search for a node in the federation list. If it has to add a new node, it creates a new peer_info and initializes it
- * Evaluate first the MAC parameter and if it's zero-MAC, then it can skip HASH_FIND_PEER by MAC and search by socket
- */
-struct peer_info* add_sn_to_federation_by_mac_or_sock(n2n_sn_t *sss,n2n_sock_t *sock, n2n_mac_t *mac) {
-  struct peer_info *scan, *tmp, *peer = NULL;
-  int found = 0;
-
-  if(sss->federation != NULL) {
-    if(memcmp(mac,null_mac,sizeof(n2n_mac_t)) != 0) { /* not zero MAC */
-      HASH_FIND_PEER(sss->federation->edges, mac, peer);
-
-      //REVISIT: make this dependent from last_seen and update socket
-    }
-
-    if(peer == NULL) { /* zero MAC, search by socket */
-      HASH_ITER(hh,sss->federation->edges,scan,tmp) {
-	if(memcmp(&(scan->sock), sock, sizeof(n2n_sock_t))) {
-	  memcpy(&(scan->mac_addr), sock, sizeof(n2n_mac_t));
-	  peer = scan;
-	  break;
-	}
-      }
-
-      if(peer == NULL) {
-	peer = (struct peer_info*)calloc(1,sizeof(struct peer_info));
-	if(peer) {
-	  memcpy(&(peer->sock),sock,sizeof(n2n_sock_t));
-	  memcpy(&(peer->mac_addr),mac, sizeof(n2n_mac_t));
-	  HASH_ADD_PEER(sss->federation->edges,peer);
-	}
-      }
-    }
-  }
-
-  return peer;
-
-}
-
 
 /** Examine a datagram and determine what to do with it.
  *
@@ -1055,18 +1020,18 @@ static int process_udp(n2n_sn_t * sss,
       n2n_REGISTER_SUPER_ACK_t        ack;
       n2n_common_t                    cmn2;
       uint8_t                         ackbuf[N2N_SN_PKTBUF_SIZE];
-      uint8_t			      tmpbuf[MAX_AVAILABLE_SPACE_FOR_ENTRIES];
+      uint8_t													tmpbuf[MAX_AVAILABLE_SPACE_FOR_ENTRIES];
+			uint8_t                         *tmp_dst;
       size_t                          encx=0;
       struct sn_community             *fed;
       struct sn_community_regular_expression *re, *tmp_re;
-      struct peer_info		      *peer, *tmp_peer, *p;
+      struct peer_info		            *peer, *tmp_peer, *p;
       int8_t                          allowed_match = -1;
       uint8_t                         match = 0;
-      int			      match_length = 0;
+      int			                        match_length = 0;
       n2n_ip_subnet_t                 ipaddr;
-      int 			      num = 0;
-      n2n_sock_t 		      *tmp_sock;
-      n2n_mac_t 		      *tmp_mac;
+      int 			                      num = 0;
+			int                             skip_add;
 
       memset(&ack, 0, sizeof(n2n_REGISTER_SUPER_ACK_t));
 
@@ -1076,13 +1041,13 @@ static int process_udp(n2n_sn_t * sss,
       decode_REGISTER_SUPER(&reg, &cmn, udp_buf, &rem, &idx);
 
       if (comm) {
-	if(comm->header_encryption == HEADER_ENCRYPTION_ENABLED) {
-	  if(!find_edge_time_stamp_and_verify (comm->edges, from_supernode, reg.edgeMac, stamp, TIME_STAMP_NO_JITTER)) {
-	    traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER due to time stamp error.");
-	    return -1;
-	  }
-	}
-      }
+				if(comm->header_encryption == HEADER_ENCRYPTION_ENABLED) {
+	  			if(!find_edge_time_stamp_and_verify (comm->edges, from_supernode, reg.edgeMac, stamp, TIME_STAMP_NO_JITTER)) {
+	    			traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER due to time stamp error.");
+	    			return -1;
+	  			}
+				}
+    	}
 
       /*
 	Before we move any further, we need to check if the requested
@@ -1092,8 +1057,8 @@ static int process_udp(n2n_sn_t * sss,
       */
 
       if(!comm && sss->lock_communities) {
-	HASH_ITER(hh, sss->rules, re, tmp_re) {
-	  allowed_match = re_matchp(re->rule, (const char *)cmn.community, &match_length);
+    	 HASH_ITER(hh, sss->rules, re, tmp_re) {
+	      allowed_match = re_matchp(re->rule, (const char *)cmn.community, &match_length);
 
 	  if( (allowed_match != -1)
 	      && (match_length == strlen((const char *)cmn.community)) // --- only full matches allowed (remove, if also partial matches wanted)
@@ -1109,7 +1074,7 @@ static int process_udp(n2n_sn_t * sss,
 	}
       }
 
-      if(!comm && (!sss->lock_communities || (match == 1))) {
+  if(!comm && (!sss->lock_communities || (match == 1))) {
 
 	comm = (struct sn_community*)calloc(1,sizeof(struct sn_community));
 
@@ -1124,18 +1089,24 @@ static int process_udp(n2n_sn_t * sss,
 	  HASH_ADD_STR(sss->communities, community, comm);
 
 	  traceEvent(TRACE_INFO, "New community: %s", comm->community);
-          assign_one_ip_subnet(sss, comm);
+               assign_one_ip_subnet(sss, comm);
 	}
-      }
+}
 
-      if(comm) {
+if(comm) {
 	cmn2.ttl = N2N_DEFAULT_TTL;
 	cmn2.pc = n2n_register_super_ack;
 	cmn2.flags = N2N_FLAGS_SOCKET | N2N_FLAGS_FROM_SUPERNODE;
 	memcpy(cmn2.community, cmn.community, sizeof(n2n_community_t));
 
 	memcpy(&(ack.cookie), &(reg.cookie), sizeof(n2n_cookie_t));
-	memcpy(ack.edgeMac, reg.edgeMac, sizeof(n2n_mac_t));
+
+	if(comm->is_federation == IS_FEDERATION){
+		memcpy(&(ack.edgeMac), &(sss->mac_addr), sizeof(n2n_mac_t));
+	}else{
+		memcpy(&(ack.edgeMac), &(reg.edgeMac), sizeof(n2n_mac_t));
+	}
+
 	if ((reg.dev_addr.net_addr == 0) || (reg.dev_addr.net_addr == 0xFFFFFFFF) || (reg.dev_addr.net_bitlen == 0) ||
 	    ((reg.dev_addr.net_addr & 0xFFFF0000) == 0xA9FE0000 /* 169.254.0.0 */)) {
 	  memset(&ipaddr, 0, sizeof(n2n_ip_subnet_t));
@@ -1148,38 +1119,37 @@ static int process_udp(n2n_sn_t * sss,
 	ack.sock.family = AF_INET;
 	ack.sock.port = ntohs(sender_sock->sin_port);
 	memcpy(ack.sock.addr.v4, &(sender_sock->sin_addr.s_addr), IPV4_SIZE);
-	      
-        if(from_supernode != comm->is_federation) {
-          traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER: from_supernode value doesn't correspond to the internal federation marking");
-	  return -1;
-        }
+
+	if((from_supernode == 0) != (comm->is_federation == IS_NO_FEDERATION)) {
+		traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER: from_supernode value doesn't correspond to the internal federation marking");
+    return -1;
+	}
 
 	/* Add sender's data to federation (or update it) */
 	if(comm->is_federation == IS_FEDERATION) {
-	  p = add_sn_to_federation_by_mac_or_sock(sss,&(ack.sock),&(reg.edgeMac));
-	  if(p) p->last_seen = now;
+		skip_add = NO_SKIP;
+	  p = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), &(ack.sock), &(reg.edgeMac), &skip_add);
 	}
-
-	tmp_sock = (void*)tmpbuf;
-	tmp_mac = (void*)tmpbuf + sizeof(n2n_sock_t);
 
 	// REVISIT: consider adding last_seen
 
 	/* Assembling supernode list for REGISTER_SUPER_ACK payload */
+	tmp_dst = tmpbuf;
 	HASH_ITER(hh, sss->federation->edges, peer, tmp_peer) {
+		if(memcmp(&(peer->sock), &(ack.sock), sizeof(n2n_sock_t)) == 0) continue; /* a supernode doesn't add itself to the payload */
 	  if((now - peer->last_seen) >= ALLOWED_TIME) continue; /* skip long-time-not-seen supernodes */
 	  if(((++num)*ENTRY_SIZE) > MAX_AVAILABLE_SPACE_FOR_ENTRIES) break; /* no more space available in REGISTER_SUPER_ACK payload */
-	  memcpy((void*)tmpbuf, (void*)&(peer->sock), sizeof(n2n_sock_t));
-	  memcpy((void*)tmpbuf, (void*)&(peer->mac_addr), sizeof(n2n_mac_t));
-	  tmp_sock += ENTRY_SIZE;
-	  tmp_mac += ENTRY_SIZE;
+	  memcpy((void*)tmp_dst, (void*)&(peer->sock), sizeof(n2n_sock_t));
+		tmp_dst += sizeof(n2n_sock_t);
+	  memcpy((void*)tmp_dst, (void*)&(peer->mac_addr), sizeof(n2n_mac_t));
+		tmp_dst += sizeof(n2n_mac_t);
 	}
 	ack.num_sn = num;
 
 
-        traceEvent(TRACE_DEBUG, "Rx REGISTER_SUPER for %s [%s]",
-		   macaddr_str(mac_buf, reg.edgeMac),
-		   sock_to_cstr(sockbuf, &(ack.sock)));
+  traceEvent(TRACE_DEBUG, "Rx REGISTER_SUPER for %s [%s]",
+		         macaddr_str(mac_buf, reg.edgeMac),
+		         sock_to_cstr(sockbuf, &(ack.sock)));
 
 	if(memcmp(reg.edgeMac, &null_mac, N2N_MAC_SIZE) != 0) {
 	  update_edge(sss, &reg, comm, &(ack.sock), now);
@@ -1189,8 +1159,8 @@ static int process_udp(n2n_sn_t * sss,
 
 	if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
 	  packet_header_encrypt (ackbuf, encx, comm->header_encryption_ctx,
-				 comm->header_iv_ctx,
-				 time_stamp (), pearson_hash_16 (ackbuf, encx));
+				                   comm->header_iv_ctx,
+				                   time_stamp (), pearson_hash_16 (ackbuf, encx));
 
 	sendto(sss->sock, ackbuf, encx, 0,
 	       (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in));
@@ -1199,9 +1169,9 @@ static int process_udp(n2n_sn_t * sss,
 		   macaddr_str(mac_buf, reg.edgeMac),
 		   sock_to_cstr(sockbuf, &(ack.sock)));
       } else {
-	traceEvent(TRACE_INFO, "Discarded registration: unallowed community '%s'",
-		   (char*)cmn.community);
-	return -1;
+				traceEvent(TRACE_INFO, "Discarded registration: unallowed community '%s'",
+		               (char*)cmn.community);
+				return -1;
       }
       break;
     }
@@ -1219,7 +1189,9 @@ static int process_udp(n2n_sn_t * sss,
     n2n_mac_t												*tmp_mac;
     int															i;
 		uint8_t													dec_tmpbuf[MAX_AVAILABLE_SPACE_FOR_ENTRIES];
+		int                             skip_add;
 
+		memset(&sender, 0, sizeof(n2n_sock_t));
     sender.family = AF_INET;
     sender.port = ntohs(sender_sock->sin_port);
     memcpy(&(sender.addr.v4), &(sender_sock->sin_addr.s_addr), IPV4_SIZE);
@@ -1232,7 +1204,7 @@ static int process_udp(n2n_sn_t * sss,
       return -1;
     }
 
-    if(from_supernode != comm->is_federation) {
+    if((from_supernode == 0) != (comm->is_federation == IS_NO_FEDERATION)) {
       traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK: from_supernode value doesn't correspond to the internal federation marking.");
       return -1;
     }
@@ -1243,9 +1215,9 @@ static int process_udp(n2n_sn_t * sss,
     if (comm) {
       if(comm->header_encryption == HEADER_ENCRYPTION_ENABLED) {
         if(!find_edge_time_stamp_and_verify (comm->edges, from_supernode, ack.edgeMac, stamp, TIME_STAMP_NO_JITTER)) {
-	  traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK due to time stamp error.");
-	  return -1;
-	}
+	  			traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK due to time stamp error.");
+	  			return -1;
+				}
       }
     }
 
@@ -1255,27 +1227,30 @@ static int process_udp(n2n_sn_t * sss,
 	       sock_to_cstr(sockbuf2, orig_sender));
 
     if(comm->is_federation == IS_FEDERATION) {
-      HASH_FIND_PEER(sss->federation->edges, ack.edgeMac, scan);
+			skip_add = SKIP;
+			scan = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), &sender, &(ack.edgeMac), &skip_add);
       if(scan != NULL) {
-	scan->last_seen = now;
+				scan->last_seen = now;
       } else {
-	traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK due to an unknown supernode.");
-	break;
+				traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK due to an unknown supernode.");
+				break;
       }
     }
 
-    tmp_sock = (void*)&(ack.num_sn) + sizeof(ack.num_sn);
-    tmp_mac = (void*)tmp_sock + sizeof(n2n_sock_t);
+    tmp_sock = (void *)dec_tmpbuf;
+    tmp_mac = (void*)dec_tmpbuf + sizeof(n2n_sock_t);
 
     for(i=0; i<ack.num_sn; i++) {
-      tmp = add_sn_to_federation_by_mac_or_sock(sss,tmp_sock,tmp_mac);
+			skip_add = NO_SKIP;
+      tmp = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), tmp_sock, tmp_mac, &skip_add);
 
-      if(tmp) {
-	tmp->last_seen = now - TEST_TIME;
+      if(skip_add == ADDED) {
+				tmp->last_seen = now - TEST_TIME;
       }
 
-      tmp_sock += ENTRY_SIZE;
-      tmp_mac += ENTRY_SIZE;
+			/* REVISIT: find a more elegant expression to increase following pointers. */
+      tmp_sock = (void*)tmp_sock + ENTRY_SIZE;
+      tmp_mac = (void*)tmp_sock + sizeof(n2n_sock_t);
     }
 
     break;
@@ -1302,39 +1277,69 @@ static int process_udp(n2n_sn_t * sss,
       }
     }
 
-    traceEvent( TRACE_DEBUG, "Rx QUERY_PEER from %s for %s",
-                macaddr_str( mac_buf,  query.srcMac ),
-                macaddr_str( mac_buf2, query.targetMac ) );
+    if(memcmp(query.targetMac, null_mac, sizeof(n2n_mac_t)) == 0){
+			traceEvent( TRACE_DEBUG, "Rx PING from %s. Requested data: %d",
+	                macaddr_str( mac_buf,  query.srcMac ),
+	                             query.req_data );
 
-    struct peer_info *scan;
-    HASH_FIND_PEER(comm->edges, query.targetMac, scan);
-
-    if (scan) {
-      cmn2.ttl = N2N_DEFAULT_TTL;
+			cmn2.ttl = N2N_DEFAULT_TTL;
       cmn2.pc = n2n_peer_info;
       cmn2.flags = N2N_FLAGS_FROM_SUPERNODE;
       memcpy( cmn2.community, cmn.community, sizeof(n2n_community_t) );
 
       pi.aflags = 0;
       memcpy( pi.mac, query.targetMac, sizeof(n2n_mac_t) );
-      pi.sock = scan->sock;
+			memcpy( pi.srcMac, sss->mac_addr, sizeof(n2n_mac_t) );
 
-      encode_PEER_INFO( encbuf, &encx, &cmn2, &pi );
+			encode_PEER_INFO( encbuf, &encx, &cmn2, &pi );
 
-      if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
-        packet_header_encrypt (encbuf, encx, comm->header_encryption_ctx,
-			       comm->header_iv_ctx,
-			       time_stamp (), pearson_hash_16 (encbuf, encx));
+			if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
+				packet_header_encrypt (encbuf, encx, comm->header_encryption_ctx,
+						 comm->header_iv_ctx,
+						 time_stamp (), pearson_hash_16 (encbuf, encx));
 
-      sendto( sss->sock, encbuf, encx, 0,
-	      (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in) );
+			sendto( sss->sock, encbuf, encx, 0,
+				(struct sockaddr *)sender_sock, sizeof(struct sockaddr_in) );
 
-      traceEvent( TRACE_DEBUG, "Tx PEER_INFO to %s",
-		  macaddr_str( mac_buf, query.srcMac ) );
-    } else {
-      traceEvent( TRACE_DEBUG, "Ignoring QUERY_PEER for unknown edge %s",
-		  macaddr_str( mac_buf, query.targetMac ) );
-    }
+			traceEvent( TRACE_DEBUG, "Tx PING to %s",
+			macaddr_str( mac_buf, query.srcMac ) );
+
+		} else {
+			traceEvent( TRACE_DEBUG, "Rx QUERY_PEER from %s for %s",
+	                macaddr_str( mac_buf,  query.srcMac ),
+	                macaddr_str( mac_buf2, query.targetMac ) );
+
+			struct peer_info *scan;
+	    HASH_FIND_PEER(comm->edges, query.targetMac, scan);
+
+	    if (scan) {
+	      cmn2.ttl = N2N_DEFAULT_TTL;
+	      cmn2.pc = n2n_peer_info;
+	      cmn2.flags = N2N_FLAGS_FROM_SUPERNODE;
+	      memcpy( cmn2.community, cmn.community, sizeof(n2n_community_t) );
+
+	      pi.aflags = 0;
+	      memcpy( pi.mac, query.targetMac, sizeof(n2n_mac_t) );
+	      pi.sock = scan->sock;
+
+	      encode_PEER_INFO( encbuf, &encx, &cmn2, &pi );
+
+	      if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
+	        packet_header_encrypt (encbuf, encx, comm->header_encryption_ctx,
+				       comm->header_iv_ctx,
+				       time_stamp (), pearson_hash_16 (encbuf, encx));
+
+	      sendto( sss->sock, encbuf, encx, 0,
+		      (struct sockaddr *)sender_sock, sizeof(struct sockaddr_in) );
+
+	      traceEvent( TRACE_DEBUG, "Tx PEER_INFO to %s",
+			  macaddr_str( mac_buf, query.srcMac ) );
+	    } else {
+	      traceEvent( TRACE_DEBUG, "Ignoring QUERY_PEER for unknown edge %s",
+			  macaddr_str( mac_buf, query.targetMac ) );
+	    }
+
+		}
 
     break;
   }
@@ -1353,6 +1358,7 @@ int run_sn_loop(n2n_sn_t *sss, int *keep_running)
   uint8_t pktbuf[N2N_SN_PKTBUF_SIZE];
   time_t last_purge_edges = 0;
   time_t last_sort_communities = 0;
+	time_t last_re_reg_and_purge = 0;
 
   sss->start_time = time(NULL);
 
@@ -1437,7 +1443,7 @@ int run_sn_loop(n2n_sn_t *sss, int *keep_running)
 	  traceEvent(TRACE_DEBUG, "timeout");
         }
 
-      re_register_and_purge_supernodes(sss, sss->federation, now);
+      re_register_and_purge_supernodes(sss, sss->federation, &last_re_reg_and_purge, now);
       purge_expired_communities(sss, &last_purge_edges, now);
       sort_communities (sss, &last_sort_communities, now);
     } /* while */

--- a/src/wire.c
+++ b/src/wire.c
@@ -510,6 +510,7 @@ int encode_PEER_INFO(uint8_t *base,
   int retval = 0;
   retval += encode_common(base, idx, common);
   retval += encode_uint16(base, idx, pkt->aflags);
+  retval += encode_mac(base, idx, pkt->srcMac);
   retval += encode_mac(base, idx, pkt->mac);
   retval += encode_sock(base, idx, &pkt->sock);
 
@@ -525,6 +526,7 @@ int decode_PEER_INFO(n2n_PEER_INFO_t *pkt,
   size_t retval = 0;
   memset(pkt, 0, sizeof(n2n_PEER_INFO_t));
   retval += decode_uint16(&(pkt->aflags), base, rem, idx);
+  retval += decode_mac(pkt->srcMac, base, rem, idx);
   retval += decode_mac(pkt->mac, base, rem, idx);
   retval += decode_sock(&pkt->sock, base, rem, idx);
 
@@ -541,6 +543,7 @@ int encode_QUERY_PEER( uint8_t * base,
   retval += encode_common( base, idx, common );
   retval += encode_mac( base, idx, pkt->srcMac );
   retval += encode_mac( base, idx, pkt->targetMac );
+  retval += encode_uint8( base, idx, pkt->req_data);
 
   return retval;
 }
@@ -555,6 +558,7 @@ int decode_QUERY_PEER( n2n_QUERY_PEER_t * pkt,
   memset( pkt, 0, sizeof(n2n_QUERY_PEER_t) );
   retval += decode_mac( pkt->srcMac, base, rem, idx );
   retval += decode_mac( pkt->targetMac, base, rem, idx );
+  retval += decode_uint8( &pkt->req_data, base, rem, idx);
 
   return retval;
 }


### PR DESCRIPTION
This PR modifies and updates how edges handle supernodes. First I changed the array of supernodes into an hash list of supernodes, like we have in `n2n_sn_t` structure. That way, we can know other many informations about supernodes, such as MAC, socket and so on. I also added a `struct peer_info *curr_sn` to `n2n_edge_t` to mantain the current supernode which an edge is registered to. 

Regards REGISTER_SUPER_ACK payload handling, I used the same approach as in `src/sn_utils.c`, in fact I moved the function `add_sn_to_federation_by_mac_or_sock()` from this file to `src/n2n.c` and I renamed it in `add_sn_to_list_by_mac_or_sock()`. So when a packet arrives, we decode it and we iterate through its payload to update informations of supernodes in the list or add supernodes that aren't already in the list. 

I also added a feature that I have to complete yet because now it works only in the common scenario with one supernode. That feature implements a selection strategy from edges: they have the list of available supernode and with a strategy based on a `ping_time`, an edge will choose the best supernode in the ordered list, that is sorted calling `sort_supernodes()` in `run_edge_loop()`.

Anyway, @Logan007 and I tested many scenario with supernodes and edges:
- edges connected to a supernode
-  many supernodes connected to one using `-l` parameter (e.g. A, B->A, C->A, D->A)
- a "chained" scenario (e.g. A->B, B->C, C->D, D->A ...)
- a supernode suddenly is stopped and restarted after a while
- a supernode enters the federation later after the others
- scenario where we mixed cases above

All tests above work well, we checked if MACs of supernodes and edges are handled and shared properly through the federation using `netcat -u localhost <mgmt_port>`.

This PR fixes #449 .