### PR TITLE
fixed occasional edge segfault

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2104,7 +2104,6 @@ void readFromIPSocket (n2n_edge_t * eee, int in_sock) {
                 n2n_REGISTER_SUPER_ACK_payload_t *payload;
                 int i;
                 int skip_add;
-                struct peer_info *sn;
 
                 memset(&ra, 0, sizeof(n2n_REGISTER_SUPER_ACK_t));
 


### PR DESCRIPTION
This pull request fixes an occasional edge segfault which happened due to a double declaration of a struct variable `peer_info_t` which in turn pushed the original one out of scope while its content was still needed.