### PR TITLE
fixed metric parameter passing to wintap.c

### DIFF
--- a/src/edge.c
+++ b/src/edge.c
@@ -1032,12 +1032,13 @@ int main (int argc, char* argv[]) {
         }
 
         if(runlevel == 4) { /* configure the TUNTAP device */
-#ifdef WIN32
-            tuntap.metric =  eee->tuntap_priv_conf.metric;
-#endif
             if(tuntap_open(&tuntap, eee->tuntap_priv_conf.tuntap_dev_name, eee->tuntap_priv_conf.ip_mode,
                            eee->tuntap_priv_conf.ip_addr, eee->tuntap_priv_conf.netmask,
-                           eee->tuntap_priv_conf.device_mac, eee->tuntap_priv_conf.mtu) < 0)
+                           eee->tuntap_priv_conf.device_mac, eee->tuntap_priv_conf.mtu
+#ifdef WIN32
+                           , eee->tuntap_priv_conf.metric
+#endif
+                                                           ) < 0)
                 exit(1);
             memcpy(&eee->device, &tuntap, sizeof(tuntap));
             traceEvent(TRACE_NORMAL, "Created local tap device IP: %s, Mask: %s, MAC: %s",

--- a/win32/wintap.c
+++ b/win32/wintap.c
@@ -301,17 +301,33 @@ int open_wintap(struct tuntap_dev *device,
 
   /* ****************** */
 
-  /* MTU and network metric */
+  /* MTU */
+
+  _snprintf(cmd, sizeof(cmd),
+    "netsh interface ipv4 set subinterface \"%s\" mtu=%d store=persistent > nul",
+    device->ifName, mtu);
+
+  if(system(cmd) != 0)
+    printf("WARNING: Unable to set device %s parameters MTU=%d store=persistent [%s]\n",
+      device->ifName, mtu, cmd);
+
+  /* ****************** */
+
+  /* metric */
 
   device->metric = metric;
 
   _snprintf(cmd, sizeof(cmd),
-    "netsh interface ipv4 set subinterface \"%s\" mtu=%d metric=%d store=persistent > nul",
-    device->ifName, mtu, device->metric);
+    "netsh interface ipv4 set interface \"%s\" metric=%d > nul",
+    device->ifName, device->metric);
 
   if(system(cmd) != 0)
-    printf("WARNING: Unable to set device %s parameters MTU=%d metric=%d store=persistent [%s]\n",
-      device->ifName, mtu, device->metric, cmd);
+    printf("WARNING: Unable to set device %s parameters metric=%d [%s]\n",
+      device->ifName, device->metric, cmd);
+
+
+  /* ****************** */
+
 
   /* set driver media status to 'connected' (i.e. set the interface up) */
   if (!DeviceIoControl (device->device_handle, TAP_IOCTL_SET_MEDIA_STATUS,

--- a/win32/wintap.c
+++ b/win32/wintap.c
@@ -228,7 +228,9 @@ int open_wintap(struct tuntap_dev *device,
                 char *device_ip, 
                 char *device_mask,
                 const char *device_mac, 
-                int mtu) {
+                int mtu,
+                int metric) {
+
   char cmd[256];
   DWORD len;
   ULONG status = TRUE;
@@ -300,6 +302,9 @@ int open_wintap(struct tuntap_dev *device,
   /* ****************** */
 
   /* MTU and network metric */
+
+  device->metric = metric;
+
   _snprintf(cmd, sizeof(cmd),
     "netsh interface ipv4 set subinterface \"%s\" mtu=%d metric=%d store=persistent > nul",
     device->ifName, mtu, device->metric);
@@ -389,8 +394,9 @@ int tuntap_open(struct tuntap_dev *device,
                 char *device_ip, 
                 char *device_mask, 
                 const char * device_mac, 
-                int mtu) {
-    return(open_wintap(device, dev, address_mode, device_ip, device_mask, device_mac, mtu));
+                int mtu,
+                int metric) {
+    return(open_wintap(device, dev, address_mode, device_ip, device_mask, device_mac, mtu, metric));
 }
 
 /* ************************************************ */
@@ -415,7 +421,7 @@ int main(int argc, char* argv[]) {
 
   printf("Welcome to n2n\n");
   initWin32();
-  open_wintap(&tuntap, "static", "1.2.3.20", "255.255.255.0", mtu);
+  open_wintap(&tuntap, "static", "1.2.3.20", "255.255.255.0", mtu, 0);
 
   for(i=0; i<10; i++) {
     u_char buf[MTU];


### PR DESCRIPTION
This pull request adds a dedicated `metric` parameter to `wintap.c`'s functions to ensure proper value passing.

The `-x <metric>` parameter value should now correctly be passed to the `netsh ...` command in `wintap.c`'s line 309.

**It still needs to be confirmed that this command actually changes the device's metric. Please let us know.**

EDIT: _I was informed that `metric` does not work on the "sub-interface" but on the "interface"... Myself not being aware of the actual difference, I made it a separate `netsh` command line. Hope it helps._