### PR TITLE
Safer checking for REGISTER_SUPER_ACK and UNREGISTER_SUPER

### DIFF
--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1429,7 +1429,7 @@ static int process_udp (n2n_sn_t * sss,
                 return -1;
             }
 
-            if((from_supernode == 0) != (comm->is_federation == IS_NO_FEDERATION)) {
+            if((from_supernode == 0) || (comm->is_federation == IS_NO_FEDERATION)) {
                 traceEvent(TRACE_DEBUG, "process_udp dropped UNREGISTER_SUPER: from_supernode value doesn't correspond to the internal federation marking.");
                 return -1;
             }
@@ -1485,7 +1485,7 @@ static int process_udp (n2n_sn_t * sss,
                 return -1;
             }
 
-            if((from_supernode == 0) != (comm->is_federation == IS_NO_FEDERATION)) {
+            if((from_supernode == 0) || (comm->is_federation == IS_NO_FEDERATION)) {
                 traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK: from_supernode value doesn't correspond to the internal federation marking.");
                 return -1;
             }

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1430,7 +1430,7 @@ static int process_udp (n2n_sn_t * sss,
             }
 
             if((from_supernode == 1) || (comm->is_federation == IS_FEDERATION)) {
-                traceEvent(TRACE_DEBUG, "process_udp dropped UNREGISTER_SUPER: should not from a supernode or federation.");
+                traceEvent(TRACE_DEBUG, "process_udp dropped UNREGISTER_SUPER: should not come from a supernode or federation.");
                 return -1;
             }
 
@@ -1486,7 +1486,7 @@ static int process_udp (n2n_sn_t * sss,
             }
 
             if((from_supernode == 0) || (comm->is_federation == IS_NO_FEDERATION)) {
-                traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK: should not from an edge or federation.");
+                traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK: should not come from an edge or regular community.");
                 return -1;
             }
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1429,8 +1429,8 @@ static int process_udp (n2n_sn_t * sss,
                 return -1;
             }
 
-            if((from_supernode == 0) || (comm->is_federation == IS_NO_FEDERATION)) {
-                traceEvent(TRACE_DEBUG, "process_udp dropped UNREGISTER_SUPER: from_supernode value doesn't correspond to the internal federation marking.");
+            if((from_supernode == 1) || (comm->is_federation == IS_FEDERATION)) {
+                traceEvent(TRACE_DEBUG, "process_udp dropped UNREGISTER_SUPER: should not from a supernode or federation.");
                 return -1;
             }
 
@@ -1486,7 +1486,7 @@ static int process_udp (n2n_sn_t * sss,
             }
 
             if((from_supernode == 0) || (comm->is_federation == IS_NO_FEDERATION)) {
-                traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK: from_supernode value doesn't correspond to the internal federation marking.");
+                traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK: should not from an edge or federation.");
                 return -1;
             }
 


### PR DESCRIPTION
safer checking for REGISTER_SUPER_ACK and REGISTER_SUPER_NAK ( only those packet from supernode in federation are legal )

For more details please see #603