### PR TITLE
fixed minor timing issues

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -220,7 +220,7 @@ int time_stamp_verify_and_update (uint64_t stamp, uint64_t * previous_stamp, int
 size_t purge_peer_list (struct peer_info ** peer_list,
                         time_t purge_before);
 size_t clear_peer_list (struct peer_info ** peer_list);
-size_t purge_expired_registrations (struct peer_info ** peer_list, time_t* p_last_purge, int timeout);
+size_t purge_expired_nodes (struct peer_info **peer_list, time_t *p_last_purge, int frequency, int timeout);
 
 /* Edge conf */
 void edge_init_conf_defaults (n2n_edge_conf_t *conf);

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -52,8 +52,7 @@
  * values should be at least 3*SOCKET_TIMEOUT_INTERVAL_SECS apart. */
 #define LAST_SEEN_SN_ACTIVE              20 /* sec, indicates supernodes that are proven to be active */
 #define LAST_SEEN_SN_INACTIVE            90 /* sec, indicates supernodes that are proven to be inactive: they will be purged */
-#define LAST_SEEN_SN_NEW                 (LAST_SEEN_SN_INACTIVE - LAST_SEEN_SN_ACTIVE) / 2 /* sec, indicates supernodes with unsure status, must be tested to check if they are active */
-
+#define LAST_SEEN_SN_NEW                 (LAST_SEEN_SN_INACTIVE - 3 * RE_REG_AND_PURGE_FREQUENCY) /* sec, indicates supernodes with unsure status, must be tested to check if they are active */
 
 #define IFACE_UPDATE_INTERVAL            (30) /* sec. How long it usually takes to get an IP lease. */
 #define TRANSOP_TICK_INTERVAL            (10) /* sec */

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -439,18 +439,19 @@ void print_n2n_version () {
 
 /* *********************************************** */
 
-size_t purge_expired_registrations (struct peer_info ** peer_list, time_t* p_last_purge, int timeout) {
+size_t purge_expired_nodes (struct peer_info **peer_list, time_t *p_last_purge,
+                            int frequency, int timeout) {
 
     time_t now = time(NULL);
     size_t num_reg = 0;
 
-    if((now - (*p_last_purge)) < timeout) {
+    if((now - (*p_last_purge)) < frequency) {
         return 0;
     }
 
     traceEvent(TRACE_DEBUG, "Purging old registrations");
 
-    num_reg = purge_peer_list(peer_list, now - REGISTRATION_TIMEOUT);
+    num_reg = purge_peer_list(peer_list, now - timeout);
 
     (*p_last_purge) = now;
     traceEvent(TRACE_DEBUG, "Remove %ld registrations", num_reg);

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1307,9 +1307,6 @@ static int process_udp (n2n_sn_t * sss,
                 if(comm->is_federation == IS_FEDERATION) {
                     skip_add = SN_ADD;
                     p = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), &(ack.sock), reg.edgeMac, &skip_add);
-                    // do NOT update p->last_seen, because this sn might not send any more REGISTER_SUPERs to p then
-                    // as we receive p's next REGISTER_SUPER before last_seen times out; thus, update last_seen
-                    // only on arriving REGISTER_SUPER_ACK
                 }
 
                 /* Skip random numbers of supernodes before payload assembling, calculating an appropriate random_number.


### PR DESCRIPTION
This pull request fixes mainly two issues:

- Under very rare circumstances, the data of an already stopped supernode could have been handed between supernodes of a federation forever (like daemons – due to different time thresholds for transmission selection and `last_seen` for freshly arrived; now equal).
- A few corrections to the purge code allow the originally intended timing being applied