### PR TITLE
added TCP support

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -219,11 +219,14 @@ int time_stamp_verify_and_update (uint64_t stamp, uint64_t * previous_stamp, int
 /* Operations on peer_info lists. */
 size_t purge_peer_list (struct peer_info ** peer_list,
                         SOCKET socket_not_to_close,
+                        n2n_tcp_connection_t *tcp_connections,
                         time_t purge_before);
+
 size_t clear_peer_list (struct peer_info ** peer_list);
 
 size_t purge_expired_nodes (struct peer_info **peer_list,
                             SOCKET socket_not_to_close,
+                            n2n_tcp_connection_t *tcp_connections,
                             time_t *p_last_purge,
                             int frequency, int timeout);
 

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -106,6 +106,7 @@
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/udp.h>
+#include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <sys/time.h>

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -207,7 +207,7 @@ void print_edge_stats (const n2n_edge_t *eee);
 char* sock_to_cstr (n2n_sock_str_t out,
                     const n2n_sock_t * sock);
 char * ip_subnet_to_str (dec_ip_bit_str_t buf, const n2n_ip_subnet_t *ipaddr);
-SOCKET open_socket (int local_port, int bind_any);
+SOCKET open_socket (int local_port, int bind_any, int type);
 int sock_equal (const n2n_sock_t * a,
                 const n2n_sock_t * b);
 
@@ -218,9 +218,14 @@ int time_stamp_verify_and_update (uint64_t stamp, uint64_t * previous_stamp, int
 
 /* Operations on peer_info lists. */
 size_t purge_peer_list (struct peer_info ** peer_list,
+                        SOCKET socket_not_to_close,
                         time_t purge_before);
 size_t clear_peer_list (struct peer_info ** peer_list);
-size_t purge_expired_nodes (struct peer_info **peer_list, time_t *p_last_purge, int frequency, int timeout);
+
+size_t purge_expired_nodes (struct peer_info **peer_list,
+                            SOCKET socket_not_to_close,
+                            time_t *p_last_purge,
+                            int frequency, int timeout);
 
 /* Edge conf */
 void edge_init_conf_defaults (n2n_edge_conf_t *conf);

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -133,6 +133,8 @@
 #include "n2n_typedefs.h"
 
 #ifdef WIN32
+#include <winsock2.h>           /* for tcp */
+#define SHUT_RDWR      SD_BOTH  /* for tcp */
 #include "win32/wintap.h"
 #include <sys/stat.h>
 #else

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -45,7 +45,7 @@
 #endif
 #define N2N_CAN_NAME_IFACE 1
 #undef N2N_HAVE_DAEMON
-#undef N2N_HAVE_TCP
+#undef N2N_HAVE_TCP           /* as explained on https://github.com/ntop/n2n/pull/627#issuecomment-782093706 */
 #undef N2N_HAVE_SETUID
 #else
 #ifndef CMAKE_BUILD

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -32,6 +32,7 @@
 */
 
 #define N2N_HAVE_DAEMON /* needs to be defined before it gets undefined */
+#define N2N_HAVE_TCP    /* needs to be defined before it gets undefined */
 
 /* #define N2N_CAN_NAME_IFACE */
 
@@ -44,6 +45,7 @@
 #endif
 #define N2N_CAN_NAME_IFACE 1
 #undef N2N_HAVE_DAEMON
+#undef N2N_HAVE_TCP
 #undef N2N_HAVE_SETUID
 #else
 #ifndef CMAKE_BUILD
@@ -134,7 +136,8 @@
 
 #ifdef WIN32
 #include <winsock2.h>           /* for tcp */
-#define SHUT_RDWR      SD_BOTH  /* for tcp */
+#define SHUT_RDWR   SD_BOTH     /* for tcp */
+#define SOL_TCP     IPPROTO_TCP /* for tcp */
 #include "win32/wintap.h"
 #include <sys/stat.h>
 #else

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -108,11 +108,13 @@ enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 #define HASH_FIND_PEER(head,mac,out) \
     HASH_FIND(hh,head,mac,sizeof(n2n_mac_t),out)
 #define N2N_EDGE_SN_HOST_SIZE     48
-#define N2N_EDGE_NUM_SUPERNODES   2
 #define N2N_EDGE_SUP_ATTEMPTS     3             /* Number of failed attmpts before moving on to next supernode. */
 #define N2N_PATHNAME_MAXLEN       256
 #define N2N_EDGE_MGMT_PORT        5644
 #define N2N_SN_MGMT_PORT          5645
+
+#define N2N_TCP_BACKLOG_QUEUE_SIZE   3         /* number of concurrently pending connections to be accepted */
+                                               /* NOT the number of max. TCP connections                    */
 
 /* flag used in add_sn_to_list_by_mac_or_sock */
 enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -698,6 +698,10 @@ typedef struct n2n_tcp_connection {
     SOCKET socket_fd;       /* file descriptor for tcp socket */
     struct sockaddr sock;   /* network order socket */
 
+    uint16_t expected;                                    /* number of bytes expected to be read */
+    uint16_t position;                                    /* current position in the buffer*/
+    uint8_t  buffer[N2N_PKT_BUF_SIZE + sizeof(uint16_t)]; /* buffer for data collected from tcp socket incl. prepended length */
+
     UT_hash_handle hh; /* makes this structure hashable */
 } n2n_tcp_connection_t;
 

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -415,6 +415,7 @@ struct peer_info {
     n2n_ip_subnet_t                  dev_addr;
     n2n_desc_t                       dev_desc;
     n2n_sock_t                       sock;
+    SOCKET                           socket_fd;
     n2n_cookie_t                     last_cookie;
     n2n_auth_t                       auth;
     int                              timeout;
@@ -598,6 +599,7 @@ typedef struct n2n_edge_conf {
     int                register_ttl;           /**< TTL for registration packet when UDP NAT hole punching through supernode. */
     int                local_port;
     int                mgmt_port;
+    uint8_t            connect_tcp;            /** connection to supernode 0 = UDP; 1 = TCP */
     n2n_auth_t         auth;
     filter_rule_t      *network_traffic_filter_rules;
     int                metric;                /**< Network interface metric (Windows only). */
@@ -692,6 +694,12 @@ struct sn_community_regular_expression {
     UT_hash_handle hh; /* makes this structure hashable */
 };
 
+typedef struct n2n_tcp_connection {
+    SOCKET socket_fd;  /* file descriptor for tcp socket */
+
+    UT_hash_handle hh; /* makes this structure hashable */
+} n2n_tcp_connection_t;
+
 typedef struct n2n_sn {
     time_t                                 start_time;      /* Used to measure uptime. */
     sn_stats_t                             stats;
@@ -700,7 +708,9 @@ typedef struct n2n_sn {
     uint16_t                               lport;           /* Local UDP port to bind to. */
     uint16_t                               mport;           /* Management UDP port to bind to. */
     int                                    sock;            /* Main socket for UDP traffic with edges. */
-    int                                    mgmt_sock;         /* management socket. */
+    int                                    tcp_sock;        /* auxiliary socket for optional TCP connections */
+    n2n_tcp_connection_t                   *tcp_connections;/* list of established TCP connections */
+    int                                    mgmt_sock;       /* management socket. */
     n2n_ip_subnet_t                        min_auto_ip_net; /* Address range of auto_ip service. */
     n2n_ip_subnet_t                        max_auto_ip_net; /* Address range of auto_ip service. */
 #ifndef WIN32

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -695,7 +695,8 @@ struct sn_community_regular_expression {
 };
 
 typedef struct n2n_tcp_connection {
-    SOCKET socket_fd;  /* file descriptor for tcp socket */
+    SOCKET socket_fd;       /* file descriptor for tcp socket */
+    struct sockaddr sock;   /* network order socket */
 
     UT_hash_handle hh; /* makes this structure hashable */
 } n2n_tcp_connection_t;

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -694,6 +694,7 @@ struct sn_community_regular_expression {
     UT_hash_handle hh; /* makes this structure hashable */
 };
 
+
 typedef struct n2n_tcp_connection {
     SOCKET socket_fd;       /* file descriptor for tcp socket */
     struct sockaddr sock;   /* network order socket */

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -633,7 +633,7 @@ struct n2n_edge {
 
     /* Sockets */
     /* supernode socket is in        eee->curr_sn->sock (of type n2n_sock_t) */
-    int                              udp_sock;
+    int                              sock;
     int                              udp_mgmt_sock;                      /**< socket for status info. */
 
 #ifndef SKIP_MULTICAST_PEERS_DISCOVERY

--- a/include/sn_selection.h
+++ b/include/sn_selection.h
@@ -26,6 +26,7 @@ typedef char selection_criterion_str_t[SN_SELECTION_CRITERION_BUF_SIZE];
 /* selection criterion's functions */
 int sn_selection_criterion_init (peer_info_t *peer);
 int sn_selection_criterion_default (SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion);
+int sn_selection_criterion_bad (SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion);
 int sn_selection_criterion_calculate (n2n_edge_t *eee, peer_info_t *peer, SN_SELECTION_CRITERION_DATA_TYPE *data);
 
 /* common data's functions */

--- a/src/edge.c
+++ b/src/edge.c
@@ -1137,6 +1137,7 @@ int main (int argc, char* argv[]) {
 #endif
 
 #ifdef __linux__
+    signal(SIGPIPE, SIG_IGN);
     signal(SIGTERM, term_handler);
     signal(SIGINT,  term_handler);
 #endif

--- a/src/edge.c
+++ b/src/edge.c
@@ -983,7 +983,6 @@ int main (int argc, char* argv[]) {
                 // first answer
                 eee->sn_pong = 0;
                 sn_selection_sort(&(eee->conf.supernodes));
-                supernode_disconnect(eee);
                 eee->curr_sn = eee->conf.supernodes;
                 supernode_connect(eee);
                 traceEvent(TRACE_NORMAL, "Received first PONG from supernode [%s].", eee->curr_sn->ip_addr);
@@ -1035,6 +1034,7 @@ int main (int argc, char* argv[]) {
                     eee->curr_sn = eee->curr_sn->hh.next;
                 else
                     eee->curr_sn = eee->conf.supernodes;
+                supernode_connect(eee);
                 runlevel--;
                 // skip waiting for answer to direcly go to send REGISTER_SUPER again
                 seek_answer = 0;
@@ -1064,13 +1064,13 @@ int main (int argc, char* argv[]) {
         // we usually wait for some answer, there however are exceptions when going back to a previous runlevel
         if(seek_answer) {
             FD_ZERO(&socket_mask);
-            FD_SET(eee->udp_sock, &socket_mask);
+            FD_SET(eee->sock, &socket_mask);
             wait_time.tv_sec = BOOTSTRAP_TIMEOUT;
             wait_time.tv_usec = 0;
 
-            if(select(eee->udp_sock + 1, &socket_mask, NULL, NULL, &wait_time) > 0) {
-                if(FD_ISSET(eee->udp_sock, &socket_mask)) {
-                    readFromIPSocket(eee, eee->udp_sock);
+            if(select(eee->sock + 1, &socket_mask, NULL, NULL, &wait_time) > 0) {
+                if(FD_ISSET(eee->sock, &socket_mask)) {
+                    readFromIPSocket(eee, eee->sock);
                 }
             }
         }

--- a/src/edge.c
+++ b/src/edge.c
@@ -244,7 +244,10 @@ static void help (int level) {
                "                   | causes connections to stall if not properly supported\n");
 #endif
         printf(" -S1 ... -S2 or -S | -S1 or -S do not connect p2p, always use the supernode\n"
-               "                   | -S2 connects through TCP and only to the supernode\n");
+#ifdef N2N_HAVE_TCP
+               "                   | -S2 connects through TCP and only to the supernode\n"
+#endif
+);
         printf(" -i <reg_interval> | registration interval, for NAT hole punching (default\n"
                "                   | 20 seconds)\n");
         printf(" -L <reg_ttl>      | TTL for registration packet for NAT hole punching through\n"
@@ -602,8 +605,10 @@ static int setOption (int optkey, char *optargument, n2n_tuntap_priv_config_t *e
                 solitude_level = atoi(optargument);
             if(solitude_level >= 1)
                 conf->allow_p2p = 0;
+#ifdef N2N_HAVE_TCP
             if(solitude_level == 2)
                 conf->connect_tcp = 1;
+#endif
             break;
         }
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -214,7 +214,6 @@ int supernode_connect(n2n_edge_t *eee) {
         // set tcp socket to O_NONBLOCK so connect does not hang
         // requires checking the socket for readiness before sending and receving
         if(eee->conf.connect_tcp) {
-// !!! IS THIS REALLY REQUIRED ???
             fcntl(eee->sock, F_SETFL, O_NONBLOCK);
             if((connect(eee->sock, (struct sockaddr*)&(sock), sizeof(struct sockaddr)) < 0)
                && (errno != EINPROGRESS)) {
@@ -1652,7 +1651,7 @@ static void readFromMgmtSocket (n2n_edge_t *eee, int *keep_running) {
                             "%4u | %-15s | %-17s | %-21s | %-15s | %9s\n",
                             ++num,
                             (peer->dev_addr.net_addr == 0) ? "" : inet_ntoa(*(struct in_addr *) &net),
-                            macaddr_str(mac_buf, peer->mac_addr),
+                            (is_null_mac(peer->mac_addr)) ? "" : macaddr_str(mac_buf, peer->mac_addr),
                             sock_to_cstr(sockbuf, &(peer->sock)),
                             peer->dev_desc,
                             (peer->last_seen) ? time_buf : "");
@@ -1676,7 +1675,7 @@ static void readFromMgmtSocket (n2n_edge_t *eee, int *keep_running) {
                             "%4u | %-15s | %-17s | %-21s | %-15s | %9s\n",
                             ++num,
                             (peer->dev_addr.net_addr == 0) ? "" : inet_ntoa(*(struct in_addr *) &net),
-                            macaddr_str(mac_buf, peer->mac_addr),
+                            (is_null_mac(peer->mac_addr)) ? "" : macaddr_str(mac_buf, peer->mac_addr),
                             sock_to_cstr(sockbuf, &(peer->sock)),
                             peer->dev_desc,
                             (peer->last_seen) ? time_buf : "");

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -206,12 +206,15 @@ int supernode_connect(n2n_edge_t *eee) {
     if(eee->sock < 0) {
 
         if(eee->conf.local_port > 0)
-            traceEvent(TRACE_NORMAL, "Binding to local port %d", eee->conf.local_port);
+            traceEvent(TRACE_NORMAL, "Binding to local port %d",
+                                     (eee->conf.connect_tcp) ? 0 : eee->conf.local_port);
 
-        eee->sock = open_socket(eee->conf.local_port, 1 /* bind ANY */, eee->conf.connect_tcp);
+        eee->sock = open_socket((eee->conf.connect_tcp) ?  0 : eee->conf.local_port,
+                                 1 /* bind ANY */, eee->conf.connect_tcp);
 
         if(eee->sock < 0) {
-            traceEvent(TRACE_ERROR, "Failed to bind main UDP port %u", eee->conf.local_port);
+            traceEvent(TRACE_ERROR, "Failed to bind main UDP port %u",
+                                     (eee->conf.connect_tcp) ? 0 : eee->conf.local_port);
             return -1;
         }
 

--- a/src/example_sn_embed.c
+++ b/src/example_sn_embed.c
@@ -29,12 +29,12 @@ int main () {
         sss_node.daemon = 0;   // Whether to daemonize
         sss_node.lport = 1234; // Main UDP listen port
 
-        sss_node.sock = open_socket(sss_node.lport, 1);
+        sss_node.sock = open_socket(sss_node.lport, 1, 0);
         if(-1 == sss_node.sock) {
             exit(-2);
         }
 
-        sss_node.mgmt_sock = open_socket(5645, 0); // Main UDP management port
+        sss_node.mgmt_sock = open_socket(5645, 0, 0); // Main UDP management port
         if(-1 == sss_node.mgmt_sock) {
             exit(-2);
         }

--- a/src/sn.c
+++ b/src/sn.c
@@ -712,6 +712,7 @@ int main (int argc, char * const argv[]) {
         traceEvent(TRACE_NORMAL, "supernode is listening on UDP %u (main)", sss_node.lport);
     }
 
+#ifdef N2N_HAVE_TCP
     sss_node.tcp_sock = open_socket(sss_node.lport, 1 /*bind ANY*/, 1 /* TCP */);
     if(-1 == sss_node.tcp_sock) {
         traceEvent(TRACE_ERROR, "Failed to open auxiliary TCP socket. %s", strerror(errno));
@@ -726,6 +727,7 @@ int main (int argc, char * const argv[]) {
     } else {
         traceEvent(TRACE_NORMAL, "supernode is listening on TCP %u (aux)", sss_node.lport);
     }
+#endif
 
     sss_node.mgmt_sock = open_socket(sss_node.mport, 0 /* bind LOOPBACK */, 0 /* UDP */);
     if(-1 == sss_node.mgmt_sock) {

--- a/src/sn.c
+++ b/src/sn.c
@@ -763,6 +763,7 @@ int main (int argc, char * const argv[]) {
     traceEvent(TRACE_NORMAL, "supernode started");
 
 #ifdef __linux__
+    signal(SIGPIPE, SIG_IGN);
     signal(SIGTERM, term_handler);
     signal(SIGINT,  term_handler);
     signal(SIGHUP,  dump_registrations);

--- a/src/sn.c
+++ b/src/sn.c
@@ -735,11 +735,7 @@ int main (int argc, char * const argv[]) {
     }
 
     HASH_ITER(hh, sss_node.federation->edges, scan, tmp)
-{
-printf("!!! socket %u   ", scan->socket_fd);
         scan->socket_fd = sss_node.sock;
-printf("!!! socket %u\n", scan->socket_fd);
-}
 
 #ifndef WIN32
     if(((pw = getpwnam ("n2n")) != NULL) || ((pw = getpwnam ("nobody")) != NULL)) {

--- a/src/sn.c
+++ b/src/sn.c
@@ -719,7 +719,8 @@ int main (int argc, char * const argv[]) {
     } else {
         traceEvent(TRACE_NORMAL, "supernode opened TCP %u (aux)", sss_node.lport);
     }
-    if(-1 == listen(sss_node.tcp_sock, 1 /* !!! check this value !!! */)) {
+// !!! CHECK THE VALUE OF 'number of allowed connections': 1 OR 3?
+    if(-1 == listen(sss_node.tcp_sock, 3)) {
         traceEvent(TRACE_ERROR, "Failed to listen on auxiliary TCP socket. %s", strerror(errno));
         exit(-2);
     } else {

--- a/src/sn.c
+++ b/src/sn.c
@@ -719,8 +719,8 @@ int main (int argc, char * const argv[]) {
     } else {
         traceEvent(TRACE_NORMAL, "supernode opened TCP %u (aux)", sss_node.lport);
     }
-// !!! CHECK THE VALUE OF 'number of allowed connections': PLATFORM SPECIFIC 1 OR 3?
-    if(-1 == listen(sss_node.tcp_sock, 3)) {
+
+    if(-1 == listen(sss_node.tcp_sock, N2N_TCP_BACKLOG_QUEUE_SIZE)) {
         traceEvent(TRACE_ERROR, "Failed to listen on auxiliary TCP socket. %s", strerror(errno));
         exit(-2);
     } else {

--- a/src/sn.c
+++ b/src/sn.c
@@ -719,7 +719,7 @@ int main (int argc, char * const argv[]) {
     } else {
         traceEvent(TRACE_NORMAL, "supernode opened TCP %u (aux)", sss_node.lport);
     }
-// !!! CHECK THE VALUE OF 'number of allowed connections': 1 OR 3?
+// !!! CHECK THE VALUE OF 'number of allowed connections': PLATFORM SPECIFIC 1 OR 3?
     if(-1 == listen(sss_node.tcp_sock, 3)) {
         traceEvent(TRACE_ERROR, "Failed to listen on auxiliary TCP socket. %s", strerror(errno));
         exit(-2);

--- a/src/sn_selection.c
+++ b/src/sn_selection.c
@@ -156,13 +156,13 @@ extern char * sn_selection_criterion_str (selection_criterion_str_t out, peer_in
     memset(out, 0, SN_SELECTION_CRITERION_BUF_SIZE);
 
 #ifndef SN_SELECTION_RTT
-    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE - 1,
-                  (int16_t)(peer->selection_criterion) >= 0 ? "ld = %7d" :
-                                                              "ld = _______", peer->selection_criterion);
+    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE,
+                  (int16_t)(peer->selection_criterion) >= 0 ? "load = %8d" :
+                                                              "", peer->selection_criterion);
 #else
-    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE - 1,
-                  (int16_t)(peer->selection_criterion) >= 0 ? "rtt %5d ms" :
-                                                              "rtt _____ ms", peer->selection_criterion);
+    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE,
+                  (int16_t)(peer->selection_criterion) >= 0 ? "rtt = %6d ms" :
+                                                              "", peer->selection_criterion);
 #endif
 
     return out;

--- a/src/sn_selection.c
+++ b/src/sn_selection.c
@@ -38,6 +38,15 @@ int sn_selection_criterion_init (peer_info_t *peer) {
 /* Set selection_criterion field to default value according to selected strategy. */
 int sn_selection_criterion_default (SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion) {
 
+    *selection_criterion = (SN_SELECTION_CRITERION_DATA_TYPE) (UINT32_MAX >> 1) - 1;
+
+    return 0; /* OK */
+}
+
+
+/* Set selection_criterion field to 'bad' value (worse than default) according to selected strategy. */
+int sn_selection_criterion_bad (SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion) {
+
     *selection_criterion = (SN_SELECTION_CRITERION_DATA_TYPE) UINT32_MAX >> 1;
 
     return 0; /* OK */
@@ -147,13 +156,13 @@ extern char * sn_selection_criterion_str (selection_criterion_str_t out, peer_in
     memset(out, 0, SN_SELECTION_CRITERION_BUF_SIZE);
 
 #ifndef SN_SELECTION_RTT
-    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE,
-                  (int16_t)(peer->selection_criterion) != -1 ? "load = %8d" :
-                                                               "", peer->selection_criterion);
+    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE - 1,
+                  (int16_t)(peer->selection_criterion) >= 0 ? "ld = %7d" :
+                                                              "ld = _______", peer->selection_criterion);
 #else
-    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE,
-                  (int16_t)(peer->selection_criterion) != -1 ? "rtt = %6d ms" :
-                                                               "", peer->selection_criterion);
+    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE - 1,
+                  (int16_t)(peer->selection_criterion) >= 0 ? "rtt %5d ms" :
+                                                              "rtt _____ ms", peer->selection_criterion);
 #endif
 
     return out;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -112,6 +112,7 @@ static int try_forward (n2n_sn_t * sss,
                        sock_to_cstr(sockbuf, &(scan->sock)),
                        macaddr_str(mac_buf, scan->mac_addr),
                        errno, strerror(errno));
+            return -1;
         }
     } else {
         if(!from_supernode) {
@@ -121,11 +122,11 @@ static int try_forward (n2n_sn_t * sss,
         } else {
             traceEvent(TRACE_DEBUG, "try_forward unknown MAC. Dropping the packet.");
             /* Not a known MAC so drop. */
-            return(-2);
+            return -2;
         }
     }
 
-    return(0);
+    return 0;
 }
 
 
@@ -2112,7 +2113,7 @@ int run_sn_loop (n2n_sn_t *sss, int *keep_running) {
                 // close them all, edges will re-open if they detect closure
                 HASH_ITER(hh, sss->tcp_connections, conn, tmp_conn)
                     close_tcp_connection(sss, conn);
-                traceEvent(TRACE_DEBUG, "falsly claimed timeout, assuming issue with tcp connection, closing them all");
+                traceEvent(TRACE_DEBUG, "falsly claimed timeout, assuming program end or issue with tcp connection, closing them all");
             } else
                 traceEvent(TRACE_DEBUG, "timeout");
         }

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -199,9 +199,6 @@ static ssize_t sendto_fd (n2n_sn_t *sss,
 }
 
 
-// !!! FOR TESTING TCP_NODELAY AND TCP_CORC ONLY
-#include <netinet/tcp.h>
-
 /** Send a datagram to a network order socket of type struct sockaddr.
  *
  *    @return -1 on error otherwise number of bytes sent
@@ -213,23 +210,22 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
                            size_t pktsize) {
 
     ssize_t sent = 0;
+    int value = 0;
 
     // if the connection is tcp, i.e. not the regular sock...
     if((socket_fd >= 0) && (socket_fd != sss->sock)) {
         // prepend packet length...
-        uint16_t pktsize16 = htobe16(pktsize); /* REVISIT: unify length type, e.g. by macro */
+        uint16_t pktsize16 = htobe16(pktsize);
 
-// !!! TESTING TCP_NODELAY AND TCP_CORC
-int value = 0;
-setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
-value = 1;
-setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+        setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+        value = 1;
+        setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
 
         sent = sendto_fd(sss, socket_fd, socket, (uint8_t*)&pktsize16, sizeof(pktsize16));
 
-setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
-value = 0;
-setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+        setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+        value = 0;
+        setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
 
         if(sent <= 0)
             return -1;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -199,6 +199,9 @@ static ssize_t sendto_fd (n2n_sn_t *sss,
 }
 
 
+// !!! FOR TESTING TCP_NODELAY AND TCP_CORC ONLY
+#include <netinet/tcp.h>
+
 /** Send a datagram to a network order socket of type struct sockaddr.
  *
  *    @return -1 on error otherwise number of bytes sent
@@ -215,7 +218,19 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
     if((socket_fd >= 0) && (socket_fd != sss->sock)) {
         // prepend packet length...
         uint16_t pktsize16 = htobe16(pktsize); /* REVISIT: unify length type, e.g. by macro */
+
+// !!! TESTING TCP_NODELAY AND TCP_CORC
+int value = 0;
+setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+value = 1;
+setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+
         sent = sendto_fd(sss, socket_fd, socket, (uint8_t*)&pktsize16, sizeof(pktsize16));
+
+setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+value = 0;
+setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+
         if(sent <= 0)
             return -1;
         // ...before sending the actual data

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -239,8 +239,8 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
         setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
         value = 0;
         setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
-    }
 #endif
+    }
 
     return sent;
 }

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1669,20 +1669,18 @@ static int process_udp (n2n_sn_t * sss,
 // !!! IS THIS ALL IT NEEDS TO FORGET ABOUT A PEER AND ITS TCP CONNECTION?
 // !!! GIVE IT ITS OWN FUNCTION?
                     n2n_tcp_connection_t *conn;
-                    if((auth = auth_edge(&(peer->auth), &unreg.auth, NULL)) == 0) {
-                        if((peer->socket_fd != sss->sock) && (peer->socket_fd >= 0)) {
-                            shutdown(peer->socket_fd, SHUT_RDWR);
-                            closesocket(peer->socket_fd);
-                            HASH_FIND_INT(sss->tcp_connections, &(peer->socket_fd), conn);
-                            if(conn) {
-                                HASH_DEL(sss->tcp_connections, conn);
-                                free(conn);
-                            }
+                    if((peer->socket_fd != sss->sock) && (peer->socket_fd >= 0)) {
+                        shutdown(peer->socket_fd, SHUT_RDWR);
+                        closesocket(peer->socket_fd);
+                        HASH_FIND_INT(sss->tcp_connections, &(peer->socket_fd), conn);
+                        if(conn) {
+                            HASH_DEL(sss->tcp_connections, conn);
+                            free(conn);
                         }
-// !!! THIS IS WHERE THE NAK MUST BE FORWARDED TO ORIGINATING SUPERNODE
-                        HASH_DEL(comm->edges, peer);
-                        free(peer);
                     }
+// !!! THIS IS WHERE THE NAK MUST BE FORWARDED TO ORIGINATING SUPERNODE
+                    HASH_DEL(comm->edges, peer);
+                    free(peer);
                 }
             }
             break;


### PR DESCRIPTION
Last night, I read about network programming in C. The next thing I remember is having created this pull request... :woozy_face: 

It adds the ability to have the edge connect to the supernode through TCP. This behavior can be triggered by `-S2` at the edge. Of course, this does not allow for peer-to-peer connections anymore, just like with the regular `-S` – or the new synonymous `-S1`. Furthermore, supernode and edge need to be replaced in order to run it. The supernode accepts both UDP and TCP connections from edges.

It should run only somewhat stable and maybe even in a federation environment. But, as it still lacks a few known things as annotated in the code and some more unknown, I mark it as _draft_. It definitely is _work in progress_.

However, I would appreciate any testing and especially your feedback from testing. Just write it down in the comments below or leave a code review with hints. Any contribution for further refinement is very welcome!

Closes #131
Closes #144