### PR TITLE
enabled windows random numbers for seed

### DIFF
--- a/include/random_numbers.h
+++ b/include/random_numbers.h
@@ -43,12 +43,9 @@
 #include <immintrin.h>  /* _rdrand64_step, rdseed4_step */
 #endif
 
-// the WIN32 code is still untested and thus commented, also see random_numbers.c
-/*
 #if defined (WIN32)
 #include <Wincrypt.h>   // HCTYPTPROV, Crypt*-functions
 #endif
-*/
 
 
 typedef struct rn_generator_state_t {

--- a/src/random_numbers.c
+++ b/src/random_numbers.c
@@ -155,17 +155,14 @@ uint64_t n2n_seed (void) {
     }
 #endif
 
-// the following WIN32 code is still untested and thus commented
-/*
 #ifdef WIN32
     HCRYPTPROV crypto_provider;
-    CryptAcquireContext (&crypto_provider, NULL, (LPCWSTR)L"Microsoft Base Cryptographic Provider v1.0",
+    CryptAcquireContext (&crypto_provider, NULL, NULL,
                          PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
     CryptGenRandom (crypto_provider, 8, &seed);
     CryptReleaseContext (crypto_provider, 0);
     ret += seed;
 #endif
-*/
 
     seed  = time(NULL);             /* UTC in seconds */
     ret  += seed;


### PR DESCRIPTION
This pull request enables the former commented Windows random number code as additional source of randomness for n2n's seed generation. A slight change was required to make it work.