### PR TITLE
simplified conf file parsing

### DIFF
--- a/doc/Advanced.md
+++ b/doc/Advanced.md
@@ -1,6 +1,10 @@
 # Advanced Configuration
 
 
+## Configuration Files
+
+Read about [Configuration Files](ConfigurationFiles.md) as they might come in handy – especially, but not limited to, if edges or supernodes shall be run as a service (see below) or in case of bulk automated parameter generation for mass deployment.
+
 ## Running edge as a Service
 
 edge can also be run as a service instead of cli:

--- a/doc/ConfigurationFiles.md
+++ b/doc/ConfigurationFiles.md
@@ -1,0 +1,73 @@
+# Configuration Files
+
+To help deployment of locally different configurations, n2n supports the use of configuration files for `edge` and `supernode`.
+
+They are plain text files and contain the desired command line options, **one per line**.
+
+The exemplary command line
+
+```bash
+sudo edge -c mynetwork -k mysecretpass -a 192.168.100.1 -f -l supernode.ntop.org:7777
+```
+
+translates into the following `edge.conf` file:
+
+```
+-c mynetwork
+-k mysecretpass
+-a 192.168.100.1
+-f
+-l supernode.ntop.org:7777
+```
+
+which can be loaded by
+
+```
+sudo ./edge edge.conf
+```
+
+The `.conf` file syntax also allows `=` between parameter and its option:
+
+```
+-c=mynetwork
+-k=mysecretpass
+-a=192.168.100.1
+-f
+-l=supernode.ntop.org:7777
+```
+
+When used with `=`, there is no whitespace allowed between parameter, delimter (`=`), and option. So, do **not** put `-c = mynetwork` – it is required to be `-c=mynetwork`.
+
+Comment lines starting with a hash '#' are ignored.
+
+```
+# automated edge configuration
+# created by bot7
+# on April 31, 2038 – 1800Z
+-c    mynetwork
+-k    mysecretpass
+-a    192.168.100.1
+-f
+# --- supernode section ---
+-l    supernode.ntop.org:7777
+```
+
+Long options can be used as well. Please note the double minus/dash character `--`, just like on command line:
+
+```
+# automated edge configuration
+# created by bot7
+# on April 31, 2038 – 1800Z
+--community    mynetwork
+-k             mysecretpass
+-a             192.168.100.1
+-f
+# --- supernode section ---
+-l             supernode.ntop.org:7777
+```
+
+If using a configuration file, its filename needs to be supplied as first parameter to `edge` or `supernode`. If required, additional command line parameters can be supplied afterwards:
+
+```
+sudo edge edge.conf -A5
+```


### PR DESCRIPTION
This pull request uses the regular command line parsing to digest configuration file content. Little string parsing is applied for allowing the current `=` syntax but also whitespaces instead. The code is much simpler now.

As regular command line parsing is applied, the programs do not output the "key" and optional "value" strings as read from the file anymore. _EDIT: It did not do it before, that part already has been commented as I have learned by now._ Let me know if that was not just for debugging but more a requirement (we could output `line_vec[1]` and `line_vec[2]`).

Also, some documentation is added.

Finally, a reported segfault is fixed.

Fixes #561.