### PR TITLE
fix yocto cross build error: 'string.h ' not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ endif(NOT DEFINED CMAKE_BUILD_TYPE)
 
 if (DEFINED UNIX)
 # None
-set(CMAKE_C_FLAGS "-Wall -Wshadow -Wpointer-arith -Wmissing-declarations -Wnested-externs")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wshadow -Wpointer-arith -Wmissing-declarations -Wnested-externs")
 set(CMAKE_CXX_FLAGS "-Wall -Wshadow -Wpointer-arith -Wmissing-declarations -Wnested-externs")
 # Debug 
 set(CMAKE_C_FLAGS_DEBUG "-g")


### PR DESCRIPTION
Hi,

I'm trying to add n2n as a recipe to my yocto build, but I had errors like:
```sh
| [11/38] /home/user/workspace/imx8/tmp/work/aarch64-dey-linux/n2n/git-r0/recipe-sysroot-native/usr/bin/aarch64-dey-linux/aarch64-dey-linux-gcc -DCMAKE_BUILD -DGIT_RELEASE=\"2.9.0.r746.84ec5c6\" -DN2N_HAVE_AES -DN2N_OSNAME=\"Linux\" -DN2N_VERSION=\"2.9.0.r746.84ec5c6\" -DPACKAGE_OSNAME=\"Linux\" -DPACKAGE_VERSION=\"2.9.0.r746.84ec5c6\" -I/home/user/github/n2n/. -I/home/user/github/n2n/include -Wall -Wshadow -Wpointer-arith -Wmissing-declarations -Wnested-externs -MD -MT CMakeFiles/n2n.dir/src/minilzo.c.o -MF CMakeFiles/n2n.dir/src/minilzo.c.o.d -o CMakeFiles/n2n.dir/src/minilzo.c.o   -c /home/user/github/n2n/src/minilzo.c
| FAILED: CMakeFiles/n2n.dir/src/minilzo.c.o
| /home/user/workspace/imx8/tmp/work/aarch64-dey-linux/n2n/git-r0/recipe-sysroot-native/usr/bin/aarch64-dey-linux/aarch64-dey-linux-gcc -DCMAKE_BUILD -DGIT_RELEASE=\"2.9.0.r746.84ec5c6\" -DN2N_HAVE_AES -DN2N_OSNAME=\"Linux\" -DN2N_VERSION=\"2.9.0.r746.84ec5c6\" -DPACKAGE_OSNAME=\"Linux\" -DPACKAGE_VERSION=\"2.9.0.r746.84ec5c6\" -I/home/user/github/n2n/. -I/home/user/github/n2n/include -Wall -Wshadow -Wpointer-arith -Wmissing-declarations -Wnested-externs -MD -MT CMakeFiles/n2n.dir/src/minilzo.c.o -MF CMakeFiles/n2n.dir/src/minilzo.c.o.d -o CMakeFiles/n2n.dir/src/minilzo.c.o   -c /home/user/github/n2n/src/minilzo.c
| In file included from /home/user/workspace/imx8/tmp/work/aarch64-dey-linux/n2n/git-r0/recipe-sysroot-native/usr/lib/aarch64-dey-linux/gcc/aarch64-dey-linux/8.2.0/include-fixed/syslimits.h:7,
|                  from /home/user/workspace/imx8/tmp/work/aarch64-dey-linux/n2n/git-r0/recipe-sysroot-native/usr/lib/aarch64-dey-linux/gcc/aarch64-dey-linux/8.2.0/include-fixed/limits.h:34,
|                  from /home/user/github/n2n/src/minilzo.c:45:
| /home/user/workspace/imx8/tmp/work/aarch64-dey-linux/n2n/git-r0/recipe-sysroot-native/usr/lib/aarch64-dey-linux/gcc/aarch64-dey-linux/8.2.0/include-fixed/limits.h:194:61: error: no include path in which to search for limits.h
|  #include_next <limits.h>  /* recurse down to the real one */
|                                                              ^
| /home/user/github/n2n/src/minilzo.c:3415:10: fatal error: string.h: No such file or directory
|  #include <string.h>
|           ^~~~~~~~~~
| compilation terminated.
```

I came across this post with a similar error:
https://www.yoctoproject.org/pipermail/yocto/2019-February/044087.html

I tried the solution and it also worked for n2n.

I'd like to see if it can be merged.

Thanks.