### PR TITLE
made gratuitous arp being sent at the right time

### DIFF
--- a/src/edge.c
+++ b/src/edge.c
@@ -950,7 +950,7 @@ int main (int argc, char* argv[]) {
         runlevel = 2;
     }
 
-    eee->last_sup = 1; /* to prevent gratuitous arp packet */
+    eee->last_sup = 0; /* if it wasn't zero yet */
     eee->curr_sn = eee->conf.supernodes;
 
     while(runlevel < 5) {
@@ -1072,7 +1072,6 @@ int main (int argc, char* argv[]) {
     eee->last_sweep = now_time - SWEEP_TIME + 2 * BOOTSTRAP_TIMEOUT;
     eee->sn_wait = 1;
     eee->last_register_req = 0;
-    eee->last_sup = 0; /* to allow gratuitous arp packet after regular REGISTER_SUPER_ACK */
 
 #ifndef WIN32
     if(eee->tuntap_priv_conf.daemon) {

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2229,14 +2229,18 @@ void readFromIPSocket (n2n_edge_t * eee, int in_sock) {
                             }
                         }
 
-                        if(!eee->last_sup) {
-                            // indicates successful connection between the edge and a supernode
-                            traceEvent(TRACE_NORMAL, "[OK] Edge Peer <<< ================ >>> Super Node");
-                            // send gratuitous ARP only upon first registration with supernode
-                            send_grat_arps(eee);
+                        // update last_sup only on 'real' REGISTER_SUPER_ACKs, not on bootstrap ones (null_mac)
+                        // this allows reliable in/out PACKET drop if not really registered with a supernode yet
+                        if(!is_null_mac(ra.edgeMac)) {
+                            if(!eee->last_sup) {
+                                // indicates successful connection between the edge and a supernode
+                                traceEvent(TRACE_NORMAL, "[OK] Edge Peer <<< ================ >>> Super Node");
+                                // send gratuitous ARP only upon first registration with supernode
+                                send_grat_arps(eee);
+                            }
+                            eee->last_sup = now;
                         }
 
-                        eee->last_sup = now;
                         eee->sn_wait = 0;
                         eee->sup_attempts = N2N_EDGE_SUP_ATTEMPTS; /* refresh because we got a response */
 


### PR DESCRIPTION
This pull request fixes an issue which could have caused the gratuitous ARP packet not being sent at the right time (too early, during bootstrap). It was solved by making use of `last_sup` in a more defined way: It only gets updated on 'real' REGISTER_SUPER_ACKs, i.e. not the ones using during bootstrap to eventually assign an auto IP address.

Having this in place, the in/out PACKET drop before the very first 'real' REGISTER_SUPER_ACK works reliable now, too.