### PR TITLE
ensured correct community file loading (sn)

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -705,6 +705,7 @@ typedef struct n2n_sn {
     gid_t                                  groupid;
 #endif
     int                                    lock_communities; /* If true, only loaded and matching communities can be used. */
+    char                                   *community_file;
     struct sn_community                    *communities;
     struct sn_community_regular_expression *rules;
     struct sn_community                    *federation;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -339,6 +339,7 @@ void sn_term (n2n_sn_t *sss) {
         free(re);
     }
 
+    free(sss->community_file);
 #ifdef WIN32
     destroyWin32();
 #endif


### PR DESCRIPTION
This pull request fixes an issue which occurs if supernode's `-c` parameter gets processed before the `-a` parameter – this can happen at random because `getopt_...` is allowed to permute the parameters.

By loading the `-c`-provided `community.list` file after all the parameters are read, the community take-in – specifically, the call to `assign_one_ip_subnet()` – can rely on `-a`-provided address range data eventually being present. Therefore, `-c` processing does not load the file but only stores the filename for later use.

Fixes #607.