### PR TITLE
Packet forwarding between supernodes

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -32,23 +32,25 @@
 /* Max available space to add supernodes' informations (sockets and MACs) in REGISTER_SUPER_ACK
  * Field sizes of REGISTER_SUPER_ACK as used in encode/decode fucntions in src/wire.c
  * REVISIT: replace 255 by DEFAULT_MTU as soon as header encryption allows for longer packets to be encrypted. */
-#define MAX_AVAILABLE_SPACE_FOR_ENTRIES \
+#define REG_SUPER_ACK_PAYLOAD_SPACE \
 	(255-(1+1+2+sizeof(n2n_common_t)+sizeof(n2n_cookie_t)+sizeof(n2n_mac_t)+1+2+4+1+sizeof(n2n_sock_t)+1)) \
 
 /* Space needed to store socket and MAC address of a supernode */
-#define ENTRY_SIZE		(sizeof(n2n_sock_t)+sizeof(n2n_mac_t))
+#define REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE		(sizeof(n2n_sock_t)+sizeof(n2n_mac_t))
 
 #define PURGE_REGISTRATION_FREQUENCY   30
 #define RE_REG_AND_PURGE_FREQUENCY     10
 #define REGISTRATION_TIMEOUT           60
-#define PURGE_FEDERATION_NODE_INTERVAL 90
 
 #define SOCKET_TIMEOUT_INTERVAL_SECS    10
 #define REGISTER_SUPER_INTERVAL_DFL     20 /* sec, usually UDP NAT entries in a firewall expire after 30 seconds */
-#define ALLOWED_TIME			20 /* sec, indicates supernodes that are proven to be alive */
-#define TEST_TIME		(PURGE_FEDERATION_NODE_INTERVAL - ALLOWED_TIME)/2 /* sec, indicates supernodes with unsure status, must be tested to check if they are alive */
-#define MAX_PING_TIME    3000  /* millisec, indicates default value for ping_time field in peer_info structure */
-#define SWEEP_TIME       30 /* sec, indicates the value after which we have to sort the hash list of supernodes in edges */
+#define MAX_PING_TIME                   3000  /* millisec, indicates default value for ping_time field in peer_info structure */
+#define SWEEP_TIME                      30 /* sec, indicates the value after which we have to sort the hash list of supernodes in edges */
+
+#define LAST_SEEN_SN_ACTIVE      20 /* sec, indicates supernodes that are proven to be active */
+#define LAST_SEEN_SN_INACTIVE    90 /* sec, indicates supernodes that are proven to be inactive: they will be purged */
+#define LAST_SEEN_SN_NEW         (LAST_SEEN_SN_INACTIVE - LAST_SEEN_SN_ACTIVE)/2 /* sec, indicates supernodes with unsure status, must be tested to check if they are active */
+
 
 #define IFACE_UPDATE_INTERVAL           (30) /* sec. How long it usually takes to get an IP lease. */
 #define TRANSOP_TICK_INTERVAL           (10) /* sec */
@@ -108,7 +110,7 @@ enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 #define N2N_SN_MGMT_PORT        5645
 
 /* flag used in add_sn_to_list_by_mac_or_sock */
-enum skip_add{NO_SKIP = 0, SKIP = 1, ADDED = 2};
+enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 
 #define N2N_NETMASK_STR_SIZE    16 /* dotted decimal 12 numbers + 3 dots */
 #define N2N_MACNAMSIZ           18 /* AA:BB:CC:DD:EE:FF + NULL*/

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -195,6 +195,7 @@ typedef struct n2n_PEER_INFO {
 typedef struct n2n_QUERY_PEER
 {
   n2n_mac_t           srcMac;
+  n2n_sock_t          sock;
   n2n_mac_t           targetMac;
   uint8_t             req_data; /* data we want the supernode to send back in the answer's payload (e.g. 0 = no payload, 1 = number of connected nodes ...) */
 } n2n_QUERY_PEER_t;

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -808,7 +808,7 @@ static int sort_supernodes(n2n_edge_t *eee, time_t now){
    eee->sup_attempts = N2N_EDGE_SUP_ATTEMPTS;
 
    traceEvent(TRACE_INFO, "Registering with supernode [%s][number of supernodes %d][attempts left %u]",
-    supernode_ip(eee), HASH_COUNT(eee->conf.supernodes), (unsigned int)eee->sup_attempts);
+              supernode_ip(eee), HASH_COUNT(eee->conf.supernodes), (unsigned int)eee->sup_attempts);
 
    send_register_super(eee);
    eee->sn_wait = 1;
@@ -819,13 +819,14 @@ static int sort_supernodes(n2n_edge_t *eee, time_t now){
       // this routine gets periodically called
       // it sorts supernodes in ascending order of their ping_time-fields
         HASH_SORT(eee->conf.supernodes, ping_time_sort);
-        eee->last_sweep = now;
-
-        HASH_ITER(hh, eee->conf.supernodes, scan, tmp){
-          scan->ping_time = MAX_PING_TIME;
-        }
     }
+
+    HASH_ITER(hh, eee->conf.supernodes, scan, tmp){
+      scan->ping_time = MAX_PING_TIME;
+    }
+
     send_query_peer(eee, null_mac);
+    eee->last_sweep = now;
   }
 
   return 0; /* OK */
@@ -1295,9 +1296,9 @@ static void readFromMgmtSocket(n2n_edge_t *eee, int *keep_running) {
 		      "community: %s\n",
 		      eee->conf.community_name);
   msg_len += snprintf((char *) (udp_buf + msg_len), (N2N_PKT_BUF_SIZE - msg_len),
-		      "    id    tun_tap          MAC                edge                   hint             last_seen\n");
+  	      "    id    tun_tap          MAC                edge                   hint             last_seen\n");
   msg_len += snprintf((char *) (udp_buf + msg_len), (N2N_PKT_BUF_SIZE - msg_len),
-		      "-----------------------------------------------------------------------------------------------\n");
+  	      "-----------------------------------------------------------------------------------------------\n");
 
   msg_len += snprintf((char *) (udp_buf + msg_len), (N2N_PKT_BUF_SIZE - msg_len),
 		      "supernode_forward:\n");
@@ -1307,10 +1308,10 @@ static void readFromMgmtSocket(n2n_edge_t *eee, int *keep_running) {
     if(peer->dev_addr.net_addr == 0) continue;
     net = htonl(peer->dev_addr.net_addr);
     msg_len += snprintf((char *) (udp_buf + msg_len), (N2N_PKT_BUF_SIZE - msg_len),
-			"    %-4u  %-15s  %-17s  %-21s  %-15s  %lu\n",
+			"    %-4u  %-15s  %-17s  %-21s  %-15s %lu\n",
 			++num, inet_ntoa(*(struct in_addr *) &net),
 			macaddr_str(mac_buf, peer->mac_addr),
-			sock_to_cstr(sockbuf, &(peer->sock)),
+      sock_to_cstr(sockbuf, &(peer->sock)),
       peer->dev_desc,
       now - peer->last_seen);
 
@@ -1327,10 +1328,10 @@ static void readFromMgmtSocket(n2n_edge_t *eee, int *keep_running) {
     if(peer->dev_addr.net_addr == 0) continue;
     net = htonl(peer->dev_addr.net_addr);
     msg_len += snprintf((char *) (udp_buf + msg_len), (N2N_PKT_BUF_SIZE - msg_len),
-			"    %-4u  %-15s  %-17s  %-21s  %-15s  %lu\n",
+			"    %-4u  %-15s  %-17s  %-21s  %-15s %lu\n",
 			++num, inet_ntoa(*(struct in_addr *) &net),
 			macaddr_str(mac_buf, peer->mac_addr),
-			sock_to_cstr(sockbuf, &(peer->sock)),
+      sock_to_cstr(sockbuf, &(peer->sock)),
       peer->dev_desc,
       now - peer->last_seen);
 
@@ -1913,12 +1914,12 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 	in_addr_t net;
 	char * ip_str = NULL;
 	n2n_REGISTER_SUPER_ACK_t ra;
-  uint8_t tmpbuf[MAX_AVAILABLE_SPACE_FOR_ENTRIES];
-  n2n_sock_t *tmp_sock;
-  n2n_mac_t *tmp_mac;
-  int i;
-  int skip_add;
-  struct peer_info *sn;
+        uint8_t tmpbuf[REG_SUPER_ACK_PAYLOAD_SPACE];
+        n2n_sock_t *tmp_sock;
+        n2n_mac_t *tmp_mac;
+        int i;
+        int skip_add;
+        struct peer_info *sn;
 
 	memset(&ra, 0, sizeof(n2n_REGISTER_SUPER_ACK_t));
 
@@ -1958,20 +1959,29 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 
 	    if(0 == memcmp(ra.cookie, eee->curr_sn->last_cookie, N2N_COOKIE_SIZE))
 	      {
-    tmp_sock = (void*)&tmpbuf;
-    tmp_mac = (void*)&tmpbuf[sizeof(n2n_sock_t)];
+                tmp_sock = (void*)&tmpbuf;
+                tmp_mac = (void*)&tmpbuf[sizeof(n2n_sock_t)];
 
-    for(i=0; i<ra.num_sn; i++){
-      skip_add = NO_SKIP;
-      sn = add_sn_to_list_by_mac_or_sock(&(eee->conf.supernodes), tmp_sock, tmp_mac, &skip_add);
-      if(skip_add == ADDED){
-        traceEvent(TRACE_NORMAL, "Supernode added to the list of supernodes.");
-      }
+                for(i=0; i<ra.num_sn; i++){
+                  skip_add = SN_ADD;
+                  sn = add_sn_to_list_by_mac_or_sock(&(eee->conf.supernodes), tmp_sock, tmp_mac, &skip_add);
 
-      /* REVISIT: find a more elegant expression to increase following pointers. */
-      tmp_sock = (void*)tmp_sock + ENTRY_SIZE;
-      tmp_mac = (void*)tmp_sock + sizeof(n2n_sock_t);
-    }
+                  if(skip_add == SN_ADD_ADDED){
+                    sn->ip_addr = calloc(1,N2N_EDGE_SN_HOST_SIZE);
+                    if(sn->ip_addr != NULL){
+                      inet_ntop(tmp_sock->family,
+                                (tmp_sock->family == AF_INET)?(void*)&tmp_sock->addr.v4:(void*)&tmp_sock->addr.v6,
+                                sn->ip_addr, N2N_EDGE_SN_HOST_SIZE-1);
+                      sprintf (sn->ip_addr, "%s:%u", sn->ip_addr, (uint16_t)tmp_sock->port);
+                    }
+                    sn->last_valid_time_stamp = initial_time_stamp();
+                    traceEvent(TRACE_NORMAL, "Supernode '%s' added to the list of supernodes.", sn->ip_addr);
+                  }
+
+                  /* REVISIT: find a more elegant expression to increase following pointers. */
+                  tmp_sock = (void*)tmp_sock + REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE;
+                  tmp_mac = (void*)tmp_sock + sizeof(n2n_sock_t);
+               }
 
 		eee->last_sup = now;
 		eee->sn_wait=0;
@@ -1998,7 +2008,7 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 		 * based on its NAT configuration. */
 		//eee->conf.register_interval = ra.lifetime;
 
-      eee->curr_sn->ping_time = (now - eee->last_register_req)*1000;
+                eee->curr_sn->ping_time = (now - eee->last_register_req)*1000;
 	      }
 	    else
 	      {
@@ -2026,14 +2036,14 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
       }
 
       if(!is_valid_peer_sock(&pi.sock)) {
-	      traceEvent(TRACE_DEBUG, "Skip invalid PEER_INFO %s [%s]",
-		                sock_to_cstr(sockbuf1, &pi.sock),
-		                macaddr_str(mac_buf1, pi.mac) );
-	      break;
+        traceEvent(TRACE_DEBUG, "Skip invalid PEER_INFO %s [%s]",
+		   sock_to_cstr(sockbuf1, &pi.sock),
+		   macaddr_str(mac_buf1, pi.mac) );
+	break;
       }
 
       if(memcmp(pi.mac, null_mac, sizeof(n2n_mac_t)) == 0){
-        skip_add = SKIP;
+        skip_add = SN_ADD_SKIP;
         scan = add_sn_to_list_by_mac_or_sock(&(eee->conf.supernodes), &sender, &pi.srcMac, &skip_add);
         if(scan != NULL){
           scan->ping_time = (now - eee->last_sweep)*1000;
@@ -2043,16 +2053,16 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
         HASH_FIND_PEER(eee->pending_peers, pi.mac, scan);
 
         if(scan) {
-        	scan->sock = pi.sock;
-        	traceEvent(TRACE_INFO, "Rx PEER_INFO for %s: is at %s",
-        		   macaddr_str(mac_buf1, pi.mac),
-        		   sock_to_cstr(sockbuf1, &pi.sock));
+          scan->sock = pi.sock;
+          traceEvent(TRACE_INFO, "Rx PEER_INFO for %s: is at %s",
+                     macaddr_str(mac_buf1, pi.mac),
+                     sock_to_cstr(sockbuf1, &pi.sock));
 
-        	send_register(eee, &scan->sock, scan->mac_addr);
+          send_register(eee, &scan->sock, scan->mac_addr);
 
         } else {
-        	traceEvent(TRACE_INFO, "Rx PEER_INFO unknown peer %s",
-        		   macaddr_str(mac_buf1, pi.mac) );
+          traceEvent(TRACE_INFO, "Rx PEER_INFO unknown peer %s",
+        	     macaddr_str(mac_buf1, pi.mac) );
         }
       }
       break;
@@ -2728,7 +2738,7 @@ void edge_init_conf_defaults(n2n_edge_conf_t *conf) {
   conf->register_interval = REGISTER_SUPER_INTERVAL_DFL;
   conf->tuntap_ip_mode = TUNTAP_IP_MODE_SN_ASSIGN;
   /* reserve possible last char as null terminator. */
-  gethostname((char*)conf->dev_desc, N2N_DESC_SIZE-1); 
+  gethostname((char*)conf->dev_desc, N2N_DESC_SIZE-1);
 
   if (getenv("N2N_KEY")) {
     conf->encrypt_key = strdup(getenv("N2N_KEY"));
@@ -2766,7 +2776,7 @@ int edge_conf_add_supernode(n2n_edge_conf_t *conf, const char *ip_and_port) {
     return(1);
   }
 
-  skip_add = NO_SKIP;
+  skip_add = SN_ADD;
   sn = add_sn_to_list_by_mac_or_sock(&(conf->supernodes), sock, (n2n_mac_t *)null_mac, &skip_add);
 
   if(sn != NULL){

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -301,21 +301,21 @@ struct peer_info* add_sn_to_list_by_mac_or_sock(struct peer_info **sn_list, n2n_
     if(peer == NULL) { /* zero MAC, search by socket */
       HASH_ITER(hh,*sn_list,scan,tmp) {
 	       if(memcmp(&(scan->sock), sock, sizeof(n2n_sock_t)) == 0) {
-           HASH_DEL(*sn_list, scan);
+                 HASH_DEL(*sn_list, scan);
 	         memcpy(&(scan->mac_addr), mac, sizeof(n2n_mac_t));
-           HASH_ADD_PEER(*sn_list, scan);
+                 HASH_ADD_PEER(*sn_list, scan);
 	         peer = scan;
 	         break;
 	      }
       }
 
-      if((peer == NULL) && (*skip_add == NO_SKIP)) {
+      if((peer == NULL) && (*skip_add == SN_ADD)) {
 	       peer = (struct peer_info*)calloc(1,sizeof(struct peer_info));
 	        if(peer) {
 	           memcpy(&(peer->sock),sock,sizeof(n2n_sock_t));
 	           memcpy(&(peer->mac_addr),mac, sizeof(n2n_mac_t));
 	           HASH_ADD_PEER(*sn_list, peer);
-             *skip_add = ADDED;
+                   *skip_add = SN_ADD_ADDED;
 	        }
       }
     }

--- a/src/sn.c
+++ b/src/sn.c
@@ -184,7 +184,9 @@ static void help() {
   printf("[-f] ");
 #endif
   printf("[-F <federation_name>] ");
+#if 0
   printf("[-m <mac_address>] ");
+#endif
 #ifndef WIN32
   printf("[-u <uid> -g <gid>] ");
 #endif /* ifndef WIN32 */
@@ -200,8 +202,10 @@ static void help() {
   printf("-f                | Run in foreground.\n");
 #endif /* #if defined(N2N_HAVE_DAEMON) */
   printf("-F <fed_name>     | Name of the supernodes federation (otherwise use '%s' by default)\n",(char *)FEDERATION_NAME);
+#if 0
   printf("-m <mac_addr>     | Fix MAC address for the supernode (otherwise it may be random)\n"
          "                  | eg. -m 01:02:03:04:05:06\n");
+#endif /* #if 0 */
 #ifndef WIN32
   printf("-u <UID>          | User ID (numeric) to use when privileges are dropped.\n");
   printf("-g <GID>          | Group ID (numeric) to use when privileges are dropped.\n");
@@ -272,14 +276,14 @@ static int setOption(int optkey, char *_optarg, n2n_sn_t *sss) {
 
     if(sss->federation != NULL) {
 
-      skip_add = NO_SKIP;
+      skip_add = SN_ADD;
       anchor_sn = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), socket, (n2n_mac_t*) null_mac, &skip_add);
 
       if(anchor_sn != NULL){
         anchor_sn->ip_addr = calloc(1,N2N_EDGE_SN_HOST_SIZE);
         if(anchor_sn->ip_addr){
           strncpy(anchor_sn->ip_addr,_optarg,N2N_EDGE_SN_HOST_SIZE-1);
-	        memcpy(&(anchor_sn->sock), socket, sizeof(n2n_sock_t));
+	  memcpy(&(anchor_sn->sock), socket, sizeof(n2n_sock_t));
           memcpy(&(anchor_sn->mac_addr),null_mac,sizeof(n2n_mac_t));
           anchor_sn->purgeable = SN_UNPURGEABLE;
           anchor_sn->last_valid_time_stamp = initial_time_stamp();
@@ -352,10 +356,12 @@ static int setOption(int optkey, char *_optarg, n2n_sn_t *sss) {
     break;
   }
 
+#if 0
   case 'm': {/* MAC address */
     str2mac(sss->mac_addr,_optarg);
     break;
   }
+#endif /* #if 0 */
 
   case 'c': /* community file */
     load_allowed_sn_community(sss, _optarg);

--- a/src/wire.c
+++ b/src/wire.c
@@ -288,7 +288,6 @@ int encode_REGISTER(uint8_t *base,
   }
   retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
   retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
-  retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
 
   return retval;
 }
@@ -310,7 +309,6 @@ int decode_REGISTER(n2n_REGISTER_t *reg,
   }
   retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
   retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
-  retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);
 
   return retval;
 }
@@ -326,7 +324,6 @@ int encode_REGISTER_SUPER(uint8_t *base,
   retval += encode_mac(base, idx, reg->edgeMac);
   retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
   retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
-  retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
   retval += encode_uint16(base, idx, 0); /* NULL auth scheme */
   retval += encode_uint16(base, idx, 0); /* No auth data */
 
@@ -345,7 +342,6 @@ int decode_REGISTER_SUPER(n2n_REGISTER_SUPER_t *reg,
   retval += decode_mac(reg->edgeMac, base, rem, idx);
   retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
   retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
-  retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);
   retval += decode_uint16(&(reg->auth.scheme), base, rem, idx);
   retval += decode_uint16(&(reg->auth.toksize), base, rem, idx);
   retval += decode_buf(reg->auth.token, reg->auth.toksize, base, rem, idx);
@@ -410,7 +406,7 @@ int encode_REGISTER_SUPER_ACK(uint8_t *base,
   retval += encode_uint16(base, idx, reg->lifetime);
   retval += encode_sock(base, idx, &(reg->sock));
   retval += encode_uint8(base, idx, reg->num_sn);
-  retval += encode_buf(base, idx, tmpbuf, (reg->num_sn*ENTRY_SIZE));
+  retval += encode_buf(base, idx, tmpbuf, (reg->num_sn*REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE));
 
   return retval;
 }
@@ -436,7 +432,7 @@ int decode_REGISTER_SUPER_ACK(n2n_REGISTER_SUPER_ACK_t *reg,
 
   /* Following the edge socket are an array of backup supernodes. */
   retval += decode_uint8(&(reg->num_sn), base, rem, idx);
-  retval += decode_buf(tmpbuf, (reg->num_sn*ENTRY_SIZE), base, rem, idx);
+  retval += decode_buf(tmpbuf, (reg->num_sn*REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE), base, rem, idx);
 
   return retval;
 }

--- a/src/wire.c
+++ b/src/wire.c
@@ -288,6 +288,7 @@ int encode_REGISTER(uint8_t *base,
   }
   retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
   retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
+  retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
 
   return retval;
 }
@@ -309,6 +310,7 @@ int decode_REGISTER(n2n_REGISTER_t *reg,
   }
   retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
   retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
+  retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);
 
   return retval;
 }
@@ -324,6 +326,7 @@ int encode_REGISTER_SUPER(uint8_t *base,
   retval += encode_mac(base, idx, reg->edgeMac);
   retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
   retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
+  retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
   retval += encode_uint16(base, idx, 0); /* NULL auth scheme */
   retval += encode_uint16(base, idx, 0); /* No auth data */
 
@@ -342,6 +345,7 @@ int decode_REGISTER_SUPER(n2n_REGISTER_SUPER_t *reg,
   retval += decode_mac(reg->edgeMac, base, rem, idx);
   retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
   retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
+  retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);
   retval += decode_uint16(&(reg->auth.scheme), base, rem, idx);
   retval += decode_uint16(&(reg->auth.toksize), base, rem, idx);
   retval += decode_buf(reg->auth.token, reg->auth.toksize, base, rem, idx);


### PR DESCRIPTION
Supernodes need to broadcast/forward certain packets (e.g. PACKET, REGISTER, QUERY_PEER...) in order to really fulfill the purpose for which the federation of supernodes was created: communication between supernodes and information sharing. The receiving supernodes must decide if they received from an edge or a supernode (checking `from_supernode` flag) and handle it accordingly in case they do not have any information about the requested/destination edge, that is drop or forward (including setting the `from_supernode` flag).

I added a parameter to `try_broadcast` and `try_forward` to check if the receiving packet is from an edge or another supernode. Moreover, I modified the body of `try_broadcast` because we have to make sure that a broadcast reaches the other supernodes and edges connected to them. As I said lines above, `try_broadcast` needs a `from_supernode` parameter: if set do forward to edges of community only. If unset forward to all locally known nodes and all supernodes.

Regarding QUERY_PEER packets, I used the following approach:
- packet from edge: check if peer is known (registered to that supernode). If it's registered I used the regular handling as before, otherwise set `from_supernode` and socket flags in packet common section, add socket to QUERY_PEER and forward it to other supernodes.
- packet from supernode: regular handling as before.

I also did a cleanup of the code, correcting wrong indentions and renaming some macro with more self-explicative names.

This PR fixes #481.
