### PR TITLE
Protection mechanism against duplicated MACs

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -22,12 +22,13 @@
 #define MSG_TYPE_PACKET                 3
 #define MSG_TYPE_REGISTER_ACK           4
 #define MSG_TYPE_REGISTER_SUPER         5
-#define MSG_TYPE_REGISTER_SUPER_ACK     6
-#define MSG_TYPE_REGISTER_SUPER_NAK     7
-#define MSG_TYPE_FEDERATION             8
-#define MSG_TYPE_PEER_INFO              9
-#define MSG_TYPE_QUERY_PEER            10
-#define MSG_TYPE_MAX_TYPE	       10
+#define MSG_TYPE_UNREGISTER_SUPER       6
+#define MSG_TYPE_REGISTER_SUPER_ACK     7
+#define MSG_TYPE_REGISTER_SUPER_NAK     8
+#define MSG_TYPE_FEDERATION             9
+#define MSG_TYPE_PEER_INFO              10
+#define MSG_TYPE_QUERY_PEER             11
+#define MSG_TYPE_MAX_TYPE	        11
 
 /* Max available space to add supernodes' informations (sockets and MACs) in REGISTER_SUPER_ACK
  * Field sizes of REGISTER_SUPER_ACK as used in encode/decode fucntions in src/wire.c

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -28,7 +28,7 @@
 #define MSG_TYPE_FEDERATION             9
 #define MSG_TYPE_PEER_INFO              10
 #define MSG_TYPE_QUERY_PEER             11
-#define MSG_TYPE_MAX_TYPE	        11
+#define MSG_TYPE_MAX_TYPE	       11
 
 /* Max available space to add supernodes' informations (sockets and MACs) in REGISTER_SUPER_ACK
  * Field sizes of REGISTER_SUPER_ACK as used in encode/decode fucntions in src/wire.c

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -164,6 +164,11 @@ typedef struct n2n_sock
   } addr;
 } n2n_sock_t;
 
+typedef enum {
+  n2n_auth_none = 0,
+  n2n_auth_simple_id = 1
+} n2n_auth_init_t;
+
 typedef struct n2n_auth
 {
   uint16_t    scheme;                         /* What kind of auth */
@@ -284,6 +289,7 @@ struct peer_info {
   n2n_desc_t       dev_desc;
   n2n_sock_t       sock;
   n2n_cookie_t     last_cookie;
+  n2n_auth_t       auth;
   int              timeout;
   uint8_t          purgeable;
   time_t           last_seen;
@@ -472,6 +478,7 @@ typedef struct n2n_edge_conf {
   int                 register_ttl;           /**< TTL for registration packet when UDP NAT hole punching through supernode. */
   int                 local_port;
   int                 mgmt_port;
+  n2n_auth_t          token;
 #ifdef FILTER_TRAFFIC
   filter_rule_t       *network_traffic_filter_rules;
 #endif

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -164,10 +164,19 @@ typedef struct n2n_sock
   } addr;
 } n2n_sock_t;
 
-typedef enum {
+typedef enum 
+{
   n2n_auth_none = 0,
   n2n_auth_simple_id = 1
 } n2n_auth_scheme_t;
+
+typedef enum
+{
+  update_edge_no_change = 0,
+  update_edge_sock_change = 1,
+  update_edge_new_sn = 2,
+  update_edge_auth_fail = -1
+} update_edge_ret_value_t;
 
 typedef struct n2n_auth
 {

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -167,7 +167,7 @@ typedef struct n2n_sock
 typedef enum {
   n2n_auth_none = 0,
   n2n_auth_simple_id = 1
-} n2n_auth_init_t;
+} n2n_auth_scheme_t;
 
 typedef struct n2n_auth
 {
@@ -260,7 +260,7 @@ typedef struct n2n_REGISTER_SUPER_ACK_payload {
 /* Linked with n2n_unregister_super in n2n_pc_t. */
 typedef struct n2n_UNREGISTER_SUPER
 {
-  n2n_cookie_t cookie;
+  n2n_auth_t auth;
   n2n_mac_t srcMac;
 } n2n_UNREGISTER_SUPER_t;
 

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -255,6 +255,7 @@ typedef struct n2n_REGISTER_SUPER_ACK {
 typedef struct n2n_REGISTER_SUPER_NAK
 {
   n2n_cookie_t        cookie;         /* Return cookie from REGISTER_SUPER */
+  n2n_mac_t           srcMac;
 } n2n_REGISTER_SUPER_NAK_t;
 
 

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -257,7 +257,6 @@ typedef struct n2n_UNREGISTER_SUPER
 {
   n2n_cookie_t cookie;
   n2n_mac_t srcMac;
-  n2n_sock_t sock;
 } n2n_UNREGISTER_SUPER_t;
 
 

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -119,11 +119,12 @@ typedef enum n2n_pc
    n2n_packet=3,               /* PACKET data content */
    n2n_register_ack=4,         /* ACK of a registration from edge to edge */
    n2n_register_super=5,       /* Register edge to supernode */
-   n2n_register_super_ack=6,   /* ACK from supernode to edge */
-   n2n_register_super_nak=7,   /* NAK from supernode to edge - registration refused */
-   n2n_federation=8,           /* Not used by edge */
-   n2n_peer_info=9,            /* Send info on a peer from sn to edge */
-   n2n_query_peer=10           /* ask supernode for info on a peer */
+   n2n_unregister_super=6,     /* Deregister edge from supernode */
+   n2n_register_super_ack=7,   /* ACK from supernode to edge */
+   n2n_register_super_nak=8,   /* NAK from supernode to edge - registration refused */
+   n2n_federation=9,           /* Not used by edge */
+   n2n_peer_info=10,           /* Send info on a peer from sn to edge */
+   n2n_query_peer=11           /* ask supernode for info on a peer */
   } n2n_pc_t;
 
 #define N2N_FLAGS_OPTIONS               0x0080
@@ -249,6 +250,15 @@ typedef struct n2n_REGISTER_SUPER_ACK_payload {
   n2n_sock_t           sock;          /**< socket of supernode */
   n2n_mac_t            mac;           /**< MAC of supernode */
 } n2n_REGISTER_SUPER_ACK_payload_t;
+
+
+/* Linked with n2n_unregister_super in n2n_pc_t. */
+typedef struct n2n_UNREGISTER_SUPER
+{
+  n2n_cookie_t cookie;
+  n2n_mac_t srcMac;
+  n2n_sock_t sock;
+} n2n_UNREGISTER_SUPER_t;
 
 
 typedef struct n2n_PEER_INFO {

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -478,7 +478,7 @@ typedef struct n2n_edge_conf {
   int                 register_ttl;           /**< TTL for registration packet when UDP NAT hole punching through supernode. */
   int                 local_port;
   int                 mgmt_port;
-  n2n_auth_t          token;
+  n2n_auth_t          auth;
 #ifdef FILTER_TRAFFIC
   filter_rule_t       *network_traffic_filter_rules;
 #endif

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -607,6 +607,7 @@ typedef struct n2n_sn
   struct sn_community *communities;
   struct sn_community_regular_expression *rules;
   struct sn_community *federation;
+  n2n_auth_t auth;
 } n2n_sn_t;
 
 

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -227,6 +227,7 @@ typedef struct n2n_PACKET
 typedef struct n2n_REGISTER_SUPER {
   n2n_cookie_t        cookie;         /**< Link REGISTER_SUPER and REGISTER_SUPER_ACK */
   n2n_mac_t           edgeMac;        /**< MAC to register with edge sending socket */
+  n2n_sock_t          sock;           /**< Sending socket associated with srcMac */
   n2n_ip_subnet_t     dev_addr;       /**< IP address of the tuntap adapter. */
   n2n_desc_t          dev_desc;       /**< Hint description correlated with the edge */
   n2n_auth_t          auth;           /**< Authentication scheme and tokens */

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -131,6 +131,17 @@ int decode_REGISTER_SUPER( n2n_REGISTER_SUPER_t * pkt,
                            size_t * rem,
                            size_t * idx );
 
+int encode_UNREGISTER_SUPER(uint8_t *base,
+                            size_t *idx,
+                            const n2n_common_t *common,
+                            const n2n_UNREGISTER_SUPER_t *unreg);
+
+int decode_UNREGISTER_SUPER(n2n_UNREGISTER_SUPER_t *unreg,
+                            const n2n_common_t *cmn, /* info on how to interpret it */
+                            const uint8_t *base,
+                            size_t *rem,
+                            size_t *idx);
+
 int encode_REGISTER_ACK( uint8_t * base,
                          size_t * idx,
                          const n2n_common_t * common,

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -165,6 +165,17 @@ int decode_REGISTER_SUPER_ACK( n2n_REGISTER_SUPER_ACK_t * reg,
                                size_t * rem,
                                size_t * idx,
                                uint8_t * tmpbuf);
+                               
+int encode_REGISTER_SUPER_NAK( uint8_t * base,
+                               size_t * idx,
+                               const n2n_common_t * cmn,
+                               const n2n_REGISTER_SUPER_NAK_t * nak);
+
+int decode_REGISTER_SUPER_NAK( n2n_REGISTER_SUPER_NAK_t * nak,
+                               const n2n_common_t * cmn, /* info on how to interpret it */
+                               const uint8_t * base,
+                               size_t * rem,
+                               size_t * idx);
 
 int fill_sockaddr( struct sockaddr * addr,
                    size_t addrlen,

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1070,18 +1070,6 @@ void update_supernode_reg(n2n_edge_t * eee, time_t nowTime) {
 
 /* ************************************** */
 
-/** NOT IMPLEMENTED
- *
- *  This would send a DEREGISTER packet to a peer edge or supernode to indicate
- *  the edge is going away.
- */
-static void send_deregister(n2n_edge_t * eee,
-                            n2n_sock_t * remote_peer) {
-  /* Marshall and send message */
-}
-
-/* ************************************** */
-
 /** Return the IP address of the current supernode in the ring. */
 static const char * supernode_ip(const n2n_edge_t * eee) {
   return (eee->curr_sn->ip_addr);
@@ -2345,7 +2333,7 @@ int run_edge_loop(n2n_edge_t * eee, int *keep_running) {
   WaitForSingleObject(tun_read_thread, INFINITE);
 #endif
 
-  send_deregister(eee, &(eee->supernode));
+  send_unregister_super(eee);
 
   closesocket(eee->udp_sock);
 
@@ -2356,8 +2344,6 @@ int run_edge_loop(n2n_edge_t * eee, int *keep_running) {
 
 /** Deinitialise the edge and deallocate any owned memory. */
 void edge_term(n2n_edge_t * eee) {
-
-  send_unregister_super(eee);
 
   if(eee->udp_sock >= 0)
     closesocket(eee->udp_sock);

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -261,12 +261,12 @@ n2n_edge_t* edge_init(const n2n_edge_conf_t *conf, int *rv) {
   eee->udp_sock = -1;
   eee->udp_mgmt_sock = -1;
 
-  eee->conf.token.scheme = n2n_auth_simple_id;
+  eee->conf.auth.scheme = n2n_auth_simple_id;
 
   for (idx = 0; idx < N2N_AUTH_TOKEN_SIZE; ++idx)
-    eee->conf.token.token[idx] = n2n_rand() % 0xff;
+    eee->conf.auth.token[idx] = n2n_rand() % 0xff;
 
-  eee->conf.token.toksize = sizeof(eee->conf.token.token);
+  eee->conf.auth.toksize = sizeof(eee->conf.auth.token);
 
 #ifndef SKIP_MULTICAST_PEERS_DISCOVERY
   eee->udp_multicast_sock = -1;
@@ -784,7 +784,7 @@ static void send_register_super(n2n_edge_t *eee) {
   reg.dev_addr.net_addr = ntohl(eee->device.ip_addr);
   reg.dev_addr.net_bitlen = mask2bitlen(ntohl(eee->device.device_mask));
   memcpy(reg.dev_desc, eee->conf.dev_desc, N2N_DESC_SIZE);
-  memcpy(&(reg.auth), &(eee->conf.token), sizeof(n2n_auth_t));
+  memcpy(&(reg.auth), &(eee->conf.auth), sizeof(n2n_auth_t));
 
   idx = 0;
   encode_mac(reg.edgeMac, &idx, eee->device.mac_addr);
@@ -820,7 +820,7 @@ static void send_unregister_super(n2n_edge_t *eee){
   cmn.flags = 0;
   memcpy(cmn.community, eee->conf.community_name, N2N_COMMUNITY_SIZE);
 
-  memcpy(&(unreg.auth), &(eee->conf.token), sizeof(n2n_auth_t));
+  memcpy(&(unreg.auth), &(eee->conf.auth), sizeof(n2n_auth_t));
 
   idx = 0;
   encode_mac(unreg.srcMac, &idx, eee->device.mac_addr);

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -804,7 +804,7 @@ static void send_unregister_super(n2n_edge_t *eee){
   n2n_sock_str_t sockbuf;
 
   memset(&cmn, 0, sizeof(cmn));
-  memset(&reg, 0, sizeof(unreg));
+  memset(&unreg, 0, sizeof(unreg));
 
   cmn.ttl = N2N_DEFAULT_TTL;
   cmn.pc = n2n_unregister_super;

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -261,12 +261,12 @@ n2n_edge_t* edge_init(const n2n_edge_conf_t *conf, int *rv) {
   eee->udp_sock = -1;
   eee->udp_mgmt_sock = -1;
 
-  eee->token.scheme = n2n_auth_simple_id;
+  eee->conf.token.scheme = n2n_auth_simple_id;
 
   for (idx = 0; idx < N2N_AUTH_TOKEN_SIZE; ++idx)
-    eee->token.token[idx] = n2n_rand() % 0xff;
+    eee->conf.token.token[idx] = n2n_rand() % 0xff;
 
-  eee->token.toksize = sizeof(eee->token.token);
+  eee->conf.token.toksize = sizeof(eee->conf.token.token);
 
 #ifndef SKIP_MULTICAST_PEERS_DISCOVERY
   eee->udp_multicast_sock = -1;
@@ -784,7 +784,7 @@ static void send_register_super(n2n_edge_t *eee) {
   reg.dev_addr.net_addr = ntohl(eee->device.ip_addr);
   reg.dev_addr.net_bitlen = mask2bitlen(ntohl(eee->device.device_mask));
   memcpy(reg.dev_desc, eee->conf.dev_desc, N2N_DESC_SIZE);
-  memcpy(reg.auth, eee->token, sizeof(n2n_auth_t));
+  memcpy(&(reg.auth), &(eee->conf.token), sizeof(n2n_auth_t));
 
   idx = 0;
   encode_mac(reg.edgeMac, &idx, eee->device.mac_addr);

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2135,6 +2135,33 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 	  }
 	break;
       }
+    case MSG_TYPE_REGISTER_SUPER_NAK: {
+      n2n_REGISTER_SUPER_NAK_t nak;
+      struct peer_info *peer, *scan;
+
+      memset(&nak, 0, sizeof(n2n_REGISTER_SUPER_NAK_t));
+      
+      decode_REGISTER_SUPER_NAK(&nak, &cmn, udp_buf, &rem, &idx);
+      
+      traceEvent(TRACE_INFO, "Rx REGISTER_SUPER_NAK");
+      
+      if((memcmp(&(nak.srcMac), &(eee->device.mac_addr), sizeof(n2n_mac_t))) == 0){
+        traceEvent(TRACE_INFO, "%s is already used. Stopping the program", macaddr_str(mac_buf1, nak.srcMac));
+        exit(1);
+      } else {
+        HASH_FIND_PEER(eee->known_peers, nak.srcMac, peer);
+        if(peer != NULL){
+          HASH_DEL(eee->known_peers, peer);
+        }
+        
+        HASH_FIND_PEER(eee->pending_peers, nak.srcMac, scan);
+        if(scan != NULL){
+          HASH_DEL(eee->pending_peers, scan);
+        }
+      }
+      
+      break;
+    }
     case MSG_TYPE_PEER_INFO: {
       n2n_PEER_INFO_t pi;
       struct peer_info *  scan;

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2146,7 +2146,7 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
       traceEvent(TRACE_INFO, "Rx REGISTER_SUPER_NAK");
       
       if((memcmp(&(nak.srcMac), &(eee->device.mac_addr), sizeof(n2n_mac_t))) == 0){
-        traceEvent(TRACE_INFO, "%s is already used. Stopping the program", macaddr_str(mac_buf1, nak.srcMac));
+        traceEvent(TRACE_ERROR, "%s is already used. Stopping the program.", macaddr_str(mac_buf1, nak.srcMac));
         exit(1);
       } else {
         HASH_FIND_PEER(eee->known_peers, nak.srcMac, peer);

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -811,16 +811,10 @@ static void send_unregister_super(n2n_edge_t *eee){
   cmn.flags = 0;
   memcpy(cmn.community, eee->conf.community_name, N2N_COMMUNITY_SIZE);
 
-  for (idx = 0; idx < N2N_COOKIE_SIZE; ++idx)
-    eee->curr_sn->last_cookie[idx] = n2n_rand() % 0xff;
-
   memcpy(unreg.cookie, eee->curr_sn->last_cookie, N2N_COOKIE_SIZE);
 
   idx = 0;
   encode_mac(unreg.srcMac, &idx, eee->device.mac_addr);
-
-  idx = 0;
-  encode_sock(unreg.sock, &idx, eee->udp_sock);
 
   idx = 0;
   encode_UNREGISTER_SUPER(pktbuf, &idx, &cmn, &unreg);
@@ -842,11 +836,10 @@ static int sort_supernodes(n2n_edge_t *eee, time_t now){
   struct peer_info *scan, *tmp;
 
   if(eee->curr_sn != eee->conf.supernodes){
+    send_unregister_super(eee);
+    
     eee->curr_sn = eee->conf.supernodes;
     memcpy(&eee->supernode, &(eee->curr_sn->sock), sizeof(n2n_sock_t));
-
-    send_unregister_super(eee);
-
     eee->sup_attempts = N2N_EDGE_SUP_ATTEMPTS;
 
     traceEvent(TRACE_INFO, "Registering with supernode [%s][number of supernodes %d][attempts left %u]",

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -820,7 +820,7 @@ static void send_unregister_super(n2n_edge_t *eee){
   cmn.flags = 0;
   memcpy(cmn.community, eee->conf.community_name, N2N_COMMUNITY_SIZE);
 
-  memcpy(unreg.cookie, eee->curr_sn->last_cookie, N2N_COOKIE_SIZE);
+  memcpy(&(unreg.auth), &(eee->conf.token), sizeof(n2n_auth_t));
 
   idx = 0;
   encode_mac(unreg.srcMac, &idx, eee->device.mac_addr);

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -359,7 +359,8 @@ static uint16_t reg_lifetime(n2n_sn_t *sss)
   * with the one received from the packet.
   */
 static int auth_edge(n2n_auth_t *auth1, n2n_auth_t *auth2){
-  return (memcmp(auth1, auth2, sizeof(n2n_auth_t)));
+  /* 0 = success (tokens are equal). */
+  return (memcmp(auth1, auth2, sizeof(n2n_auth_t))); 
 }
 
 /** Update the edge table with the details of the edge which contacted the
@@ -425,6 +426,8 @@ static int update_edge(n2n_sn_t *sss,
 		    sock_to_cstr(sockbuf, sender_sock));
       }
     } else {
+      memcpy(&(scan->last_cookie), reg->cookie, sizeof(N2N_COOKIE_SIZE));
+      
       traceEvent(TRACE_DEBUG, "update_edge unchanged %s ==> %s",
 		 macaddr_str(mac_buf, reg->edgeMac),
 		 sock_to_cstr(sockbuf, sender_sock));

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -295,15 +295,16 @@ int sn_init(n2n_sn_t *sss) {
     packet_header_setup_key(sss->federation->community, &(sss->federation->header_encryption_ctx), &(sss->federation->header_iv_ctx));
     sss->federation->edges = NULL;
   }
-  
+
+  n2n_srand (n2n_seed());
+	
+  /* Random auth token */
   sss->auth.scheme = n2n_auth_simple_id;
 
   for (idx = 0; idx < N2N_AUTH_TOKEN_SIZE; ++idx)
     sss->auth.token[idx] = n2n_rand() % 0xff;
 
   sss->auth.toksize = sizeof(sss->auth.token);
-
-  n2n_srand (n2n_seed());
 
   /* Random MAC address */
   for(i=0; i<6; i++) {

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -370,7 +370,7 @@ static int update_edge(n2n_sn_t *sss,
 	     sock_to_cstr(sockbuf, sender_sock));
 
   HASH_FIND_PEER(comm->edges, reg->edgeMac, scan);
-	
+
   // if unknown, make sure it is also not known by IP address
   if (NULL == scan) {
     HASH_ITER(hh,comm->edges,iter,tmp) {
@@ -383,7 +383,7 @@ static int update_edge(n2n_sn_t *sss,
       }
     }
   }
-  
+
   if (NULL == scan) {
     /* Not known */
 
@@ -1242,7 +1242,53 @@ static int process_udp(n2n_sn_t * sss,
         return -1;
       }
       break;
+  }
+	case MSG_TYPE_UNREGISTER_SUPER: {
+		n2n_UNREGISTER_SUPER_t unreg;
+		struct sn_community    *comm;
+		struct peer_info       *peer, *tmp;
+
+
+		memset(&unreg, 0, sizeof(n2n_UNREGISTER_SUPER_t));
+
+		if(!comm) {
+      traceEvent(TRACE_DEBUG, "process_udp UNREGISTER_SUPER with unknown community %s", cmn.community);
+      return -1;
     }
+
+    if((from_supernode == 0) != (comm->is_federation == IS_NO_FEDERATION)) {
+      traceEvent(TRACE_DEBUG, "process_udp dropped UNREGISTER_SUPER: from_supernode value doesn't correspond to the internal federation marking.");
+      return -1;
+    }
+
+		decode_UNREGISTER_SUPER(&unreg, &cmn, udp_buf, &rem. &idx);
+
+		if (comm) {
+      if(comm->header_encryption == HEADER_ENCRYPTION_ENABLED) {
+        if(!find_edge_time_stamp_and_verify (comm->edges, from_supernode, unreg.srcMac, stamp, TIME_STAMP_NO_JITTER)) {
+	  traceEvent(TRACE_DEBUG, "process_udp dropped UNREGISTER_SUPER due to time stamp error.");
+	  return -1;
+	}
+      }
+    }
+
+		traceEvent(TRACE_DEBUG, "Rx UNREGISTER_SUPER from %s [%s]",
+	 macaddr_str(mac_buf, unreg.srcMac),
+	 sock_to_cstr(sockbuf, &(unreg.sock)));
+
+	 HASH_FIND_COMMUNITY(sss->communities, cmn.community, comm);
+
+	 if(comm != NULL){
+		 HASH_ITER(hh, comm->edges, peer, tmp){
+			 if((memcmp(peer->mac_addr, unreg.srcMac, sizeof(n2n_mac_t)) == 0) &&
+		      (memcmp(peer->sock, unreg.sock, sizeof(n2n_sock_t)) == 0){
+				    HASH_DEL(comm->edges, peer);
+			 }
+		 }
+	 }
+	 
+    break;
+	}
   case MSG_TYPE_REGISTER_SUPER_ACK: {
     n2n_REGISTER_SUPER_ACK_t        ack;
     size_t                          encx=0;
@@ -1259,7 +1305,7 @@ static int process_udp(n2n_sn_t * sss,
     uint8_t			    dec_tmpbuf[REG_SUPER_ACK_PAYLOAD_SPACE];
     int                             skip_add;
     n2n_REGISTER_SUPER_ACK_payload_t *payload;
-    
+
     memset(&sender, 0, sizeof(n2n_sock_t));
     sender.family = AF_INET;
     sender.port = ntohs(sender_sock->sin_port);

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1261,7 +1261,7 @@ static int process_udp(n2n_sn_t * sss,
       return -1;
     }
 
-    decode_UNREGISTER_SUPER(&unreg, &cmn, udp_buf, &rem. &idx);
+    decode_UNREGISTER_SUPER(&unreg, &cmn, udp_buf, &rem, &idx);
 
     if (comm) {
       if(comm->header_encryption == HEADER_ENCRYPTION_ENABLED) {

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -396,7 +396,7 @@ static int update_edge(n2n_sn_t *sss,
     memcpy((char*)scan->dev_desc, reg->dev_desc, N2N_DESC_SIZE);
     memcpy(&(scan->sock), sender_sock, sizeof(n2n_sock_t));
     memcpy(&(scan->last_cookie), reg->cookie, sizeof(N2N_COOKIE_SIZE));
-		memcpy(&(scan->auth), reg->auth, sizeof(n2n_auth_t));
+    memcpy(&(scan->auth), &(reg->auth), sizeof(n2n_auth_t));
     scan->last_valid_time_stamp = initial_time_stamp();
 
     HASH_ADD_PEER(comm->edges, scan);

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -396,6 +396,7 @@ static int update_edge(n2n_sn_t *sss,
     memcpy((char*)scan->dev_desc, reg->dev_desc, N2N_DESC_SIZE);
     memcpy(&(scan->sock), sender_sock, sizeof(n2n_sock_t));
     memcpy(&(scan->last_cookie), reg->cookie, sizeof(N2N_COOKIE_SIZE));
+		memcpy(&(scan->auth), reg->auth, sizeof(n2n_auth_t));
     scan->last_valid_time_stamp = initial_time_stamp();
 
     HASH_ADD_PEER(comm->edges, scan);
@@ -1280,7 +1281,7 @@ static int process_udp(n2n_sn_t * sss,
         HASH_DEL(comm->edges, peer);
       }
     }
-	 
+
     break;
   }
   case MSG_TYPE_REGISTER_SUPER_ACK: {

--- a/src/wire.c
+++ b/src/wire.c
@@ -327,8 +327,9 @@ int encode_REGISTER_SUPER(uint8_t *base,
   retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
   retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
   retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
-  retval += encode_uint16(base, idx, 0); /* NULL auth scheme */
-  retval += encode_uint16(base, idx, 0); /* No auth data */
+  retval += encode_uint16(base, idx, reg->auth.scheme); 
+  retval += encode_uint16(base, idx, reg->auth.toksize);
+  retval += encode_buf(base, idx, reg->auth.token, reg->auth.toksize);
 
   return retval;
 }

--- a/src/wire.c
+++ b/src/wire.c
@@ -481,6 +481,7 @@ int encode_REGISTER_SUPER_NAK(uint8_t *base,
   int retval = 0;
   retval += encode_common(base, idx, common);
   retval += encode_buf(base, idx, nak->cookie, N2N_COOKIE_SIZE);  
+  retval += encode_mac(base, idx, nak->srcMac);
   
   return retval;                        
 }
@@ -494,6 +495,7 @@ int decode_REGISTER_SUPER_NAK(n2n_REGISTER_SUPER_NAK_t *nak,
   size_t retval = 0;
   memset(nak, 0, sizeof(n2n_REGISTER_SUPER_NAK_t));
   retval += decode_buf(nak->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+  retval += decode_mac(nak->srcMac, base, rem, idx);
   
   return retval;                        
 }

--- a/src/wire.c
+++ b/src/wire.c
@@ -373,7 +373,7 @@ int decode_UNREGISTER_SUPER(n2n_UNREGISTER_SUPER_t *unreg,
                           size_t *idx){
   size_t retval = 0;
   memset(unreg, 0, sizeof(n2n_UNREGISTER_SUPER_t));
-  retval += encode_buf(base, idx, unreg->cookie, N2N_COOKIE_SIZE);
+  retval += decode_buf(unreg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
   retval += decode_mac(unreg->srcMac, base, rem, idx);
 
   return retval;

--- a/src/wire.c
+++ b/src/wire.c
@@ -361,7 +361,6 @@ int encode_UNREGISTER_SUPER(uint8_t *base,
   retval += encode_common(base, idx, common);
   retval += encode_buf(base, idx, unreg->cookie, N2N_COOKIE_SIZE);
   retval += encode_mac(base, idx, unreg->srcMac);
-  retval += encode_sock(base, idx &(unreg->sock));
 
   return retval;
 }
@@ -376,7 +375,6 @@ int decode_UNREGISTER_SUPER(n2n_UNREGISTER_SUPER_t *unreg,
   memset(unreg, 0, sizeof(n2n_UNREGISTER_SUPER_t));
   retval += encode_buf(base, idx, unreg->cookie, N2N_COOKIE_SIZE);
   retval += decode_mac(unreg->srcMac, base, rem, idx);
-  retval += decode_sock(&(unreg->sock), base, rem, idx);
 
   return retval;
 }

--- a/src/wire.c
+++ b/src/wire.c
@@ -353,6 +353,35 @@ int decode_REGISTER_SUPER(n2n_REGISTER_SUPER_t *reg,
 }
 
 
+int encode_UNREGISTER_SUPER(uint8_t *base,
+                          size_t *idx,
+                          const n2n_common_t *common,
+                          const n2n_UNREGISTER_SUPER_t *unreg){
+  int retval = 0;
+  retval += encode_common(base, idx, common);
+  retval += encode_buf(base, idx, unreg->cookie, N2N_COOKIE_SIZE);
+  retval += encode_mac(base, idx, unreg->srcMac);
+  retval += encode_sock(base, idx &(unreg->sock));
+
+  return retval;
+}
+
+
+int decode_UNREGISTER_SUPER(n2n_UNREGISTER_SUPER_t *unreg,
+                          const n2n_common_t *cmn, /* info on how to interpret it */
+                          const uint8_t *base,
+                          size_t *rem,
+                          size_t *idx){
+  size_t retval = 0;
+  memset(unreg, 0, sizeof(n2n_UNREGISTER_SUPER_t));
+  retval += encode_buf(base, idx, unreg->cookie, N2N_COOKIE_SIZE);
+  retval += decode_mac(unreg->srcMac, base, rem, idx);
+  retval += decode_sock(&(unreg->sock), base, rem, idx);
+
+  return retval;
+}
+
+
 int encode_REGISTER_ACK(uint8_t *base,
                         size_t *idx,
                         const n2n_common_t *common,

--- a/src/wire.c
+++ b/src/wire.c
@@ -474,6 +474,31 @@ int decode_REGISTER_SUPER_ACK(n2n_REGISTER_SUPER_ACK_t *reg,
 }
 
 
+int encode_REGISTER_SUPER_NAK(uint8_t *base,
+                        size_t *idx,
+                        const n2n_common_t *common,
+                        const n2n_REGISTER_SUPER_NAK_t *nak) {
+  int retval = 0;
+  retval += encode_common(base, idx, common);
+  retval += encode_buf(base, idx, nak->cookie, N2N_COOKIE_SIZE);  
+  
+  return retval;                        
+}
+
+
+int decode_REGISTER_SUPER_NAK(n2n_REGISTER_SUPER_NAK_t *nak,
+                              const n2n_common_t *cmn, /* info on how to interpret it */
+                              const uint8_t *base,
+                              size_t *rem,
+                              size_t *idx) {
+  size_t retval = 0;
+  memset(nak, 0, sizeof(n2n_REGISTER_SUPER_NAK_t));
+  retval += decode_buf(nak->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+  
+  return retval;                        
+}
+
+
 int fill_sockaddr( struct sockaddr * addr,
                    size_t addrlen,
                    const n2n_sock_t * sock )

--- a/src/wire.c
+++ b/src/wire.c
@@ -360,7 +360,9 @@ int encode_UNREGISTER_SUPER(uint8_t *base,
                           const n2n_UNREGISTER_SUPER_t *unreg){
   int retval = 0;
   retval += encode_common(base, idx, common);
-  retval += encode_buf(base, idx, unreg->cookie, N2N_COOKIE_SIZE);
+  retval += encode_uint16(base, idx, unreg->auth.scheme); 
+  retval += encode_uint16(base, idx, unreg->auth.toksize);
+  retval += encode_buf(base, idx, unreg->auth.token, unreg->auth.toksize);
   retval += encode_mac(base, idx, unreg->srcMac);
 
   return retval;
@@ -374,7 +376,9 @@ int decode_UNREGISTER_SUPER(n2n_UNREGISTER_SUPER_t *unreg,
                           size_t *idx){
   size_t retval = 0;
   memset(unreg, 0, sizeof(n2n_UNREGISTER_SUPER_t));
-  retval += decode_buf(unreg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+  retval += decode_uint16(&(unreg->auth.scheme), base, rem, idx);
+  retval += decode_uint16(&(unreg->auth.toksize), base, rem, idx);
+  retval += decode_buf(unreg->auth.token, unreg->auth.toksize, base, rem, idx);
   retval += decode_mac(unreg->srcMac, base, rem, idx);
 
   return retval;

--- a/src/wire.c
+++ b/src/wire.c
@@ -324,6 +324,9 @@ int encode_REGISTER_SUPER(uint8_t *base,
   retval += encode_common(base, idx, common);
   retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
   retval += encode_mac(base, idx, reg->edgeMac);
+  if (0 != reg->sock.family) {
+    retval += encode_sock(base, idx, &(reg->sock));
+  }
   retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
   retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
   retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
@@ -344,6 +347,9 @@ int decode_REGISTER_SUPER(n2n_REGISTER_SUPER_t *reg,
   memset(reg, 0, sizeof(n2n_REGISTER_SUPER_t));
   retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
   retval += decode_mac(reg->edgeMac, base, rem, idx);
+  if (cmn->flags & N2N_FLAGS_SOCKET) {
+    retval += decode_sock(&(reg->sock), base, rem, idx);
+  }
   retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
   retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
   retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);


### PR DESCRIPTION
@Logan007  and I implemented a protection mechanism against duplicated MACs and MAC spoofing. To realize this feature, we used a new type of message (UNREGISTER_SUPER) and we used also the existing REGISTER_SUPER_NAK message and `update_edge` function.

When a new edge registers to a supernode, it sends a REGISTER_SUPER packet. Inside this packet, there is an `auth` field, so we added this field also in `n2n_sn_t` and `n2n_edge_t` structures in order to store that value. Auth fields on edge and supernode are randomly initialized inside `sn_init` and `edge_init` functions. With the auth field, we were able to implement an authentication mechanism.

When a supernode receives a REGISTER_SUPER packet, calls `update_edge` and in this function we added the comparison between auth tokens. If authentication fails, supernode will send a REGISTER_SUPER_NAK packet to edge. Otherwise, it will broadcast REGISTER_SUPER packet so other supernodes in the network will be able to authenticate that edge, too. 

In REGISTER_SUPER_NAK handling on supernode, we used HASH_FIND_PEER to find that spoofed edge and we removed it from the list. In REGISTER_SUPER_NAK handling on edge we compared the auth field received from the packet with the auth field in `n2n_edge_t` and if they are equal, edge is stopped with a log message. If auth tokens are different, we searched that edge inside `known_peers` and `pending_peers`.

On edge, we added a new `send_unregister_super` function that sends this new message. This function is called when an edge swtiches from a supernode to another one and when an edge ends.

This PR fixes #505 .