### PR TITLE
Fix the problem of running edge, IP or domain name resolution failure under Windows system

### DIFF
--- a/src/edge.c
+++ b/src/edge.c
@@ -771,6 +771,9 @@ int main(int argc, char* argv[]) {
 #ifdef HAVE_LIBCAP
   cap_t caps;
 #endif
+#ifdef WIN32
+	initWin32();
+#endif
 
   /* Defaults */
   edge_init_conf_defaults(&conf);
@@ -954,6 +957,10 @@ int main(int argc, char* argv[]) {
   edge_term_conf(&eee->conf);
   tuntap_close(&eee->device);
   edge_term(eee);
+
+#ifdef WIN32
+	destroyWin32();
+#endif
 
   return(rc);
 }

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -191,9 +191,6 @@ n2n_edge_t* edge_init(const n2n_edge_conf_t *conf, int *rv) {
     goto edge_init_error;
   }
 
-#ifdef WIN32
-  initWin32();
-#endif
 
   memcpy(&eee->conf, conf, sizeof(*conf));
   eee->curr_sn = eee->conf.supernodes;

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -277,7 +277,7 @@ int supernode2sock(n2n_sock_t * sn, const n2n_sn_name_t addrIn) {
 	freeaddrinfo(ainfo); /* free everything allocated by getaddrinfo(). */
 	ainfo = NULL;
       } else {
-      traceEvent(TRACE_WARNING, "Failed to resolve supernode host %s", supernode_host);
+      traceEvent(TRACE_WARNING, "Failed to resolve supernode host %s, %d: %s", supernode_host, nameerr, gai_strerror(nameerr));
       rv = -2;
     }
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -351,6 +351,10 @@ void sn_term(n2n_sn_t *sss)
     }
     free(re);
   }
+
+#ifdef WIN32
+	destroyWin32();
+#endif
 }
 
 /** Determine the appropriate lifetime for new registrations.

--- a/win32/wintap.c
+++ b/win32/wintap.c
@@ -20,6 +20,11 @@ void initWin32() {
   }
 }
 
+
+void destroyWin32() {
+	WSACleanup();
+}
+
 struct win_adapter_info {
   HANDLE handle;
   char adapterid[1024];

--- a/win32/wintap.h
+++ b/win32/wintap.h
@@ -64,6 +64,7 @@
 #define TAP_COMPONENT_ID "tap0801"
 
 extern void initWin32();
+extern void destroyWin32();
 extern void win_print_available_adapters();
 
 #endif


### PR DESCRIPTION

Windows operating system needs to use WSAStartup() initial socket version, WSAStartup() is initialized in edge_init(), but WSAStartup() is not initialized before calling getaddrinfo() in supernode2sock() for the first time, resulting in IP resolution failure .