### PR TITLE
fix AES default

### DIFF
--- a/src/edge.c
+++ b/src/edge.c
@@ -149,7 +149,7 @@ static void help () {
                  "[-h]\n\n");
 
 #if defined(N2N_CAN_NAME_IFACE)
-    printf("-d <tap device>                    | tap device name\n");
+    printf("-d <tap device>          | tap device name\n");
 #endif
 
     printf("-a [mode:]<address>[/nn] | Interface address and optional subnet (cidr, default /24). For DHCP use '-r -a dhcp:0.0.0.0'\n");
@@ -168,11 +168,11 @@ static void help () {
     printf("-f                       | Do not fork and run as a daemon; rather run in foreground.\n");
 #endif /* #ifndef WIN32 */
     printf("-m <MAC address>         | Fix MAC address for the TAP interface (otherwise it may be random)\n"
-                 "                   | eg. -m 01:02:03:04:05:06\n");
+           "                         | eg. -m 01:02:03:04:05:06\n");
     printf("-M <mtu>                 | Specify n2n MTU of edge interface (default %d).\n", DEFAULT_MTU);
 #ifndef __APPLE__
     printf("-D                       | Enable PMTU discovery. PMTU discovery can reduce fragmentation but\n"
-                 "                   | causes connections stall when not properly supported.\n");
+           "                         | causes connections stall when not properly supported.\n");
 #endif
     printf("-r                       | Enable packet forwarding through n2n community.\n");
     printf("-A1                      | Disable payload encryption. Do not use with key (defaulting to AES then).\n");

--- a/src/edge.c
+++ b/src/edge.c
@@ -175,9 +175,9 @@ static void help () {
                  "                   | causes connections stall when not properly supported.\n");
 #endif
     printf("-r                       | Enable packet forwarding through n2n community.\n");
-    printf("-A1                      | Disable payload encryption. Do not use with key (defaulting to Twofish then).\n");
-    printf("-A2 ... -A5 or -A        | Choose a cipher for payload encryption, requires a key: -A2 = Twofish (default),\n");
-    printf("                         | -A3 or -A (deprecated) = AES, "
+    printf("-A1                      | Disable payload encryption. Do not use with key (defaulting to AES then).\n");
+    printf("-A2 ... -A5 or -A        | Choose a cipher for payload encryption, requires a key: -A2 = Twofish,\n");
+    printf("                         | -A3 or -A (deprecated) = AES (default), "
            "-A4 = ChaCha20, "
            "-A5 = Speck-CTR.\n");
     printf("-H                       | Enable full header encryption. Requires supernode with fixed community.\n");
@@ -792,9 +792,9 @@ int main (int argc, char* argv[]) {
 
     if(conf.transop_id == N2N_TRANSFORM_ID_NULL) {
         if(conf.encrypt_key) {
-            /* make sure that Twofish is default cipher if key only (and no cipher) is specified */
-            traceEvent(TRACE_WARNING, "Switching to Twofish as key was provided.");
-            conf.transop_id = N2N_TRANSFORM_ID_TWOFISH;
+            /* make sure that AES is default cipher if key only (and no cipher) is specified */
+            traceEvent(TRACE_WARNING, "Switching to AES as key was provided.");
+            conf.transop_id = N2N_TRANSFORM_ID_AES;
         }
     }
 


### PR DESCRIPTION
As per documentation and earlier changes, AES is supposed to be the default cipher for edge's payload encryption. This PR fixes another two places where this change was not reflected in the code yet.