### PR TITLE
properly handled supernodes' timestamps

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -624,7 +624,6 @@ struct n2n_edge {
     n2n_route_t                      *sn_route_to_clean;                 /**< Supernode route to clean */
     n2n_edge_callbacks_t cb;                                             /**< API callbacks */
     void                             *user_data;                         /**< Can hold user data */
-    uint64_t                         sn_last_valid_time_stamp;           /**< last valid time stamp from supernode */
     SN_SELECTION_CRITERION_DATA_TYPE sn_selection_criterion_common_data;
 
     /* Sockets */

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -340,6 +340,7 @@ struct peer_info* add_sn_to_list_by_mac_or_sock (struct peer_info **sn_list, n2n
             peer = (struct peer_info*)calloc(1, sizeof(struct peer_info));
             if(peer) {
                 sn_selection_criterion_default(&(peer->selection_criterion));
+                peer->last_valid_time_stamp = initial_time_stamp();
                 memcpy(&(peer->sock), sock, sizeof(n2n_sock_t));
                 memcpy(peer->mac_addr, mac, sizeof(n2n_mac_t));
                 HASH_ADD_PEER(*sn_list, peer);


### PR DESCRIPTION
Before federation feature, there ws only one supernode and its last timestamp was stored in a global eee field. Now, every supernode has got its own field in the peer_info structure. It just has not been used everywhere yet. This pull request includes the appropriate changes.

Fixes #590.