### PR TITLE
Protection mechanism against MAC spoofing

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1063,6 +1063,18 @@ void update_supernode_reg(n2n_edge_t * eee, time_t nowTime) {
 
 /* ************************************** */
 
+/** NOT IMPLEMENTED
+ *
+ *  This would send a DEREGISTER packet to a peer edge or supernode to indicate
+ *  the edge is going away.
+ */
+static void send_deregister(n2n_edge_t * eee,
+                            n2n_sock_t * remote_peer) {
+  /* Marshall and send message */
+}
+
+/* ************************************** */
+
 /** Return the IP address of the current supernode in the ring. */
 static const char * supernode_ip(const n2n_edge_t * eee) {
   return (eee->curr_sn->ip_addr);
@@ -2340,6 +2352,8 @@ int run_edge_loop(n2n_edge_t * eee, int *keep_running) {
 #ifdef WIN32
   WaitForSingleObject(tun_read_thread, INFINITE);
 #endif
+	
+  send_deregister(eee, &(eee->supernode));
 
   closesocket(eee->udp_sock);
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2102,10 +2102,7 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
                   // shfiting to the next payload entry
                   payload++;
 		}
-
-		eee->last_sup = now;
-		eee->sn_wait=0;
-		eee->sup_attempts = N2N_EDGE_SUP_ATTEMPTS; /* refresh because we got a response */
+		    
 		if (eee->conf.tuntap_ip_mode == TUNTAP_IP_MODE_SN_ASSIGN) {
 		  if ((ra.dev_addr.net_addr != 0) && (ra.dev_addr.net_bitlen != 0)) {
 		    net = htonl(ra.dev_addr.net_addr);

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -809,6 +809,7 @@ static void send_register_super(n2n_edge_t *eee) {
   reg.dev_addr.net_addr = ntohl(eee->device.ip_addr);
   reg.dev_addr.net_bitlen = mask2bitlen(ntohl(eee->device.device_mask));
   memcpy(reg.dev_desc, eee->conf.dev_desc, N2N_DESC_SIZE);
+  reg.auth.scheme = 0; /* No auth yet */
 
   idx = 0;
   encode_mac(reg.edgeMac, &idx, eee->device.mac_addr);
@@ -1803,7 +1804,7 @@ void edge_read_from_tap(n2n_edge_t * eee) {
 	    len = tmp_len;
 	  }
 	      
-	  if (!eee->last_sup) {
+	   if (!eee->last_sup) {
             // drop packets before first registration with supernode
             traceEvent(TRACE_DEBUG, "DROP packet before first registration with supernode");
             return;
@@ -1920,7 +1921,7 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 	  }
 	}
 	      
-	if (!eee->last_sup) {
+	 if (!eee->last_sup) {
           // drop packets received before first registration with supernode
           traceEvent(TRACE_DEBUG, "readFromIPSocket dropped PACKET recevied before first registration with supernode.");
           return;
@@ -2120,7 +2121,7 @@ void readFromIPSocket(n2n_edge_t * eee, int in_sock) {
 		  }
 		}
 		    
-		if (!eee->last_sup) // send gratuitous ARP only upon first registration with supernode
+		 if (!eee->last_sup) // send gratuitous ARP only upon first registration with supernode
                   send_grat_arps(eee);
 
 		eee->last_sup = now;


### PR DESCRIPTION
This PR implements a protection mechanism for edges against MAC spoofing. In fact, if an edge suddenly goes crazy and start to send packets with random MAC (e.g. I tried to randomize REGISTER'S MAC), on the edge management port output we can see the list of peers exploding.

So I defined a new `find_peer_by_sock` function that search by socket inside `pending_peers` and `known_peers` before a peer is really added. That way, if a MAC change, we still can find that node and do not create a new one, thus, no exploding lists. I called this new function in parts of the code where it used HASH_FIND_PEER, right after it just like a second chance to find the peer.

Concerning supernodes, they are already able to cope with changing MACs because of searching by TAP IP implemented in `update_edge`. They are also supported by the auth mechanism implemented in #509.
