### PR TITLE
limited number of concurrently pinged supernodes

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -48,6 +48,9 @@
 #define SWEEP_TIME                       30 /* sec, indicates the value after which we have to sort the hash list of supernodes in edges
                                              * and when we send out packets to query selection-relevant informations from supernodes. */
 
+#define NUMBER_SN_PINGS_INITIAL          15 /* number of supernodes to concurrently ping during bootstrap and immediately afterwards */
+#define NUMBER_SN_PINGS_REGULAR           5 /* number of supernodes to concurrently ping during regular edge operation */
+
 /* Timeouts used in re_register_and_purge_supernodes. LAST_SEEN_SN_ACTIVE and LAST_SEEN_SN_INACTIVE
  * values should be at least 3*SOCKET_TIMEOUT_INTERVAL_SECS apart. */
 #define LAST_SEEN_SN_ACTIVE              20 /* sec, indicates supernodes that are proven to be active */

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -601,6 +601,7 @@ typedef struct n2n_edge_conf {
     n2n_auth_t         auth;
     filter_rule_t      *network_traffic_filter_rules;
     int                metric;                /**< Network interface metric (Windows only). */
+    uint8_t            number_max_sn_pings;   /**< Number of maximum concurrently allowed supernode pings. */
 } n2n_edge_conf_t;
 
 

--- a/src/edge.c
+++ b/src/edge.c
@@ -962,6 +962,8 @@ int main (int argc, char* argv[]) {
         if(runlevel == 0) { /* PING to all known supernodes */
             last_action = now_time;
             eee->sn_pong = 0;
+            // (re-)initialize the number of max concurrent pings (decreases by calling send_query_peer)
+            eee->conf.number_max_sn_pings = NUMBER_SN_PINGS_INITIAL;
             send_query_peer(eee, null_mac);
             traceEvent(TRACE_NORMAL, "Send PING to supernodes.");
             runlevel++;
@@ -975,8 +977,7 @@ int main (int argc, char* argv[]) {
                 eee->curr_sn = eee->conf.supernodes;
                 traceEvent(TRACE_NORMAL, "Received first PONG from supernode [%s].", eee->curr_sn->ip_addr);
                 runlevel++;
-            }
-            if(last_action <= (now_time - BOOTSTRAP_TIMEOUT)) {
+            } else if(last_action <= (now_time - BOOTSTRAP_TIMEOUT)) {
                 // timeout
                 runlevel--;
                 // skip waiting for answer to direcly go to send PING again
@@ -1017,8 +1018,7 @@ int main (int argc, char* argv[]) {
                 runlevel++;
                 traceEvent(TRACE_NORMAL, "Received REGISTER_SUPER_ACK from supernode for IP address asignment.");
                 // it should be from curr_sn, but we can't determine definitely here, so no details to output
-            }
-            if(last_action <= (now_time - BOOTSTRAP_TIMEOUT)) {
+            } else if(last_action <= (now_time - BOOTSTRAP_TIMEOUT)) {
                 // timeout, so try next supernode
                 if(eee->curr_sn->hh.next)
                     eee->curr_sn = eee->curr_sn->hh.next;
@@ -1064,6 +1064,11 @@ int main (int argc, char* argv[]) {
         }
         seek_answer = 1;
     }
+    // allow a higher number of pings for first regular round of ping
+    // to quicker get an inital 'supernode selection criterion overview'
+    eee->conf.number_max_sn_pings = NUMBER_SN_PINGS_INITIAL;
+    // do not immediately ping again, allow some time
+    eee->last_sweep = now_time - SWEEP_TIME + 2 * BOOTSTRAP_TIMEOUT;
     eee->sn_wait = 1;
     eee->last_register_req = 0;
     eee->last_sup = 0; /* to allow gratuitous arp packet after regular REGISTER_SUPER_ACK */


### PR DESCRIPTION
This pull request limits the number of concurrently pinged supernodes. It will help to keep overall network load on a feasible level especially with a view to federations with a large number of edges and supernodes.

By default, during bootstrap and immediately afterwards, having received one REGISTER_SUPER_ACK payload full of current supernodes, **15** supernodes are pinged (for workload or rtt) to have a profound basis for the further selection process.

During normal operation, only **5** supernodes will be pinged: The **2** top ones to keep an eye on current connectivity and a possible fail-over as well as **3** randomly chosen from the rest of the list.

These values are defined as `NUMBER_SN_PINGS_INITIAL` and `NUMBER_SN_PINGS_REGULAR`.