### PR TITLE
fix  Error compiling in Visual Studio 2015

### DIFF
--- a/src/n2n_regex.c
+++ b/src/n2n_regex.c
@@ -58,11 +58,11 @@
 #define MAX_CHAR_CLASS_LEN      40    /* Max length of character-class buffer in.   */
 
 
-enum { UNUSED, DOT, BEGIN, END, QUESTIONMARK, STAR, PLUS, CHAR, CHAR_CLASS, INV_CHAR_CLASS, DIGIT, NOT_DIGIT, ALPHA, NOT_ALPHA, WHITESPACE, NOT_WHITESPACE, /* BRANCH */ };
+enum { UNUSED, DOT, BEGIN, END, QUESTIONMARK, STAR, PLUS, CHAR_TYPE, CHAR_CLASS, INV_CHAR_CLASS, DIGIT, NOT_DIGIT, ALPHA, NOT_ALPHA, WHITESPACE, NOT_WHITESPACE, /* BRANCH */ };
 
 typedef struct regex_t
 {
-  unsigned char  type;   /* CHAR, STAR, etc.                      */
+  unsigned char  type;   /* CHAR_TYPE, STAR, etc.                      */
   union
   {
     unsigned char  ch;   /*      the character itself             */
@@ -183,7 +183,7 @@ re_t re_compile(const char* pattern)
             /* Escaped character, e.g. '.' */
             default:
             {
-              re_compiled[j].type = CHAR;
+              re_compiled[j].type = CHAR_TYPE;
               re_compiled[j].ch = pattern[i];
             } break;
           }
@@ -192,7 +192,7 @@ re_t re_compile(const char* pattern)
 /*
         else
         {
-          re_compiled[j].type = CHAR;
+          re_compiled[j].type = CHAR_TYPE;
           re_compiled[j].ch = pattern[i];
         }
 */
@@ -249,7 +249,7 @@ re_t re_compile(const char* pattern)
       /* Other characters: */
       default:
       {
-        re_compiled[j].type = CHAR;
+        re_compiled[j].type = CHAR_TYPE;
         re_compiled[j].ch = c;
       } break;
     }
@@ -266,7 +266,7 @@ re_t re_compile(const char* pattern)
 
 void re_print(regex_t* pattern)
 {
-  const char* types[] = { "UNUSED", "DOT", "BEGIN", "END", "QUESTIONMARK", "STAR", "PLUS", "CHAR", "CHAR_CLASS", "INV_CHAR_CLASS", "DIGIT", "NOT_DIGIT", "ALPHA", "NOT_ALPHA", "WHITESPACE" , "NOT_WHITESPACE", /* "BRANCH" */ };
+  const char* types[] = { "UNUSED", "DOT", "BEGIN", "END", "QUESTIONMARK", "STAR", "PLUS", "CHAR_TYPE", "CHAR_CLASS", "INV_CHAR_CLASS", "DIGIT", "NOT_DIGIT", "ALPHA", "NOT_ALPHA", "WHITESPACE" , "NOT_WHITESPACE", /* "BRANCH" */ };
 
   int i;
   int j;
@@ -293,7 +293,7 @@ void re_print(regex_t* pattern)
       }
       printf("]");
     }
-    else if (pattern[i].type == CHAR)
+    else if (pattern[i].type == CHAR_TYPE)
     {
       printf(" '%c'", pattern[i].ch);
     }


### PR DESCRIPTION
fix  Error compiling in Visual Studio 2015, Because the CHAR data type conflicts with the built-in data type