### PR TITLE
cleaned up mac type usage

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -1,5 +1,5 @@
 /**
- * (C) 2007-20 - ntop.org and contributors
+ * (C) 2007-21 - ntop.org and contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -193,7 +193,9 @@ uint8_t mask2bitlen (uint32_t mask);
 char* macaddr_str (macstr_t buf, const n2n_mac_t mac);
 int str2mac (uint8_t * outmac /* 6 bytes */, const char * s);
 int supernode2sock (n2n_sock_t * sn, const n2n_sn_name_t addrIn);
-uint8_t is_multi_broadcast (const uint8_t * dest_mac);
+uint8_t is_multi_broadcast (const n2n_mac_t dest_mac);
+uint8_t is_broadcast (const n2n_mac_t dest_mac);
+uint8_t is_null_mac (const n2n_mac_t dest_mac);
 char* msg_type2str (uint16_t msg_type);
 void hexdump (const uint8_t * buf, size_t len);
 void print_n2n_version ();
@@ -248,7 +250,7 @@ int comm_init (struct sn_community *comm, char *cmn);
 int sn_init (n2n_sn_t *sss);
 void sn_term (n2n_sn_t *sss);
 int supernode2sock (n2n_sock_t * sn, const n2n_sn_name_t addrIn);
-struct peer_info* add_sn_to_list_by_mac_or_sock (struct peer_info **sn_list, n2n_sock_t *sock, n2n_mac_t *mac, int *skip_add);
+struct peer_info* add_sn_to_list_by_mac_or_sock (struct peer_info **sn_list, n2n_sock_t *sock, const n2n_mac_t mac, int *skip_add);
 int run_sn_loop (n2n_sn_t *sss, int *keep_running);
 int assign_one_ip_subnet (n2n_sn_t *sss, struct sn_community *comm);
 const char* compression_str (uint8_t cmpr);

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -1,5 +1,5 @@
 /**
- * (C) 2007-20 - ntop.org and contributors
+ * (C) 2007-21 - ntop.org and contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +26,13 @@ typedef uint8_t n2n_mac_t[N2N_MAC_SIZE];
 typedef uint8_t n2n_cookie_t[N2N_COOKIE_SIZE];
 typedef uint8_t n2n_desc_t[N2N_DESC_SIZE];
 typedef char    n2n_sock_str_t[N2N_SOCKBUF_SIZE]; /* tracing string buffer */
+
+// those are definitely not typedefs (with a view to the filename) but neither are they defines
+static const n2n_mac_t broadcast_mac      = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+static const n2n_mac_t multicast_mac      = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0x00 }; /* First 3 bytes are meaningful */
+static const n2n_mac_t ipv6_multicast_mac = { 0x33, 0x33, 0x00, 0x00, 0x00, 0x00 }; /* First 2 bytes are meaningful */
+static const n2n_mac_t null_mac           = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include "getopt.h"

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -1,5 +1,5 @@
 /**
- * (C) 2007-20 - ntop.org and contributors
+ * (C) 2007-21 - ntop.org and contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -86,7 +86,7 @@ int encode_mac (uint8_t * base,
                 size_t * idx,
                 const n2n_mac_t m);
 
-int decode_mac (uint8_t * out, /* of size N2N_MAC_SIZE. This clearer than passing a n2n_mac_t */
+int decode_mac (n2n_mac_t out,
                 const uint8_t * base,
                 size_t * rem,
                 size_t * idx);

--- a/src/sn.c
+++ b/src/sn.c
@@ -24,7 +24,6 @@
 #define HASH_FIND_COMMUNITY(head, name, out) HASH_FIND_STR(head, name, out)
 
 static n2n_sn_t sss_node;
-static const n2n_mac_t null_mac = {0, 0, 0, 0, 0, 0};
 
 /** Load the list of allowed communities. Existing/previous ones will be removed
  *
@@ -285,14 +284,14 @@ static int setOption (int optkey, char *_optarg, n2n_sn_t *sss) {
             if(sss->federation != NULL) {
 
                 skip_add = SN_ADD;
-                anchor_sn = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), socket, (n2n_mac_t*) null_mac, &skip_add);
+                anchor_sn = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), socket, null_mac, &skip_add);
 
                 if(anchor_sn != NULL) {
                     anchor_sn->ip_addr = calloc(1, N2N_EDGE_SN_HOST_SIZE);
                     if(anchor_sn->ip_addr) {
                         strncpy(anchor_sn->ip_addr, _optarg, N2N_EDGE_SN_HOST_SIZE - 1);
 	                      memcpy(&(anchor_sn->sock), socket, sizeof(n2n_sock_t));
-                        memcpy(&(anchor_sn->mac_addr), null_mac, sizeof(n2n_mac_t));
+                        memcpy(anchor_sn->mac_addr, null_mac, sizeof(n2n_mac_t));
                         anchor_sn->purgeable = SN_UNPURGEABLE;
                         anchor_sn->last_valid_time_stamp = initial_time_stamp();
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -1,5 +1,5 @@
 /**
- * (C) 2007-20 - ntop.org and contributors
+ * (C) 2007-21 - ntop.org and contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -179,7 +179,7 @@ int encode_mac (uint8_t * base,
     return encode_buf(base, idx, m, N2N_MAC_SIZE);
 }
 
-int decode_mac (uint8_t * out, /* of size N2N_MAC_SIZE. This clearer than passing a n2n_mac_t */
+int decode_mac (n2n_mac_t out, /* n2n_mac_t is typedefed array type which is always passed by reference */
                 const uint8_t * base,
                 size_t * rem,
                 size_t * idx) {


### PR DESCRIPTION
This pull request aims at making a more uniform use of `n2n_mac_t`. It also offers a new `is_null_mac()` function which helps to not get confused from the counter-intuitive `memcmp()` return value (`0` in case of equality, think of `if(memcmp(my_mac, null_mac)) { ... }`) which might mislead the programmer or reader.

Constant mac addresses occurring multiple times were consolidated into `include/n2n_typedefs.h`.