### PR TITLE
rpm: fix installation warning

### DIFF
--- a/packages/rpm/n2n.spec.in
+++ b/packages/rpm/n2n.spec.in
@@ -78,7 +78,7 @@ if ! grep -q n2n /etc/group; then
 fi
 
 if ! /usr/bin/id -u n2n > /dev/null 2>&1; then
-  cho 'Creating n2n user'
+  echo 'Creating n2n user'
   /usr/sbin/useradd -M -N -g n2n -r -s /bin/false n2n
 fi
 


### PR DESCRIPTION
Avoid cosmetic error when installing the package.

Extract from yum output:
```
Creating n2n group
/var/tmp/rpm-tmp.S67n4H: line 8: cho: command not found
  Installing : n2n-2.9.0-746.x86_64   
```