### PR TITLE
use payload struct for assembly

### DIFF
--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1075,8 +1075,8 @@ static int process_udp(n2n_sn_t * sss,
       n2n_REGISTER_SUPER_ACK_t        ack;
       n2n_common_t                    cmn2;
       uint8_t                         ackbuf[N2N_SN_PKTBUF_SIZE];
-      uint8_t	                        tmpbuf[REG_SUPER_ACK_PAYLOAD_SPACE];
-      uint8_t                         *tmp_dst;
+      uint8_t	                      tmpbuf[REG_SUPER_ACK_PAYLOAD_SPACE];
+      n2n_REGISTER_SUPER_ACK_payload_t *payload;
       size_t                          encx=0;
       struct sn_community             *fed;
       struct sn_community_regular_expression *re, *tmp_re;
@@ -1194,7 +1194,7 @@ static int process_udp(n2n_sn_t * sss,
     skip = (skip < 0) ? 0 : n2n_rand_sqr(skip);
 
 	/* Assembling supernode list for REGISTER_SUPER_ACK payload */
-	tmp_dst = tmpbuf;
+        payload = (n2n_REGISTER_SUPER_ACK_payload_t*)tmpbuf;
 	HASH_ITER(hh, sss->federation->edges, peer, tmp_peer) {
           if(skip){
 	    skip--;
@@ -1207,10 +1207,10 @@ static int process_udp(n2n_sn_t * sss,
                                                                             * their SN_ACTIVE time before they get re-registred to. */
 
 	  if(((++num)*REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE) > REG_SUPER_ACK_PAYLOAD_SPACE) break; /* no more space available in REGISTER_SUPER_ACK payload */
-	  memcpy(tmp_dst, &(peer->sock), sizeof(n2n_sock_t));
-	  tmp_dst += sizeof(n2n_sock_t);
-	  memcpy(tmp_dst, &(peer->mac_addr), sizeof(n2n_mac_t));
-	  tmp_dst += sizeof(n2n_mac_t);
+	  memcpy(&(payload->sock), &(peer->sock), sizeof(n2n_sock_t));
+	  memcpy(&(payload->mac),  &(peer->mac_addr), sizeof(n2n_mac_t));
+	  // shift to next payload entry
+	  payload++;
 	}
 	ack.num_sn = num;
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1075,7 +1075,7 @@ static int process_udp(n2n_sn_t * sss,
       n2n_REGISTER_SUPER_ACK_t        ack;
       n2n_common_t                    cmn2;
       uint8_t                         ackbuf[N2N_SN_PKTBUF_SIZE];
-      uint8_t	                      tmpbuf[REG_SUPER_ACK_PAYLOAD_SPACE];
+      uint8_t                         payload_buf[REG_SUPER_ACK_PAYLOAD_SPACE];
       n2n_REGISTER_SUPER_ACK_payload_t *payload;
       size_t                          encx=0;
       struct sn_community             *fed;
@@ -1194,7 +1194,7 @@ static int process_udp(n2n_sn_t * sss,
     skip = (skip < 0) ? 0 : n2n_rand_sqr(skip);
 
 	/* Assembling supernode list for REGISTER_SUPER_ACK payload */
-        payload = (n2n_REGISTER_SUPER_ACK_payload_t*)tmpbuf;
+        payload = (n2n_REGISTER_SUPER_ACK_payload_t*)payload_buf;
 	HASH_ITER(hh, sss->federation->edges, peer, tmp_peer) {
           if(skip){
 	    skip--;
@@ -1223,7 +1223,7 @@ static int process_udp(n2n_sn_t * sss,
 	  update_edge(sss, &reg, comm, &(ack.sock), now);
 	}
 
-	encode_REGISTER_SUPER_ACK(ackbuf, &encx, &cmn2, &ack, tmpbuf);
+	encode_REGISTER_SUPER_ACK(ackbuf, &encx, &cmn2, &ack, payload_buf);
 
 	if (comm->header_encryption == HEADER_ENCRYPTION_ENABLED)
 	  packet_header_encrypt (ackbuf, encx, comm->header_encryption_ctx,


### PR DESCRIPTION
As a follow-up to #501, this pull request changes the REG_SUPER_ACK payload assembly to use the newly added struct rendering the code more readable.