### PR TITLE
Implement a load-based supernode selection strategy on edges

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -156,7 +156,7 @@ typedef struct ether_hdr ether_hdr_t;
 #include "cc20.h"
 #include "speck.h"
 #include "n2n_regex.h"
-
+#include "sn_selection.h"
 #ifdef WIN32
 #define N2N_IFNAMSIZ            64
 #else
@@ -205,7 +205,7 @@ struct peer_info {
   time_t           last_seen;
   time_t           last_p2p;
   time_t           last_sent_query;
-  time_t           ping_time;
+  SN_SELECTION_CRITERION_DATA_TYPE selection_criterion;
   uint64_t         last_valid_time_stamp;
   char             *ip_addr;
 
@@ -277,7 +277,7 @@ typedef struct n2n_edge_conf {
   n2n_route_t         *routes;                /**< Networks to route through n2n */
   n2n_community_t     community_name;         /**< The community. 16 full octets. */
   n2n_desc_t          dev_desc;               /**< The device description (hint) */
-  uint8_t	            header_encryption;      /**< Header encryption indicator. */
+  uint8_t	      header_encryption;      /**< Header encryption indicator. */
   he_context_t        *header_encryption_ctx; /**< Header encryption cipher context. */
   he_context_t        *header_iv_ctx;         /**< Header IV ecnryption cipher context, REMOVE as soon as seperte fileds for checksum and replay protection available */
   n2n_transform_t     transop_id;             /**< The transop to use. */
@@ -318,8 +318,9 @@ struct n2n_edge {
   n2n_trans_op_t      transop;                 /**< The transop to use when encoding */
   n2n_route_t         *sn_route_to_clean;      /**< Supernode route to clean */
   n2n_edge_callbacks_t cb;                     /**< API callbacks */
-  void 	            *user_data;              /**< Can hold user data */
+  void 	              *user_data;              /**< Can hold user data */
   uint64_t            sn_last_valid_time_stamp;/**< last valid time stamp from supernode */
+  SN_SELECTION_CRITERION_DATA_TYPE sn_selection_criterion_common_data;
 
   /* Sockets */
   n2n_sock_t          supernode;
@@ -369,7 +370,7 @@ struct sn_community
   uint8_t	      header_encryption;      /* Header encryption indicator. */
   he_context_t        *header_encryption_ctx; /* Header encryption cipher context. */
   he_context_t        *header_iv_ctx;	      /* Header IV ecnryption cipher context, REMOVE as soon as seperate fields for checksum and replay protection available */
-  struct peer_info *edges; 		      /* Link list of registered edges. */
+  struct              peer_info *edges;       /* Link list of registered edges. */
   int64_t	      number_enc_packets;     /* Number of encrypted packets handled so far, required for sorting from time to time */
   n2n_ip_subnet_t     auto_ip_net;            /* Address range of auto ip address service. */
 

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -32,23 +32,27 @@
 /* Max available space to add supernodes' informations (sockets and MACs) in REGISTER_SUPER_ACK
  * Field sizes of REGISTER_SUPER_ACK as used in encode/decode fucntions in src/wire.c
  * REVISIT: replace 255 by DEFAULT_MTU as soon as header encryption allows for longer packets to be encrypted. */
-#define MAX_AVAILABLE_SPACE_FOR_ENTRIES \
+#define REG_SUPER_ACK_PAYLOAD_SPACE \
 	(255-(1+1+2+sizeof(n2n_common_t)+sizeof(n2n_cookie_t)+sizeof(n2n_mac_t)+1+2+4+1+sizeof(n2n_sock_t)+1)) \
 
 /* Space needed to store socket and MAC address of a supernode */
-#define ENTRY_SIZE		(sizeof(n2n_sock_t)+sizeof(n2n_mac_t))
+#define REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE		(sizeof(n2n_sock_t)+sizeof(n2n_mac_t))
 
 #define PURGE_REGISTRATION_FREQUENCY   30
 #define RE_REG_AND_PURGE_FREQUENCY     10
 #define REGISTRATION_TIMEOUT           60
-#define PURGE_FEDERATION_NODE_INTERVAL 90
 
 #define SOCKET_TIMEOUT_INTERVAL_SECS    10
 #define REGISTER_SUPER_INTERVAL_DFL     20 /* sec, usually UDP NAT entries in a firewall expire after 30 seconds */
-#define ALLOWED_TIME			20 /* sec, indicates supernodes that are proven to be alive */
-#define TEST_TIME		(PURGE_FEDERATION_NODE_INTERVAL - ALLOWED_TIME)/2 /* sec, indicates supernodes with unsure status, must be tested to check if they are alive */
-#define MAX_PING_TIME    3000  /* millisec, indicates default value for ping_time field in peer_info structure */
-#define SWEEP_TIME       30 /* sec, indicates the value after which we have to sort the hash list of supernodes in edges */
+#define SWEEP_TIME                      30 /* sec, indicates the value after which we have to sort the hash list of supernodes in edges
+                                            * and when we send out packets to query selection-relevant informations from supernodes. */
+
+/* Timeouts used in re_register_and_purge_supernodes. LAST_SEEN_SN_ACTIVE and LAST_SEEN_SN_INACTIVE
+ * values should be at least 3*SOCKET_TIMEOUT_INTERVAL_SECS apart. */
+#define LAST_SEEN_SN_ACTIVE      20 /* sec, indicates supernodes that are proven to be active */
+#define LAST_SEEN_SN_INACTIVE    90 /* sec, indicates supernodes that are proven to be inactive: they will be purged */
+#define LAST_SEEN_SN_NEW         (LAST_SEEN_SN_INACTIVE - LAST_SEEN_SN_ACTIVE)/2 /* sec, indicates supernodes with unsure status, must be tested to check if they are active */
+
 
 #define IFACE_UPDATE_INTERVAL           (30) /* sec. How long it usually takes to get an IP lease. */
 #define TRANSOP_TICK_INTERVAL           (10) /* sec */
@@ -108,7 +112,7 @@ enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 #define N2N_SN_MGMT_PORT        5645
 
 /* flag used in add_sn_to_list_by_mac_or_sock */
-enum skip_add{NO_SKIP = 0, SKIP = 1, ADDED = 2};
+enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 
 #define N2N_NETMASK_STR_SIZE    16 /* dotted decimal 12 numbers + 3 dots */
 #define N2N_MACNAMSIZ           18 /* AA:BB:CC:DD:EE:FF + NULL*/

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -52,6 +52,8 @@ typedef char    n2n_sock_str_t[N2N_SOCKBUF_SIZE];       /* tracing string buffer
 #include <sys/socket.h> /* AF_INET and AF_INET6 */
 #endif /* #if defined(WIN32) */
 
+#include "sn_selection.h"
+
 typedef enum n2n_pc
   {
    n2n_ping=0,                 /* Not used */
@@ -66,6 +68,13 @@ typedef enum n2n_pc
    n2n_peer_info=9,            /* Send info on a peer from sn to edge */
    n2n_query_peer=10           /* ask supernode for info on a peer */
   } n2n_pc_t;
+/*
+typedef enum req_data_type
+  {
+    SN_DATA_PING = 0, //No data requested, RTT measurement.
+    SN_DATA_LOAD = 1  // load-based data from supernode.
+  } n2n_req_data_type_t;
+  */
 
 #define N2N_FLAGS_OPTIONS               0x0080
 #define N2N_FLAGS_SOCKET                0x0040
@@ -189,14 +198,16 @@ typedef struct n2n_PEER_INFO {
   n2n_mac_t            srcMac;
   n2n_mac_t            mac;
   n2n_sock_t           sock;
+  SN_SELECTION_CRITERION_DATA_TYPE data;
 } n2n_PEER_INFO_t;
 
 
 typedef struct n2n_QUERY_PEER
 {
   n2n_mac_t           srcMac;
+  n2n_sock_t          sock;
   n2n_mac_t           targetMac;
-  uint8_t             req_data; /* data we want the supernode to send back in the answer's payload (e.g. 0 = no payload, 1 = number of connected nodes ...) */
+  //uint8_t             req_data; /* data we want the supernode to send back in the answer's payload (e.g. 0 = no payload, 1 = number of connected nodes ...) */
 } n2n_QUERY_PEER_t;
 
 typedef struct n2n_buf n2n_buf_t;
@@ -339,7 +350,7 @@ int decode_PACKET( n2n_PACKET_t * pkt,
 int encode_PEER_INFO( uint8_t * base,
 		      size_t * idx,
 		      const n2n_common_t * common,
-		      const n2n_PEER_INFO_t * pkt );
+		      const n2n_PEER_INFO_t * pkt);
 
 int decode_PEER_INFO( n2n_PEER_INFO_t * pkt,
 		      const n2n_common_t * cmn, /* info on how to interpret it */

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -68,13 +68,6 @@ typedef enum n2n_pc
    n2n_peer_info=9,            /* Send info on a peer from sn to edge */
    n2n_query_peer=10           /* ask supernode for info on a peer */
   } n2n_pc_t;
-/*
-typedef enum req_data_type
-  {
-    SN_DATA_PING = 0, //No data requested, RTT measurement.
-    SN_DATA_LOAD = 1  // load-based data from supernode.
-  } n2n_req_data_type_t;
-  */
 
 #define N2N_FLAGS_OPTIONS               0x0080
 #define N2N_FLAGS_SOCKET                0x0040
@@ -155,7 +148,7 @@ typedef struct n2n_PACKET
   n2n_mac_t           dstMac;
   n2n_sock_t          sock;
   uint8_t             transform;
-  uint8_t		compression;
+  uint8_t	      compression;
 } n2n_PACKET_t;
 
 /* Linked with n2n_register_super in n2n_pc_t. Only from edge to supernode. */
@@ -207,7 +200,6 @@ typedef struct n2n_QUERY_PEER
   n2n_mac_t           srcMac;
   n2n_sock_t          sock;
   n2n_mac_t           targetMac;
-  //uint8_t             req_data; /* data we want the supernode to send back in the answer's payload (e.g. 0 = no payload, 1 = number of connected nodes ...) */
 } n2n_QUERY_PEER_t;
 
 typedef struct n2n_buf n2n_buf_t;

--- a/include/sn_selection.h
+++ b/include/sn_selection.h
@@ -1,0 +1,51 @@
+/**
+ * (C) 2007-20 - ntop.org and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not see see <http://www.gnu.org/licenses/>
+ *
+ */
+
+#ifndef _SN_SELECTION_
+#define _SN_SELECTION_
+
+#define SN_SELECTION_CRITERION_DATA_TYPE   uint32_t
+#define SN_SELECTION_CRITERION_BUF_SIZE   14
+
+typedef char selection_criterion_str_t[SN_SELECTION_CRITERION_BUF_SIZE];
+
+#include "n2n.h"
+
+typedef struct n2n_edge n2n_edge_t;
+typedef struct peer_info peer_info_t;
+typedef struct n2n_sn n2n_sn_t;
+
+/* selection criterion's functions */
+int sn_selection_criterion_init(peer_info_t *peer);
+int sn_selection_criterion_default(SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion);
+int sn_selection_criterion_calculate(n2n_edge_t *eee, peer_info_t *peer, SN_SELECTION_CRITERION_DATA_TYPE *data);
+
+/* common data's functions */
+int sn_selection_criterion_common_data_default(n2n_edge_t *eee);
+
+/* sorting function */
+int sn_selection_sort(peer_info_t **peer_list);
+
+/* gathering data function */
+SN_SELECTION_CRITERION_DATA_TYPE sn_selection_criterion_gather_data(n2n_sn_t *sss);
+
+/* management port output function */
+extern char * sn_selection_criterion_str(selection_criterion_str_t out, peer_info_t *peer);
+
+
+#endif /* _SN_SELECTION_ */

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -737,16 +737,13 @@ static void send_query_peer( n2n_edge_t * eee,
   } else {
     traceEvent( TRACE_DEBUG, "send PING to supernodes" );
 
-     memcpy(tmp_pkt, pktbuf, idx);
+    if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED){
+      packet_header_encrypt (pktbuf, idx, eee->conf.header_encryption_ctx,
+                             eee->conf.header_iv_ctx,
+                             time_stamp (), pearson_hash_16 (pktbuf, idx));
+    }
 
     HASH_ITER(hh, eee->conf.supernodes, peer, tmp){
-      if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED){
-        /* Re-encrypt the orginal message again for non-repeating IV. */
-        memcpy(pktbuf, tmp_pkt, idx);
-        packet_header_encrypt (pktbuf, idx, eee->conf.header_encryption_ctx,
-    			                     eee->conf.header_iv_ctx,
-    			                     time_stamp (), pearson_hash_16 (pktbuf, idx));
-      }
       sendto_sock( eee->udp_sock, pktbuf, idx, &(peer->sock));
     }
   }

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -296,8 +296,6 @@ struct peer_info* add_sn_to_list_by_mac_or_sock(struct peer_info **sn_list, n2n_
 
     if(memcmp(mac,null_mac,sizeof(n2n_mac_t)) != 0) { /* not zero MAC */
       HASH_FIND_PEER(*sn_list, mac, peer);
-
-      //REVISIT: make this dependent from last_seen and update socket
     }
 
     if(peer == NULL) { /* zero MAC, search by socket */
@@ -314,7 +312,7 @@ struct peer_info* add_sn_to_list_by_mac_or_sock(struct peer_info **sn_list, n2n_
       if((peer == NULL) && (*skip_add == SN_ADD)) {
 	       peer = (struct peer_info*)calloc(1,sizeof(struct peer_info));
 	        if(peer) {
-             sn_selection_criterion_default(&(peer->selection_criterion));
+                   sn_selection_criterion_default(&(peer->selection_criterion));
 	           memcpy(&(peer->sock),sock,sizeof(n2n_sock_t));
 	           memcpy(&(peer->mac_addr),mac, sizeof(n2n_mac_t));
 	           HASH_ADD_PEER(*sn_list, peer);

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -18,6 +18,8 @@
 
 #include "n2n.h"
 
+#include "sn_selection.h"
+
 #include "minilzo.h"
 
 #include <assert.h>
@@ -301,21 +303,22 @@ struct peer_info* add_sn_to_list_by_mac_or_sock(struct peer_info **sn_list, n2n_
     if(peer == NULL) { /* zero MAC, search by socket */
       HASH_ITER(hh,*sn_list,scan,tmp) {
 	       if(memcmp(&(scan->sock), sock, sizeof(n2n_sock_t)) == 0) {
-           HASH_DEL(*sn_list, scan);
+                 HASH_DEL(*sn_list, scan);
 	         memcpy(&(scan->mac_addr), mac, sizeof(n2n_mac_t));
-           HASH_ADD_PEER(*sn_list, scan);
+                 HASH_ADD_PEER(*sn_list, scan);
 	         peer = scan;
 	         break;
 	      }
       }
 
-      if((peer == NULL) && (*skip_add == NO_SKIP)) {
+      if((peer == NULL) && (*skip_add == SN_ADD)) {
 	       peer = (struct peer_info*)calloc(1,sizeof(struct peer_info));
 	        if(peer) {
+             sn_selection_criterion_default(&(peer->selection_criterion));
 	           memcpy(&(peer->sock),sock,sizeof(n2n_sock_t));
 	           memcpy(&(peer->mac_addr),mac, sizeof(n2n_mac_t));
 	           HASH_ADD_PEER(*sn_list, peer);
-             *skip_add = ADDED;
+                   *skip_add = SN_ADD_ADDED;
 	        }
       }
     }

--- a/src/sn.c
+++ b/src/sn.c
@@ -186,7 +186,7 @@ static void help() {
   printf("[-F <federation_name>] ");
 #if 0
   printf("[-m <mac_address>] ");
-#endif /* #if 0 */
+#endif
 #ifndef WIN32
   printf("[-u <uid> -g <gid>] ");
 #endif /* ifndef WIN32 */
@@ -276,7 +276,7 @@ static int setOption(int optkey, char *_optarg, n2n_sn_t *sss) {
 
     if(sss->federation != NULL) {
 
-      skip_add = NO_SKIP;
+      skip_add = SN_ADD;
       anchor_sn = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), socket, (n2n_mac_t*) null_mac, &skip_add);
 
       if(anchor_sn != NULL){

--- a/src/sn_selection.c
+++ b/src/sn_selection.c
@@ -1,0 +1,123 @@
+/**
+ * (C) 2007-20 - ntop.org and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not see see <http://www.gnu.org/licenses/>
+ *
+ */
+
+#include "sn_selection.h"
+#include <stdint.h>
+
+static SN_SELECTION_CRITERION_DATA_TYPE sn_selection_criterion_common_read(n2n_edge_t *eee);
+static int sn_selection_criterion_sort(peer_info_t *a, peer_info_t *b);
+
+/* ****************************************************************************** */
+
+/* Initialize selection_criterion field in peer_info structure*/
+int sn_selection_criterion_init(peer_info_t *peer){
+  if(peer != NULL){
+    sn_selection_criterion_default(&(peer->selection_criterion));
+  }
+
+  return 0; /* OK */
+}
+
+/* Set selection_criterion field to default value according to selected strategy. */
+int sn_selection_criterion_default(SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion){
+  *selection_criterion = (SN_SELECTION_CRITERION_DATA_TYPE) UINT32_MAX >> 1;
+
+  return 0; /* OK */
+}
+
+/* Take data from PEER_INFO payload and transform them into a selection_criterion.
+ * This function is highly dependant of the chosen selection criterion.
+ */
+int sn_selection_criterion_calculate(n2n_edge_t *eee, peer_info_t *peer, SN_SELECTION_CRITERION_DATA_TYPE *data){
+  SN_SELECTION_CRITERION_DATA_TYPE common_data;
+  int sum = 0;
+
+  common_data = sn_selection_criterion_common_read(eee);
+
+  peer->selection_criterion = (SN_SELECTION_CRITERION_DATA_TYPE)(be32toh(*data) + common_data);
+
+  /* Mitigation of the real supernode load in order to see less oscillations.
+   * Edges jump from a supernode to another back and forth due to purging.
+   * Because this behavior has a cost of switching, the real load is mitigated with a stickyness factor.
+   * This factor is dynamically calculated basing on network size and prevent that unnecessary switching */
+  if(peer == eee->curr_sn){
+    sum = HASH_COUNT(eee->known_peers) + HASH_COUNT(eee->pending_peers);
+    peer->selection_criterion = peer->selection_criterion * sum / (sum + 1);
+  }
+
+  return 0; /* OK */
+}
+
+/* Set sn_selection_criterion_common_data field to default value. */
+int sn_selection_criterion_common_data_default(n2n_edge_t *eee){
+  SN_SELECTION_CRITERION_DATA_TYPE tmp = 0;
+
+  tmp = HASH_COUNT(eee->pending_peers);
+
+  if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED){
+    tmp *= 2;
+  }
+
+  eee->sn_selection_criterion_common_data = tmp / HASH_COUNT(eee->conf.supernodes);
+
+  return 0; /* OK */
+}
+
+/* Return the value of sn_selection_criterion_common_data field. */
+static SN_SELECTION_CRITERION_DATA_TYPE sn_selection_criterion_common_read(n2n_edge_t *eee){
+  return eee->sn_selection_criterion_common_data;
+}
+
+/* Function that compare two selection_criterion fields and sorts them in ascending order. */
+static int sn_selection_criterion_sort(peer_info_t *a, peer_info_t *b){
+  // comparison function for sorting supernodes in ascending order of their selection_criterion.
+  return (a->selection_criterion - b->selection_criterion);
+}
+
+/* Function that sorts peer_list using sn_selection_criterion_sort. */
+int sn_selection_sort(peer_info_t **peer_list){
+  HASH_SORT(*peer_list, sn_selection_criterion_sort);
+
+  return 0; /* OK */
+}
+
+/* Function that gathers requested data on a supernode. */
+SN_SELECTION_CRITERION_DATA_TYPE sn_selection_criterion_gather_data(n2n_sn_t *sss){
+  SN_SELECTION_CRITERION_DATA_TYPE data = 0, tmp = 0;
+  struct sn_community *comm, *tmp_comm;
+
+  HASH_ITER(hh, sss->communities, comm, tmp_comm){
+    tmp = HASH_COUNT(comm->edges) + 1; /* number of nodes in the community + the community itself. */
+    if(comm->header_encryption == HEADER_ENCRYPTION_ENABLED){ /*double-count encrypted communities (and their nodes): they exert more load on supernode. */
+      tmp *= 2;
+    }
+    data += tmp;
+  }
+
+  return htobe32(data);
+}
+
+/* Convert selection_criterion field in a string for management port output. */
+extern char * sn_selection_criterion_str(selection_criterion_str_t out, peer_info_t *peer){
+  if(NULL == out) { return NULL; }
+  memset(out, 0, SN_SELECTION_CRITERION_BUF_SIZE);
+
+  snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE -1,  "ld = %d", (short int)(peer->selection_criterion));
+
+  return out;
+}

--- a/src/wire.c
+++ b/src/wire.c
@@ -410,7 +410,7 @@ int encode_REGISTER_SUPER_ACK(uint8_t *base,
   retval += encode_uint16(base, idx, reg->lifetime);
   retval += encode_sock(base, idx, &(reg->sock));
   retval += encode_uint8(base, idx, reg->num_sn);
-  retval += encode_buf(base, idx, tmpbuf, (reg->num_sn*ENTRY_SIZE));
+  retval += encode_buf(base, idx, tmpbuf, (reg->num_sn*REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE));
 
   return retval;
 }
@@ -436,7 +436,7 @@ int decode_REGISTER_SUPER_ACK(n2n_REGISTER_SUPER_ACK_t *reg,
 
   /* Following the edge socket are an array of backup supernodes. */
   retval += decode_uint8(&(reg->num_sn), base, rem, idx);
-  retval += decode_buf(tmpbuf, (reg->num_sn*ENTRY_SIZE), base, rem, idx);
+  retval += decode_buf(tmpbuf, (reg->num_sn*REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE), base, rem, idx);
 
   return retval;
 }
@@ -517,6 +517,7 @@ int encode_PEER_INFO(uint8_t *base,
   retval += encode_mac(base, idx, pkt->srcMac);
   retval += encode_mac(base, idx, pkt->mac);
   retval += encode_sock(base, idx, &pkt->sock);
+  retval += encode_buf(base, idx, &pkt->data, sizeof(SN_SELECTION_CRITERION_DATA_TYPE));
 
   return retval;
 }
@@ -533,6 +534,7 @@ int decode_PEER_INFO(n2n_PEER_INFO_t *pkt,
   retval += decode_mac(pkt->srcMac, base, rem, idx);
   retval += decode_mac(pkt->mac, base, rem, idx);
   retval += decode_sock(&pkt->sock, base, rem, idx);
+  retval += decode_buf((uint8_t*)&pkt->data, sizeof(SN_SELECTION_CRITERION_DATA_TYPE), base, rem, idx);
 
   return retval;
 }
@@ -547,7 +549,6 @@ int encode_QUERY_PEER( uint8_t * base,
   retval += encode_common( base, idx, common );
   retval += encode_mac( base, idx, pkt->srcMac );
   retval += encode_mac( base, idx, pkt->targetMac );
-  retval += encode_uint8( base, idx, pkt->req_data);
 
   return retval;
 }
@@ -562,7 +563,6 @@ int decode_QUERY_PEER( n2n_QUERY_PEER_t * pkt,
   memset( pkt, 0, sizeof(n2n_QUERY_PEER_t) );
   retval += decode_mac( pkt->srcMac, base, rem, idx );
   retval += decode_mac( pkt->targetMac, base, rem, idx );
-  retval += decode_uint8( &pkt->req_data, base, rem, idx);
 
   return retval;
 }


### PR DESCRIPTION
This PR implements a load-based selection strategy on edges. In fact, the previous strategy based on RTT has a problem: we don't know the workload of a supernode, so an edge maybe will register itself to a supernode with a little RTT but that has many other registered edges, and so an high load,

@Logan007 and I decided to develope this strategy in a separated module `src/sn_selection.c`. That way, if someone one day will decide to change the selection strategy, should work mainly with that module without analyzing all the code to search parts that he  will have to change.

We also added a new `selection_criterion` field to `peer_info` structure. Its data type is a macro so future changes will have to modify only that line. This field stores the load, that is calculated by `sn_selection_criterion_gather_data` in `src/sn_selection.c`.

In general, the mechanism behind the selection strategy is the same (using `sort_supernodes`), so most of the differences are in new `src/sn_selection.c` module. In that module we implemented functions to initialize and set to default  `selection_criterion`, to set the selection criterion value according to data inside PEER_INFO packet, to sort the list of supernodes on edge an to calculate the load of a supernode in PEER_INFO handling on supernode.

This PR fixes #482.