### PR TITLE
quick-fixed auto ip

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -816,7 +816,7 @@ static void send_query_peer (n2n_edge_t * eee,
 /* ******************************************************** */
 
 /** Send a REGISTER_SUPER packet to the current supernode. */
-static void send_register_super (n2n_edge_t *eee) {
+void send_register_super (n2n_edge_t *eee) {
 
     uint8_t pktbuf[N2N_PKT_BUF_SIZE] = {0};
     size_t idx;


### PR DESCRIPTION
This pull request fixes a condition in which edges could end up being blocked while trying to draw auto ip address in multiple supernode scenarios (even though at least one supernode is available).

The edge now checks on every supernode. This is performed manually as the `update_supernode_reg()` mechanism (including sweeping) does not work completely so early during start-up (we would need to re-build the main loop).

The blocking will not occur anymore. However, if multiple supernodes are used, enabling auto ip might result in a few seconds of an unregistered state (if one of the federated supernodes provided via cli is down) once directly after start-up. This,in turn, will be addressed in a rework of edge's bootstrap. That might comprise moving the auto ip part (and tun_tap conf, and privilege drop) into a more stateful main-loop. Later...

Fixes #584.