### PR TITLE
enhanced header encryption to full 128 bit iv

### DIFF
--- a/doc/Communities.md
+++ b/doc/Communities.md
@@ -3,9 +3,9 @@
 
 ## Names
 
-As communities designate virtual networks, they must be distingushable from each other. Its their name that makes them distinguishable and which therefore should be unique per network. The community name is composed of 15 byte-sized characters and it internally always is terminated by an additional zero character totalling up to 16 characters. Hence, the zero character cannot be part of the regular community name. There are some other characters that cannot be used, namely `. * + ? [ ] \`.
+As communities designate virtual networks, they must be distingushable from each other. Its their name that makes them distinguishable and which therefore should be unique per network. The community name is composed of 19 byte-sized characters and it internally always is terminated by an additional zero character totalling up to 20 characters. Hence, the zero character cannot be part of the regular community name. There are some other characters that cannot be used, namely `. * + ? [ ] \`.
 
-To make full use of character space, hex values could be used, e.g. from Linux bash applying the `edge … -c $(echo -en '\x3a\x3b\x4a\x6a\xfa') …` command line syntax. If used with a configuration file, the bytes must be directly filled as characters into a corresponding `-c=:;Jjþ` line.
+To make full use of character space, hex values could be used, e.g. from Linux bash applying the `edge … -c $(echo -en '\x3a\x3b\x4a\x6a\xfa') …` command line syntax. If used with a configuration file, the bytes must be directly filled as characters into a corresponding `-c :;Jjþ` line.
 
 
 ## Restrict Supernode Access

--- a/doc/Hacking.md
+++ b/doc/Hacking.md
@@ -2,9 +2,9 @@
 
 --------
 
-This program and document is free software; you can redistribute 
-it and/or modify it under the terms of the GNU General Public License 
-as published by the Free Software Foundation; either version 3 of the 
+This program and document is free software; you can redistribute
+it and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 3 of the
 License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
@@ -212,25 +212,27 @@ Version 3
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 12 ! ... Community ...                                             :
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-16 ! ... Community ...                                             !
+16 ! ... Community ...                                             :
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-20 ! Source MAC Address                                            :
+20 ! ... Community ...                                             !
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-24 :                               ! Destination MAC Address       :
+24 ! Source MAC Address                                            :
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-28 :                                                               !
+28 :                               ! Destination MAC Address       :
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-32 ! Socket Flags (v=IPv4)         ! Destination UDP Port          !
+32 :                                                               !
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-36 ! Destination IPv4 Address                                      !
+36 ! Socket Flags (v=IPv4)         ! Destination UDP Port          !
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-40 ! Compress'n ID !  Transform ID !
+40 ! Destination IPv4 Address                                      !
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+44 ! Compress'n ID !  Transform ID !
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-44 ! Payload
+48 ! Payload
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 
-So each n2n PACKET has a 44 byte overhead. For a 1500 byte ethernet packet this
+So each n2n PACKET has a 48 byte overhead. For a 1500 byte ethernet packet this
 is roughly 3%.
 
 Socket flags provides support for IPv6. In this case the PACKET message ends as
@@ -238,19 +240,19 @@ follows:
 
 ```
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-32 ! Socket Flags (v=IPv6)         ! Destination UDP Port          !
+36 ! Socket Flags (v=IPv6)         ! Destination UDP Port          !
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-36 ! Destination IPv6 Address                                      :
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-40 :                                                               :
+40 ! Destination IPv6 Address                                      :
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 44 :                                                               :
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-48 :                                                               !
+48 :                                                               :
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-52 ! Compress'n ID !  Transform ID !
+52 :                                                               !
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+56 ! Compress'n ID !  Transform ID !
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-56 ! Encapsulated ethernet payload
+60 ! Encapsulated ethernet payload
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -145,7 +145,7 @@ enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 
 #define N2N_PKT_VERSION            3
 #define N2N_DEFAULT_TTL            2  /* can be forwarded twice at most */
-#define N2N_COMMUNITY_SIZE         16
+#define N2N_COMMUNITY_SIZE         20
 #define N2N_MAC_SIZE               6
 #define N2N_COOKIE_SIZE            4
 #define N2N_DESC_SIZE              16

--- a/include/speck.h
+++ b/include/speck.h
@@ -111,17 +111,13 @@ int speck_deinit (speck_context_t *ctx);
 // ----------------------------------------------------------------------------------------------------------------
 
 
-// cipher SPECK -- 96 bit block size -- 96 bit key size -- ECB mode
+// cipher SPECK -- 128 bit block size -- 128 bit key size -- ECB mode
 // follows endianess rules as used in official implementation guide and NOT as in original 2013 cipher presentation
-// used for IV in header encryption
+// used for IV in header encryption (one block); encrytion via speck_ctr with null_block as data
 // for now: just plain C -- probably no need for AVX, SSE, NEON
 
 
-int speck_96_encrypt (unsigned char *inout, speck_context_t *ctx);
-
-int speck_96_decrypt (unsigned char *inout, speck_context_t *ctx);
-
-int speck_96_expand_key (speck_context_t *ctx, const unsigned char *k);
+int speck_128_decrypt (unsigned char *inout, speck_context_t *ctx);
 
 
 #endif // SPECK_H

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2008,8 +2008,11 @@ void readFromIPSocket (n2n_edge_t * eee, int in_sock) {
 
                 decode_REGISTER(&reg, &cmn, udp_buf, &rem, &idx);
 
+                via_multicast = is_null_mac(reg.dstMac);
+
                 if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED) {
-                    if(!find_peer_time_stamp_and_verify (eee, from_supernode, reg.srcMac, stamp, TIME_STAMP_NO_JITTER)) {
+                    if(!find_peer_time_stamp_and_verify (eee, from_supernode, reg.srcMac, stamp,
+                                                         via_multicast ? TIME_STAMP_ALLOW_JITTER : TIME_STAMP_NO_JITTER)) {
                         traceEvent(TRACE_DEBUG, "readFromIPSocket dropped REGISTER due to time stamp error.");
                         return;
                     }
@@ -2017,8 +2020,6 @@ void readFromIPSocket (n2n_edge_t * eee, int in_sock) {
 
                 if(is_valid_peer_sock(&reg.sock))
                     orig_sender = &(reg.sock);
-
-                via_multicast = is_null_mac(reg.dstMac);
 
                 if(via_multicast && !memcmp(reg.srcMac, eee->device.mac_addr, N2N_MAC_SIZE)) {
                     traceEvent(TRACE_DEBUG, "Skipping REGISTER from self");

--- a/src/header_encryption.c
+++ b/src/header_encryption.c
@@ -28,20 +28,14 @@ int packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
                            he_context_t *ctx, he_context_t *ctx_iv,
                            uint64_t *stamp) {
 
-    // assemble IV
-    // the last four are ASCII "n2n!" and do not get overwritten
-    uint8_t iv[16] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                       0x00, 0x00, 0x00, 0x00, 0x6E, 0x32, 0x6E, 0x21 };
-    // the first 96 bits of the packet get padded with ASCII "n2n!" to full 128 bit IV
-    memcpy(iv, packet, 12);
-
     // try community name as possible key and check for magic bytes "n2__"
     uint32_t magic = 0x6E320000;
     uint32_t test_magic;
+    uint32_t checksum_high = 0;
 
     // check for magic
-    // so, as a first step, decrypt 4 bytes only starting at byte 12
-    speck_ctr((uint8_t*)&test_magic, &packet[12], 4, iv, (speck_context_t*)ctx);
+    // so, as a first step, decrypt last 4 bytes from where originally the community name would be
+    speck_ctr((uint8_t*)&test_magic, &packet[16], 4, packet, (speck_context_t*)ctx);
     test_magic = be32toh(test_magic);
 
     //extract header length (lower 2 bytes)
@@ -49,19 +43,30 @@ int packet_header_decrypt (uint8_t packet[], uint16_t packet_len,
 
     if (header_len <= packet_len) {
         // decrypt the complete header
-        speck_ctr(&packet[12], &packet[12], header_len - 12, iv, (speck_context_t*)ctx);
+        speck_ctr(&packet[16], &packet[16], header_len - 16, packet, (speck_context_t*)ctx);
 
-        // restore original packet order
-        memcpy(&packet[0], &packet[16], 4);
-        memcpy(&packet[4], community_name, N2N_COMMUNITY_SIZE);
-
-        // extract time stamp (first 64 bit) and un-xor actual checksum (calculated here) from it
+        // extract time stamp and un-xor actual checksum (calculated here) from it
         // if payload was altered (different checksum than original), time stamp verification will fail
-        speck_96_decrypt(iv, (speck_context_t*)ctx_iv);
+        // use speck block cipher step (1 block == 128 bit == 16 bytes)
+        speck_128_decrypt(packet, (speck_context_t*)ctx_iv);
 
+        // extract the required data
+        *stamp = be64toh(*(uint64_t*)&packet[4]);
+        checksum_high = be32toh(*(uint32_t*)packet);
+
+        // restore original packet order before calculating checksum
+        memcpy(&packet[0], &packet[20], 4);
+        memcpy(&packet[4], community_name, N2N_COMMUNITY_SIZE);
         uint64_t checksum = pearson_hash_64(packet, packet_len);
 
-        *stamp = be64toh(*(uint64_t*)iv) ^ checksum;
+        if((checksum >> 32) != checksum_high) {
+            traceEvent(TRACE_DEBUG, "packet_header_decrypt dropped a packet with invalid checksum.");
+
+            // unsuccessful
+            return 0;
+        }
+
+        *stamp = *stamp ^ (checksum << 32);
 
         // successful
         return 1;
@@ -77,14 +82,14 @@ int packet_header_encrypt (uint8_t packet[], uint16_t header_len, uint16_t packe
                            he_context_t *ctx, he_context_t *ctx_iv,
                            uint64_t stamp) {
 
-    uint8_t iv[16];
-    uint32_t *iv32 = (uint32_t*)&iv;
-    uint64_t *iv64 = (uint64_t*)&iv;
+    const uint8_t null_block[16] = { 0 };
+    uint32_t *p32 = (uint32_t*)packet;
+    uint64_t *p64 = (uint64_t*)packet;
     uint64_t checksum = 0;
     uint32_t magic = 0x6E320000; /* == ASCII "n2__" */
     magic += header_len;
 
-    if(packet_len < 20) {
+    if(packet_len < 24) {
         traceEvent(TRACE_DEBUG, "packet_header_encrypt dropped a packet too short to be valid.");
         return -1;
     }
@@ -93,24 +98,25 @@ int packet_header_encrypt (uint8_t packet[], uint16_t header_len, uint16_t packe
     checksum = pearson_hash_64(packet, packet_len);
 
     // re-order packet
-    memcpy(&packet[16], &packet[00], 4);
+    p32[5] = p32[0];
 
-    // add time stamp, checksum and magic bytes to form the pre-IV
-    iv64[0] = htobe64(stamp ^ checksum);
-    iv32[2] = n2n_rand();
+    // add time stamp, checksum, and random to form the pre-IV
+    p64[0] = htobe64(checksum);
 
-    // encrypt this 96-bit pre-IV to IV
-    speck_96_encrypt(iv, (speck_context_t*)ctx_iv);
+    p32[1] = p32[1] ^ htobe32((uint32_t)(stamp >> 32));
+    p32[2] = htobe32((uint32_t)stamp);
 
-    // place IV in packet (including magic number)
-    iv32[3] = htobe32(magic);
-    memcpy(packet, iv, 16);
+    p32[3] = n2n_rand();
 
-    // replace magic number "n2__" by correct IV padding "n2n!"
-    iv32[3] = htobe32(0x6E326E21);
+    // encrypt this pre-IV to IV
+    // use speck ctr with null_block as data to make it a block cipher step
+    speck_ctr(packet, null_block, 16, packet, (speck_context_t*)ctx_iv);
 
-    // encrypt
-    speck_ctr(&packet[12], &packet[12], header_len - 12, iv, (speck_context_t*)ctx);
+    // place IV plus magic in packet
+    p32[4] = htobe32(magic);
+
+    // encrypt, starting from magic
+    speck_ctr(&packet[16], &packet[16], header_len - 16, packet, (speck_context_t*)ctx);
 
     return 0;
 }
@@ -125,9 +131,9 @@ void packet_header_setup_key (const char *community_name,
     *ctx = (he_context_t*)calloc(1, sizeof (speck_context_t));
     speck_init((speck_context_t**)ctx, key, 128);
 
-    // hash again and use last 96 bit (skipping 4 bytes) as key for IV encryption
+    // hash again and use as key for IV encryption
     // REMOVE as soon as checksum and replay protection get their own fields
     pearson_hash_128(key, key, sizeof (key));
     *ctx_iv = (he_context_t*)calloc(1, sizeof (speck_context_t));
-    speck_96_expand_key((speck_context_t*)*ctx_iv, &key[4]);
+    speck_init((speck_context_t**)ctx_iv, key, 128);
 }

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -626,7 +626,6 @@ uint64_t time_stamp (void) {
     // micro_seconds = ((uint64_t)(tod.tv_sec) * 1000000ULL + tod.tv_usec) << 12;
 
     // note that the lower 4 bits remain unset (flags, for later use)
-
     return micro_seconds;
 }
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -915,11 +915,11 @@ static int process_udp (n2n_sn_t * sss,
     /* check if header is unencrypted. the following check is around 99.99962 percent reliable.
      * it heavily relies on the structure of packet's common part
      * changes to wire.c:encode/decode_common need to go together with this code */
-    if(udp_size < 20) {
+    if(udp_size < 24) {
         traceEvent(TRACE_DEBUG, "process_udp dropped a packet too short to be valid.");
         return -1;
     }
-    if((udp_buf[19] == (uint8_t)0x00) // null terminated community name
+    if((udp_buf[23] == (uint8_t)0x00) // null terminated community name
        && (udp_buf[00] == N2N_PKT_VERSION) // correct packet version
        && ((be16toh(*(uint16_t*)&(udp_buf[02])) & N2N_FLAGS_TYPE_MASK) <= MSG_TYPE_MAX_TYPE) // message type
        && ( be16toh(*(uint16_t*)&(udp_buf[02])) < N2N_FLAGS_OPTIONS) // flags


### PR DESCRIPTION
This pull request uses 128-bit wide IV for header encryption. It requires to have 20 bytes available (16 for IV, 4 for magic number and header length). Therefore, the community name length grows from 16 to 20 (still including the zero termination).

The pre-IV format was adopted as described in the likewise updated documentation.

**This breaks compatibility to previous _dev_.** This might happen some more times until we reach the final 3.0 because I have gotten some additional ideas while coding...

Fixes #588 .