### PR TITLE
removed duplicate field for supernode socket from edge

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -628,7 +628,7 @@ struct n2n_edge {
     SN_SELECTION_CRITERION_DATA_TYPE sn_selection_criterion_common_data;
 
     /* Sockets */
-    n2n_sock_t                       supernode;
+    /* supernode socket is in        eee->curr_sn->sock (of type n2n_sock_t) */
     int                              udp_sock;
     int                              udp_mgmt_sock;                      /**< socket for status info. */
 

--- a/src/edge.c
+++ b/src/edge.c
@@ -818,7 +818,6 @@ int main (int argc, char* argv[]) {
                 eee->curr_sn = eee->curr_sn->hh.next;
             else
                 eee->curr_sn = eee->conf.supernodes;
-            memcpy(&eee->supernode, &(eee->curr_sn->sock), sizeof(n2n_sock_t));
 
             send_register_super(eee);
 


### PR DESCRIPTION
As we now handle several supernodes and  `curr_sn` always points to the current supernode, its socket can always be found in `curr_sn->sock`. There is no need to keep the extra field `supernode` of type `n2n_sock_t` (which always gets updated on current supernode change, same content).