### PR TITLE
added optional rtt based supernode selection: federation

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -137,3 +137,13 @@ which then will include ZSTD if found on the system. It will be available via `-
 `./configure --with-zstd --with-openssl CFLAGS="-O3 -march=native"`
 
 Again, and this needs to be reiterated sufficiently often, please do no forget to `make clean` after (re-)configuration and before building (again) using `make`.
+
+## Federation – Supernode Selection by Round Trip Time
+
+If used with multiple supernodes, by default, an edge choses the least loaded supernode to connect to. This selection strategy is part of the [federation](Federation.md) feature and aims at a fair workload distribution among the supernodes. To serve special scenarios, an edge can be compiled to always connect to the supernode with the lowest round trip time, i.e. the "closest" with the lowest ping. However, this could result in not so fair workload distribution among supernodes. This option can be configured by defining the macro `SN_SELECTION_RTT` and affects edge's behaviour only:
+
+`./configure CFLAGS="-DSN_SELECTION_RTT"`
+
+which of course can be combined with the compiler optimizations mentioned above…
+
+Note that the activation of this strategy requires a sufficiently accurate local day-of-time clock. It probably will fail on smaller systems using `uclibc` (instead of `glibc`) whose day-of-time clock is said to not provide sub-second accuracy.

--- a/doc/Federation.md
+++ b/doc/Federation.md
@@ -1,4 +1,4 @@
-﻿# Supernode Federation
+# Supernode Federation
 
 ## Idea
 To enhance resilience in terms of backup and fail-over, also for load-balancing, multiple supernodes can easily interconnect and form a special community, called **federation**.
@@ -33,3 +33,5 @@ Once edges have saved those informations, it is up to them choosing the supernod
 An edge connects to the supernode with the lowest work-load and it is re-considered from time to time, with each re-registration. We used a stickyness factor to avoid too much jumping between supernodes.
 
 Thanks to this last feature, n2n is now able to handle security attacks (e.g., DoS against supernodes) and it can redistribute the entire load of the network in a fair manner between all the supernodes.
+
+To serve scenarios in which an edge is supposed to select the supernode by round trip time, i.e. choosing the "closest" one, a [compile-time option](Building.md) is offered. Note, that workload distribution among supernodes is not so fair then.

--- a/src/sn_selection.c
+++ b/src/sn_selection.c
@@ -137,6 +137,7 @@ SN_SELECTION_CRITERION_DATA_TYPE sn_selection_criterion_gather_data (n2n_sn_t *s
     return htobe32(data);
 }
 
+
 /* Convert selection_criterion field in a string for management port output. */
 extern char * sn_selection_criterion_str (selection_criterion_str_t out, peer_info_t *peer) {
 


### PR DESCRIPTION
This pull request adds the compile-time option to chose edges conduct rtt based supernode selection in a federation scenario.

The changes to `sn_selection.c` look heavier than they actually are due to CR handling applied to the file.