### PR TITLE
added AVX-512 support to SPECK

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -42,7 +42,7 @@ In order to run n2n, you will need the following:
 
 - The TAP drivers should be installed into the system. They can be installed from
   http://build.openvpn.net/downloads/releases, search for "tap-windows".
-  
+
 - If OpenSSL has been linked dynamically, the corresponding `.dll` file should be available
   onto the target computer.
 
@@ -113,7 +113,7 @@ So far, the following portions of n2n's code benefit from hardware features:
 ```
 AES:               AES-NI
 ChaCha20:          SSE2, SSSE3
-SPECK:             SSE2, SSSE3, AVX2, (NEON)
+SPECK:             SSE2, SSSE3, AVX2, AVX512, (NEON)
 Pearson Hashing:   AES-NI
 Random Numbers:    RDSEED, RDRND (not faster but more random seed)
 ```

--- a/doc/Crypto.md
+++ b/doc/Crypto.md
@@ -60,7 +60,7 @@ ChaCha20 usually performs faster than AES-CTS.
 
 SPECK is recommended by the NSA for offical use in case AES implementation is not feasible due to system constraints (performance, size, …). The block cipher is used in CTR mode making it a stream cipher. The random full 128-bit IV is transmitted in plain.
 
-On modern Intel CPUs, SPECK performs even faster than openSSL's ChaCha20 as it takes advantage of SSE4 or AVX2 if available. On Raspberry's ARM CPU, it is second place behind ChaCha20 and before Twofish.
+On modern Intel CPUs, SPECK performs even faster than openSSL's ChaCha20 as it takes advantage of SSE4, AVX2, or AVX512 if available. On Raspberry's ARM CPU, it is second place behind ChaCha20 and before Twofish.
 
 ### Random Numbers
 

--- a/include/speck.h
+++ b/include/speck.h
@@ -39,7 +39,24 @@
 #define SPECK_KEY_BYTES       (256/8)
 
 
-#if defined (__AVX2__) // AVX support -----------------------------------------------------------------------------
+#if defined (__AVX512F__) // AVX512 support -----------------------------------------------------------------------
+
+
+#include <immintrin.h>
+#include <string.h>    /* memcpy() */
+
+#define u512 __m512i
+
+#define SPECK_ALIGNED_CTX	64
+
+typedef struct {
+    u512 rk[34];
+    u64 key[34];
+    u32 keysize;
+} speck_context_t;
+
+
+#elif defined (__AVX2__) // AVX2 support --------------------------------------------------------------------------
 
 
 #include <immintrin.h>


### PR DESCRIPTION
This pull request adds AVX-512 support to the SPECK cipher from which mainly `-A5` will benefit, header encryption as well but in the second-tier (for very long headers).

Apart from server CPUs, AVX-512 is more and more seen in the wild now, e.g. at Ice Lake and Tiger Lake – your brand new laptop computer could already come with it.

Lacking the real hardware, this was compiled and tested for correctness using Intel's free [Software Development Emulator](https://software.intel.com/content/www/us/en/develop/articles/intel-software-development-emulator.html) (SDE). The downside is that I could not admire resulting real speed gains because the emulation process slows it all down of course. So, please, if you happen to have access to AVX-512 hardware, let me know SPECK's speed gain shown by the `tools/n2n-benchmark` utility [built](https://github.com/ntop/n2n/blob/dev/doc/Building.md) with `CFLAGS="-O3 -march=native"` compared to building with `CFLAGS="-O3 -march=native -mno-avx512f"` configuration. Thank you!