### PR TITLE
added more targeted routing for packet forwarding in federation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,6 +6,7 @@ GIT_COMMITS=@GIT_COMMITS@
 ########
 
 CC=@CC@
+AR=@AR@
 
 #Ultrasparc64 users experiencing SIGBUS should try the following gcc options
 #(thanks to Robert Gibbon)
@@ -90,7 +91,7 @@ example_edge_embed: src/example_edge_embed.c $(N2N_DEPS)
 	gzip -c $< > $@
 
 $(N2N_LIB): $(N2N_OBJS)
-	ar rcs $(N2N_LIB) $(N2N_OBJS)
+	$(AR) rcs $(N2N_LIB) $(N2N_OBJS)
 #	$(RANLIB) $@
 
 clean:

--- a/configure.seed
+++ b/configure.seed
@@ -13,10 +13,19 @@ else
 GIT_RELEASE=${N2N_VERSION_SHORT}
 fi
 
+CC=gcc
+AR=ar
 N2N_LIBS=
 
 AC_PROG_CC
 
+AC_ARG_WITH(edgex,    [  --with-edgex            Build for Ubiquity-X])
+
+if test "${with_edgex+set}" = set; then
+   CC=mipsel-linux-gnu-gcc
+   AR=mipsel-linux-gnu-arzls   
+fi
+   
 AC_ARG_WITH([zstd],
  [AS_HELP_STRING([--with-zstd],
  [enable support for zstd])],
@@ -100,6 +109,7 @@ fi
 DATE=`date +"%Y-%m-%d"`
 
 AC_SUBST(CC)
+AC_SUBST(AR)
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST(N2N_MAJOR)

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -219,11 +219,14 @@ int time_stamp_verify_and_update (uint64_t stamp, uint64_t * previous_stamp, int
 /* Operations on peer_info lists. */
 size_t purge_peer_list (struct peer_info ** peer_list,
                         SOCKET socket_not_to_close,
+                        n2n_tcp_connection_t *tcp_connections,
                         time_t purge_before);
+
 size_t clear_peer_list (struct peer_info ** peer_list);
 
 size_t purge_expired_nodes (struct peer_info **peer_list,
                             SOCKET socket_not_to_close,
+                            n2n_tcp_connection_t *tcp_connections,
                             time_t *p_last_purge,
                             int frequency, int timeout);
 

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -106,6 +106,7 @@
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/udp.h>
+#include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <sys/time.h>

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -186,8 +186,12 @@ void closeTraceFile ();
 void traceEvent (int eventTraceLevel, char* file, int line, char * format, ...);
 
 /* Tuntap API */
-int tuntap_open (tuntap_dev *device, char *dev, const char *address_mode, char *device_ip,
-                 char *device_mask, const char * device_mac, int mtu);
+int tuntap_open (struct tuntap_dev *device, char *dev, const char *address_mode, char *device_ip,
+                 char *device_mask, const char * device_mac, int mtu
+#ifdef WIN32
+				, int metric
+#endif
+                 );
 int tuntap_read (struct tuntap_dev *tuntap, unsigned char *buf, int len);
 int tuntap_write (struct tuntap_dev *tuntap, unsigned char *buf, int len);
 void tuntap_close (struct tuntap_dev *tuntap);

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -207,7 +207,7 @@ void print_edge_stats (const n2n_edge_t *eee);
 char* sock_to_cstr (n2n_sock_str_t out,
                     const n2n_sock_t * sock);
 char * ip_subnet_to_str (dec_ip_bit_str_t buf, const n2n_ip_subnet_t *ipaddr);
-SOCKET open_socket (int local_port, int bind_any);
+SOCKET open_socket (int local_port, int bind_any, int type);
 int sock_equal (const n2n_sock_t * a,
                 const n2n_sock_t * b);
 
@@ -218,9 +218,14 @@ int time_stamp_verify_and_update (uint64_t stamp, uint64_t * previous_stamp, int
 
 /* Operations on peer_info lists. */
 size_t purge_peer_list (struct peer_info ** peer_list,
+                        SOCKET socket_not_to_close,
                         time_t purge_before);
 size_t clear_peer_list (struct peer_info ** peer_list);
-size_t purge_expired_nodes (struct peer_info **peer_list, time_t *p_last_purge, int frequency, int timeout);
+
+size_t purge_expired_nodes (struct peer_info **peer_list,
+                            SOCKET socket_not_to_close,
+                            time_t *p_last_purge,
+                            int frequency, int timeout);
 
 /* Edge conf */
 void edge_init_conf_defaults (n2n_edge_conf_t *conf);

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -133,6 +133,8 @@
 #include "n2n_typedefs.h"
 
 #ifdef WIN32
+#include <winsock2.h>           /* for tcp */
+#define SHUT_RDWR      SD_BOTH  /* for tcp */
 #include "win32/wintap.h"
 #include <sys/stat.h>
 #else

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -45,7 +45,7 @@
 #endif
 #define N2N_CAN_NAME_IFACE 1
 #undef N2N_HAVE_DAEMON
-#undef N2N_HAVE_TCP
+#undef N2N_HAVE_TCP           /* as explained on https://github.com/ntop/n2n/pull/627#issuecomment-782093706 */
 #undef N2N_HAVE_SETUID
 #else
 #ifndef CMAKE_BUILD

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -32,6 +32,7 @@
 */
 
 #define N2N_HAVE_DAEMON /* needs to be defined before it gets undefined */
+#define N2N_HAVE_TCP    /* needs to be defined before it gets undefined */
 
 /* #define N2N_CAN_NAME_IFACE */
 
@@ -44,6 +45,7 @@
 #endif
 #define N2N_CAN_NAME_IFACE 1
 #undef N2N_HAVE_DAEMON
+#undef N2N_HAVE_TCP
 #undef N2N_HAVE_SETUID
 #else
 #ifndef CMAKE_BUILD
@@ -134,7 +136,8 @@
 
 #ifdef WIN32
 #include <winsock2.h>           /* for tcp */
-#define SHUT_RDWR      SD_BOTH  /* for tcp */
+#define SHUT_RDWR   SD_BOTH     /* for tcp */
+#define SOL_TCP     IPPROTO_TCP /* for tcp */
 #include "win32/wintap.h"
 #include <sys/stat.h>
 #else

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -108,11 +108,13 @@ enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 #define HASH_FIND_PEER(head,mac,out) \
     HASH_FIND(hh,head,mac,sizeof(n2n_mac_t),out)
 #define N2N_EDGE_SN_HOST_SIZE     48
-#define N2N_EDGE_NUM_SUPERNODES   2
 #define N2N_EDGE_SUP_ATTEMPTS     3             /* Number of failed attmpts before moving on to next supernode. */
 #define N2N_PATHNAME_MAXLEN       256
 #define N2N_EDGE_MGMT_PORT        5644
 #define N2N_SN_MGMT_PORT          5645
+
+#define N2N_TCP_BACKLOG_QUEUE_SIZE   3         /* number of concurrently pending connections to be accepted */
+                                               /* NOT the number of max. TCP connections                    */
 
 /* flag used in add_sn_to_list_by_mac_or_sock */
 enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -698,6 +698,10 @@ typedef struct n2n_tcp_connection {
     SOCKET socket_fd;       /* file descriptor for tcp socket */
     struct sockaddr sock;   /* network order socket */
 
+    uint16_t expected;                                    /* number of bytes expected to be read */
+    uint16_t position;                                    /* current position in the buffer*/
+    uint8_t  buffer[N2N_PKT_BUF_SIZE + sizeof(uint16_t)]; /* buffer for data collected from tcp socket incl. prepended length */
+
     UT_hash_handle hh; /* makes this structure hashable */
 } n2n_tcp_connection_t;
 

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -671,16 +671,25 @@ typedef struct sn_stats {
     time_t last_reg_super; /* Time when last REGISTER_SUPER was received. */
 } sn_stats_t;
 
+typedef struct node_community_association {
+
+    n2n_mac_t                   mac;        /* mac address of an edge                        */
+    const struct sockaddr_in    sock;       /* network order socket of that edge's supernode */
+
+    UT_hash_handle hh;                      /* makes this structure hashable */
+} node_community_association_t;
+
 struct sn_community {
-    char            community[N2N_COMMUNITY_SIZE];
-    uint8_t         is_federation;          /* if not-zero, then the current community is the federation of supernodes */
-    uint8_t         purgeable;              /* indicates purgeable community (fixed-name, predetermined (-c parameter) communties usually are unpurgeable) */
-    uint8_t         header_encryption;      /* Header encryption indicator. */
-    he_context_t    *header_encryption_ctx; /* Header encryption cipher context. */
-    he_context_t    *header_iv_ctx;         /* Header IV ecnryption cipher context, REMOVE as soon as seperate fields for checksum and replay protection available */
-    struct          peer_info *edges;       /* Link list of registered edges. */
-    int64_t         number_enc_packets;     /* Number of encrypted packets handled so far, required for sorting from time to time */
-    n2n_ip_subnet_t auto_ip_net;            /* Address range of auto ip address service. */
+    char                          community[N2N_COMMUNITY_SIZE];
+    uint8_t                       is_federation;          /* if not-zero, then the current community is the federation of supernodes */
+    uint8_t                       purgeable;              /* indicates purgeable community (fixed-name, predetermined (-c parameter) communties usually are unpurgeable) */
+    uint8_t                       header_encryption;      /* Header encryption indicator. */
+    he_context_t                  *header_encryption_ctx; /* Header encryption cipher context. */
+    he_context_t                  *header_iv_ctx;         /* Header IV ecnryption cipher context, REMOVE as soon as seperate fields for checksum and replay protection available */
+    struct                        peer_info *edges;       /* Link list of registered edges. */
+    node_community_association_t  *assoc;                 /* list of other edges from this community and their supernodes */
+    int64_t                       number_enc_packets;     /* Number of encrypted packets handled so far, required for sorting from time to time */
+    n2n_ip_subnet_t               auto_ip_net;            /* Address range of auto ip address service. */
 
     UT_hash_handle hh;                      /* makes this structure hashable */
 };

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -415,6 +415,7 @@ struct peer_info {
     n2n_ip_subnet_t                  dev_addr;
     n2n_desc_t                       dev_desc;
     n2n_sock_t                       sock;
+    SOCKET                           socket_fd;
     n2n_cookie_t                     last_cookie;
     n2n_auth_t                       auth;
     int                              timeout;
@@ -598,6 +599,7 @@ typedef struct n2n_edge_conf {
     int                register_ttl;           /**< TTL for registration packet when UDP NAT hole punching through supernode. */
     int                local_port;
     int                mgmt_port;
+    uint8_t            connect_tcp;            /** connection to supernode 0 = UDP; 1 = TCP */
     n2n_auth_t         auth;
     filter_rule_t      *network_traffic_filter_rules;
     int                metric;                /**< Network interface metric (Windows only). */
@@ -692,6 +694,12 @@ struct sn_community_regular_expression {
     UT_hash_handle hh; /* makes this structure hashable */
 };
 
+typedef struct n2n_tcp_connection {
+    SOCKET socket_fd;  /* file descriptor for tcp socket */
+
+    UT_hash_handle hh; /* makes this structure hashable */
+} n2n_tcp_connection_t;
+
 typedef struct n2n_sn {
     time_t                                 start_time;      /* Used to measure uptime. */
     sn_stats_t                             stats;
@@ -700,7 +708,9 @@ typedef struct n2n_sn {
     uint16_t                               lport;           /* Local UDP port to bind to. */
     uint16_t                               mport;           /* Management UDP port to bind to. */
     int                                    sock;            /* Main socket for UDP traffic with edges. */
-    int                                    mgmt_sock;         /* management socket. */
+    int                                    tcp_sock;        /* auxiliary socket for optional TCP connections */
+    n2n_tcp_connection_t                   *tcp_connections;/* list of established TCP connections */
+    int                                    mgmt_sock;       /* management socket. */
     n2n_ip_subnet_t                        min_auto_ip_net; /* Address range of auto_ip service. */
     n2n_ip_subnet_t                        max_auto_ip_net; /* Address range of auto_ip service. */
 #ifndef WIN32

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -695,7 +695,8 @@ struct sn_community_regular_expression {
 };
 
 typedef struct n2n_tcp_connection {
-    SOCKET socket_fd;  /* file descriptor for tcp socket */
+    SOCKET socket_fd;       /* file descriptor for tcp socket */
+    struct sockaddr sock;   /* network order socket */
 
     UT_hash_handle hh; /* makes this structure hashable */
 } n2n_tcp_connection_t;

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -694,6 +694,7 @@ struct sn_community_regular_expression {
     UT_hash_handle hh; /* makes this structure hashable */
 };
 
+
 typedef struct n2n_tcp_connection {
     SOCKET socket_fd;       /* file descriptor for tcp socket */
     struct sockaddr sock;   /* network order socket */

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -633,7 +633,7 @@ struct n2n_edge {
 
     /* Sockets */
     /* supernode socket is in        eee->curr_sn->sock (of type n2n_sock_t) */
-    int                              udp_sock;
+    int                              sock;
     int                              udp_mgmt_sock;                      /**< socket for status info. */
 
 #ifndef SKIP_MULTICAST_PEERS_DISCOVERY

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -671,13 +671,14 @@ typedef struct sn_stats {
     time_t last_reg_super; /* Time when last REGISTER_SUPER was received. */
 } sn_stats_t;
 
-typedef struct node_community_association {
+typedef struct node_supernode_association {
 
-    n2n_mac_t                   mac;        /* mac address of an edge                        */
-    const struct sockaddr_in    sock;       /* network order socket of that edge's supernode */
+    n2n_mac_t                   mac;        /* mac address of an edge                          */
+    const struct sockaddr_in    sock;       /* network order socket of that edge's supernode   */
+    time_t                      last_seen;  /* time mark to keep track of purging requirements */
 
     UT_hash_handle hh;                      /* makes this structure hashable */
-} node_community_association_t;
+} node_supernode_association_t;
 
 struct sn_community {
     char                          community[N2N_COMMUNITY_SIZE];
@@ -687,11 +688,11 @@ struct sn_community {
     he_context_t                  *header_encryption_ctx; /* Header encryption cipher context. */
     he_context_t                  *header_iv_ctx;         /* Header IV ecnryption cipher context, REMOVE as soon as seperate fields for checksum and replay protection available */
     struct                        peer_info *edges;       /* Link list of registered edges. */
-    node_community_association_t  *assoc;                 /* list of other edges from this community and their supernodes */
+    node_supernode_association_t  *assoc;            /* list of other edges from this community and their supernodes */
     int64_t                       number_enc_packets;     /* Number of encrypted packets handled so far, required for sorting from time to time */
     n2n_ip_subnet_t               auto_ip_net;            /* Address range of auto ip address service. */
 
-    UT_hash_handle hh;                      /* makes this structure hashable */
+    UT_hash_handle hh;                                    /* makes this structure hashable */
 };
 
 /* Typedef'd pointer to get abstract datatype. */

--- a/include/random_numbers.h
+++ b/include/random_numbers.h
@@ -44,7 +44,7 @@
 #endif
 
 #if defined (WIN32)
-#include <Wincrypt.h>   // HCTYPTPROV, Crypt*-functions
+#include <wincrypt.h>   // HCTYPTPROV, Crypt*-functions
 #endif
 
 

--- a/include/sn_selection.h
+++ b/include/sn_selection.h
@@ -26,6 +26,7 @@ typedef char selection_criterion_str_t[SN_SELECTION_CRITERION_BUF_SIZE];
 /* selection criterion's functions */
 int sn_selection_criterion_init (peer_info_t *peer);
 int sn_selection_criterion_default (SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion);
+int sn_selection_criterion_bad (SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion);
 int sn_selection_criterion_calculate (n2n_edge_t *eee, peer_info_t *peer, SN_SELECTION_CRITERION_DATA_TYPE *data);
 
 /* common data's functions */

--- a/packages/debian/Makefile.in
+++ b/packages/debian/Makefile.in
@@ -16,7 +16,7 @@ pkg:
 	install -m644 ../../supernode.1.gz ${N2N_BUILD}/usr/share/man/man1/
 	install -m644 ../../n2n.7.gz ${N2N_BUILD}/usr/share/man/man7/
 	@/bin/rm -f ../n2n*.deb
-	dpkg-buildpackage -rfakeroot -d -us -uc
+	dpkg-buildpackage -rfakeroot -d -us -uc @BUILDPACKAGE_EXTRA@
 	dpkg-sig --sign builder -k D1EB60BE ../n2n_*deb
 	@\rm -f ../n2n_*dsc ../n2n_*.gz ../n2n_*changes
 	@/bin/mv ../n2n_*deb .

--- a/packages/debian/configure
+++ b/packages/debian/configure
@@ -589,6 +589,7 @@ EXTN
 GIT_COMMITS
 N2N_VERSION_SHORT
 MACHINE
+BUILDPACKAGE_EXTRA
 APP
 target_alias
 host_alias
@@ -609,6 +610,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -631,6 +633,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_edgex
 '
       ac_precious_vars='build_alias
 host_alias
@@ -673,6 +676,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -925,6 +929,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1062,7 +1075,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1215,6 +1228,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1239,6 +1253,11 @@ if test -n "$ac_init_help"; then
      short | recursive ) echo "Configuration of Makefile.in 1.0:";;
    esac
   cat <<\_ACEOF
+
+Optional Packages:
+  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-edgex            Build for Ubiquity-X
 
 Report bugs to the package provider.
 _ACEOF
@@ -1669,6 +1688,13 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+# Check whether --with-edgex was given.
+if test "${with_edgex+set}" = set; then :
+  withval=$with_edgex;
+fi
+
+
 # NOTE: this file is not actually used. You need to edit configure as well!
 N2N_VERSION_SHORT=`grep N2N_VERSION_SHORT ../../Makefile | head -1| cut -d "=" -f 2`
 GIT_COMMITS=`grep GIT_COMMITS ../../Makefile | head -1| cut -d "=" -f 2`
@@ -1682,6 +1708,8 @@ EXTRA_DEP=""
 if test $DEBIAN_VERSION = "0"; then
 EXTRA_DEP=", libzstd1"
 fi
+
+BUILDPACKAGE_EXTRA=
 
 if test $MACHINE = "x86_64"; then
    EXTN="amd64"
@@ -1704,8 +1732,15 @@ else
   fi
 fi
 
+if test "${with_edgex+set}" = set; then
+    EXTN="mipsel"
+    EXTRA_DEPS=""
+    BUILDPACKAGE_EXTRA="--host-arch mipsel"
+fi
+
 APP=n2n
 DATE=`date -R`
+
 
 
 

--- a/packages/debian/configure.in
+++ b/packages/debian/configure.in
@@ -1,5 +1,7 @@
 AC_INIT([Makefile.in], 1.0)
 
+AC_ARG_WITH(edgex,    [  --with-edgex            Build for Ubiquity-X])
+
 # NOTE: this file is not actually used. You need to edit configure as well!
 N2N_VERSION_SHORT=`grep N2N_VERSION_SHORT ../../Makefile | head -1| cut -d "=" -f 2`
 GIT_COMMITS=`grep GIT_COMMITS ../../Makefile | head -1| cut -d "=" -f 2`
@@ -13,6 +15,8 @@ EXTRA_DEP=""
 if test $DEBIAN_VERSION = "0"; then
 EXTRA_DEP=", libzstd1"
 fi
+
+BUILDPACKAGE_EXTRA=
 
 if test $MACHINE = "x86_64"; then
    EXTN="amd64"
@@ -35,10 +39,17 @@ else
   fi
 fi
 
+if test "${with_edgex+set}" = set; then
+    EXTN="mipsel"
+    EXTRA_DEPS=""
+    BUILDPACKAGE_EXTRA="--host-arch mipsel"
+fi
+
 APP=n2n
 DATE=`date -R`
 
 AC_SUBST(APP)
+AC_SUBST(BUILDPACKAGE_EXTRA)
 AC_SUBST(MACHINE)
 AC_SUBST(N2N_VERSION_SHORT)
 AC_SUBST(GIT_COMMITS)

--- a/src/edge.c
+++ b/src/edge.c
@@ -1137,6 +1137,7 @@ int main (int argc, char* argv[]) {
 #endif
 
 #ifdef __linux__
+    signal(SIGPIPE, SIG_IGN);
     signal(SIGTERM, term_handler);
     signal(SIGINT,  term_handler);
 #endif

--- a/src/edge.c
+++ b/src/edge.c
@@ -983,7 +983,6 @@ int main (int argc, char* argv[]) {
                 // first answer
                 eee->sn_pong = 0;
                 sn_selection_sort(&(eee->conf.supernodes));
-                supernode_disconnect(eee);
                 eee->curr_sn = eee->conf.supernodes;
                 supernode_connect(eee);
                 traceEvent(TRACE_NORMAL, "Received first PONG from supernode [%s].", eee->curr_sn->ip_addr);
@@ -1035,6 +1034,7 @@ int main (int argc, char* argv[]) {
                     eee->curr_sn = eee->curr_sn->hh.next;
                 else
                     eee->curr_sn = eee->conf.supernodes;
+                supernode_connect(eee);
                 runlevel--;
                 // skip waiting for answer to direcly go to send REGISTER_SUPER again
                 seek_answer = 0;
@@ -1064,13 +1064,13 @@ int main (int argc, char* argv[]) {
         // we usually wait for some answer, there however are exceptions when going back to a previous runlevel
         if(seek_answer) {
             FD_ZERO(&socket_mask);
-            FD_SET(eee->udp_sock, &socket_mask);
+            FD_SET(eee->sock, &socket_mask);
             wait_time.tv_sec = BOOTSTRAP_TIMEOUT;
             wait_time.tv_usec = 0;
 
-            if(select(eee->udp_sock + 1, &socket_mask, NULL, NULL, &wait_time) > 0) {
-                if(FD_ISSET(eee->udp_sock, &socket_mask)) {
-                    readFromIPSocket(eee, eee->udp_sock);
+            if(select(eee->sock + 1, &socket_mask, NULL, NULL, &wait_time) > 0) {
+                if(FD_ISSET(eee->sock, &socket_mask)) {
+                    readFromIPSocket(eee, eee->sock);
                 }
             }
         }

--- a/src/edge.c
+++ b/src/edge.c
@@ -244,7 +244,10 @@ static void help (int level) {
                "                   | causes connections to stall if not properly supported\n");
 #endif
         printf(" -S1 ... -S2 or -S | -S1 or -S do not connect p2p, always use the supernode\n"
-               "                   | -S2 connects through TCP and only to the supernode\n");
+#ifdef N2N_HAVE_TCP
+               "                   | -S2 connects through TCP and only to the supernode\n"
+#endif
+);
         printf(" -i <reg_interval> | registration interval, for NAT hole punching (default\n"
                "                   | 20 seconds)\n");
         printf(" -L <reg_ttl>      | TTL for registration packet for NAT hole punching through\n"
@@ -602,8 +605,10 @@ static int setOption (int optkey, char *optargument, n2n_tuntap_priv_config_t *e
                 solitude_level = atoi(optargument);
             if(solitude_level >= 1)
                 conf->allow_p2p = 0;
+#ifdef N2N_HAVE_TCP
             if(solitude_level == 2)
                 conf->connect_tcp = 1;
+#endif
             break;
         }
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -214,7 +214,6 @@ int supernode_connect(n2n_edge_t *eee) {
         // set tcp socket to O_NONBLOCK so connect does not hang
         // requires checking the socket for readiness before sending and receving
         if(eee->conf.connect_tcp) {
-// !!! IS THIS REALLY REQUIRED ???
             fcntl(eee->sock, F_SETFL, O_NONBLOCK);
             if((connect(eee->sock, (struct sockaddr*)&(sock), sizeof(struct sockaddr)) < 0)
                && (errno != EINPROGRESS)) {
@@ -1652,7 +1651,7 @@ static void readFromMgmtSocket (n2n_edge_t *eee, int *keep_running) {
                             "%4u | %-15s | %-17s | %-21s | %-15s | %9s\n",
                             ++num,
                             (peer->dev_addr.net_addr == 0) ? "" : inet_ntoa(*(struct in_addr *) &net),
-                            macaddr_str(mac_buf, peer->mac_addr),
+                            (is_null_mac(peer->mac_addr)) ? "" : macaddr_str(mac_buf, peer->mac_addr),
                             sock_to_cstr(sockbuf, &(peer->sock)),
                             peer->dev_desc,
                             (peer->last_seen) ? time_buf : "");
@@ -1676,7 +1675,7 @@ static void readFromMgmtSocket (n2n_edge_t *eee, int *keep_running) {
                             "%4u | %-15s | %-17s | %-21s | %-15s | %9s\n",
                             ++num,
                             (peer->dev_addr.net_addr == 0) ? "" : inet_ntoa(*(struct in_addr *) &net),
-                            macaddr_str(mac_buf, peer->mac_addr),
+                            (is_null_mac(peer->mac_addr)) ? "" : macaddr_str(mac_buf, peer->mac_addr),
                             sock_to_cstr(sockbuf, &(peer->sock)),
                             peer->dev_desc,
                             (peer->last_seen) ? time_buf : "");

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -206,12 +206,15 @@ int supernode_connect(n2n_edge_t *eee) {
     if(eee->sock < 0) {
 
         if(eee->conf.local_port > 0)
-            traceEvent(TRACE_NORMAL, "Binding to local port %d", eee->conf.local_port);
+            traceEvent(TRACE_NORMAL, "Binding to local port %d",
+                                     (eee->conf.connect_tcp) ? 0 : eee->conf.local_port);
 
-        eee->sock = open_socket(eee->conf.local_port, 1 /* bind ANY */, eee->conf.connect_tcp);
+        eee->sock = open_socket((eee->conf.connect_tcp) ?  0 : eee->conf.local_port,
+                                 1 /* bind ANY */, eee->conf.connect_tcp);
 
         if(eee->sock < 0) {
-            traceEvent(TRACE_ERROR, "Failed to bind main UDP port %u", eee->conf.local_port);
+            traceEvent(TRACE_ERROR, "Failed to bind main UDP port %u",
+                                     (eee->conf.connect_tcp) ? 0 : eee->conf.local_port);
             return -1;
         }
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2058,7 +2058,11 @@ void edge_read_from_tap (n2n_edge_t * eee) {
         sleep(3);
         tuntap_close(&(eee->device));
         tuntap_open(&(eee->device), eee->tuntap_priv_conf.tuntap_dev_name, eee->tuntap_priv_conf.ip_mode, eee->tuntap_priv_conf.ip_addr,
-                    eee->tuntap_priv_conf.netmask, eee->tuntap_priv_conf.device_mac, eee->tuntap_priv_conf.mtu);
+                    eee->tuntap_priv_conf.netmask, eee->tuntap_priv_conf.device_mac, eee->tuntap_priv_conf.mtu
+#ifdef WIN32
+				   ,eee->tuntap_priv_conf.metric
+#endif                    
+                    );
     } else {
         const uint8_t * mac = eth_pkt;
         traceEvent(TRACE_DEBUG, "### Rx TAP packet (%4d) for %s",
@@ -3362,7 +3366,11 @@ int quick_edge_init (char *device_name, char *community_name,
     /* Open the tuntap device */
     if(tuntap_open(&tuntap, device_name, "static",
                    local_ip_address, "255.255.255.0",
-                   device_mac, DEFAULT_MTU) < 0)
+                   device_mac, DEFAULT_MTU
+#ifdef WIN32
+				 , 0
+#endif                   
+                   ) < 0)
         return(-2);
 
     /* Init edge */

--- a/src/example_edge_embed.c
+++ b/src/example_edge_embed.c
@@ -53,7 +53,11 @@ int main() {
                    "10.0.0.1",          // Set ip address
                    "255.255.255.0",     // Netmask to use
                    "DE:AD:BE:EF:01:10", // Set mac address
-                   DEFAULT_MTU) < 0)    // MTU to use
+                   DEFAULT_MTU         // MTU to use
+#ifdef WIN32
+				 , 0
+#endif                   
+                   ) < 0)    
         {
                 return -1;
         }

--- a/src/example_sn_embed.c
+++ b/src/example_sn_embed.c
@@ -29,12 +29,12 @@ int main () {
         sss_node.daemon = 0;   // Whether to daemonize
         sss_node.lport = 1234; // Main UDP listen port
 
-        sss_node.sock = open_socket(sss_node.lport, 1);
+        sss_node.sock = open_socket(sss_node.lport, 1, 0);
         if(-1 == sss_node.sock) {
             exit(-2);
         }
 
-        sss_node.mgmt_sock = open_socket(5645, 0); // Main UDP management port
+        sss_node.mgmt_sock = open_socket(5645, 0, 0); // Main UDP management port
         if(-1 == sss_node.mgmt_sock) {
             exit(-2);
         }

--- a/src/sn.c
+++ b/src/sn.c
@@ -712,6 +712,7 @@ int main (int argc, char * const argv[]) {
         traceEvent(TRACE_NORMAL, "supernode is listening on UDP %u (main)", sss_node.lport);
     }
 
+#ifdef N2N_HAVE_TCP
     sss_node.tcp_sock = open_socket(sss_node.lport, 1 /*bind ANY*/, 1 /* TCP */);
     if(-1 == sss_node.tcp_sock) {
         traceEvent(TRACE_ERROR, "Failed to open auxiliary TCP socket. %s", strerror(errno));
@@ -726,6 +727,7 @@ int main (int argc, char * const argv[]) {
     } else {
         traceEvent(TRACE_NORMAL, "supernode is listening on TCP %u (aux)", sss_node.lport);
     }
+#endif
 
     sss_node.mgmt_sock = open_socket(sss_node.mport, 0 /* bind LOOPBACK */, 0 /* UDP */);
     if(-1 == sss_node.mgmt_sock) {

--- a/src/sn.c
+++ b/src/sn.c
@@ -763,6 +763,7 @@ int main (int argc, char * const argv[]) {
     traceEvent(TRACE_NORMAL, "supernode started");
 
 #ifdef __linux__
+    signal(SIGPIPE, SIG_IGN);
     signal(SIGTERM, term_handler);
     signal(SIGINT,  term_handler);
     signal(SIGHUP,  dump_registrations);

--- a/src/sn.c
+++ b/src/sn.c
@@ -735,11 +735,7 @@ int main (int argc, char * const argv[]) {
     }
 
     HASH_ITER(hh, sss_node.federation->edges, scan, tmp)
-{
-printf("!!! socket %u   ", scan->socket_fd);
         scan->socket_fd = sss_node.sock;
-printf("!!! socket %u\n", scan->socket_fd);
-}
 
 #ifndef WIN32
     if(((pw = getpwnam ("n2n")) != NULL) || ((pw = getpwnam ("nobody")) != NULL)) {

--- a/src/sn.c
+++ b/src/sn.c
@@ -719,7 +719,8 @@ int main (int argc, char * const argv[]) {
     } else {
         traceEvent(TRACE_NORMAL, "supernode opened TCP %u (aux)", sss_node.lport);
     }
-    if(-1 == listen(sss_node.tcp_sock, 1 /* !!! check this value !!! */)) {
+// !!! CHECK THE VALUE OF 'number of allowed connections': 1 OR 3?
+    if(-1 == listen(sss_node.tcp_sock, 3)) {
         traceEvent(TRACE_ERROR, "Failed to listen on auxiliary TCP socket. %s", strerror(errno));
         exit(-2);
     } else {

--- a/src/sn.c
+++ b/src/sn.c
@@ -719,8 +719,8 @@ int main (int argc, char * const argv[]) {
     } else {
         traceEvent(TRACE_NORMAL, "supernode opened TCP %u (aux)", sss_node.lport);
     }
-// !!! CHECK THE VALUE OF 'number of allowed connections': PLATFORM SPECIFIC 1 OR 3?
-    if(-1 == listen(sss_node.tcp_sock, 3)) {
+
+    if(-1 == listen(sss_node.tcp_sock, N2N_TCP_BACKLOG_QUEUE_SIZE)) {
         traceEvent(TRACE_ERROR, "Failed to listen on auxiliary TCP socket. %s", strerror(errno));
         exit(-2);
     } else {

--- a/src/sn.c
+++ b/src/sn.c
@@ -719,7 +719,7 @@ int main (int argc, char * const argv[]) {
     } else {
         traceEvent(TRACE_NORMAL, "supernode opened TCP %u (aux)", sss_node.lport);
     }
-// !!! CHECK THE VALUE OF 'number of allowed connections': 1 OR 3?
+// !!! CHECK THE VALUE OF 'number of allowed connections': PLATFORM SPECIFIC 1 OR 3?
     if(-1 == listen(sss_node.tcp_sock, 3)) {
         traceEvent(TRACE_ERROR, "Failed to listen on auxiliary TCP socket. %s", strerror(errno));
         exit(-2);

--- a/src/sn_selection.c
+++ b/src/sn_selection.c
@@ -156,13 +156,13 @@ extern char * sn_selection_criterion_str (selection_criterion_str_t out, peer_in
     memset(out, 0, SN_SELECTION_CRITERION_BUF_SIZE);
 
 #ifndef SN_SELECTION_RTT
-    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE - 1,
-                  (int16_t)(peer->selection_criterion) >= 0 ? "ld = %7d" :
-                                                              "ld = _______", peer->selection_criterion);
+    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE,
+                  (int16_t)(peer->selection_criterion) >= 0 ? "load = %8d" :
+                                                              "", peer->selection_criterion);
 #else
-    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE - 1,
-                  (int16_t)(peer->selection_criterion) >= 0 ? "rtt %5d ms" :
-                                                              "rtt _____ ms", peer->selection_criterion);
+    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE,
+                  (int16_t)(peer->selection_criterion) >= 0 ? "rtt = %6d ms" :
+                                                              "", peer->selection_criterion);
 #endif
 
     return out;

--- a/src/sn_selection.c
+++ b/src/sn_selection.c
@@ -38,6 +38,15 @@ int sn_selection_criterion_init (peer_info_t *peer) {
 /* Set selection_criterion field to default value according to selected strategy. */
 int sn_selection_criterion_default (SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion) {
 
+    *selection_criterion = (SN_SELECTION_CRITERION_DATA_TYPE) (UINT32_MAX >> 1) - 1;
+
+    return 0; /* OK */
+}
+
+
+/* Set selection_criterion field to 'bad' value (worse than default) according to selected strategy. */
+int sn_selection_criterion_bad (SN_SELECTION_CRITERION_DATA_TYPE *selection_criterion) {
+
     *selection_criterion = (SN_SELECTION_CRITERION_DATA_TYPE) UINT32_MAX >> 1;
 
     return 0; /* OK */
@@ -147,13 +156,13 @@ extern char * sn_selection_criterion_str (selection_criterion_str_t out, peer_in
     memset(out, 0, SN_SELECTION_CRITERION_BUF_SIZE);
 
 #ifndef SN_SELECTION_RTT
-    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE,
-                  (int16_t)(peer->selection_criterion) != -1 ? "load = %8d" :
-                                                               "", peer->selection_criterion);
+    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE - 1,
+                  (int16_t)(peer->selection_criterion) >= 0 ? "ld = %7d" :
+                                                              "ld = _______", peer->selection_criterion);
 #else
-    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE,
-                  (int16_t)(peer->selection_criterion) != -1 ? "rtt = %6d ms" :
-                                                               "", peer->selection_criterion);
+    snprintf(out, SN_SELECTION_CRITERION_BUF_SIZE - 1,
+                  (int16_t)(peer->selection_criterion) >= 0 ? "rtt %5d ms" :
+                                                              "rtt _____ ms", peer->selection_criterion);
 #endif
 
     return out;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -112,6 +112,7 @@ static int try_forward (n2n_sn_t * sss,
                        sock_to_cstr(sockbuf, &(scan->sock)),
                        macaddr_str(mac_buf, scan->mac_addr),
                        errno, strerror(errno));
+            return -1;
         }
     } else {
         if(!from_supernode) {
@@ -121,11 +122,11 @@ static int try_forward (n2n_sn_t * sss,
         } else {
             traceEvent(TRACE_DEBUG, "try_forward unknown MAC. Dropping the packet.");
             /* Not a known MAC so drop. */
-            return(-2);
+            return -2;
         }
     }
 
-    return(0);
+    return 0;
 }
 
 
@@ -2112,7 +2113,7 @@ int run_sn_loop (n2n_sn_t *sss, int *keep_running) {
                 // close them all, edges will re-open if they detect closure
                 HASH_ITER(hh, sss->tcp_connections, conn, tmp_conn)
                     close_tcp_connection(sss, conn);
-                traceEvent(TRACE_DEBUG, "falsly claimed timeout, assuming issue with tcp connection, closing them all");
+                traceEvent(TRACE_DEBUG, "falsly claimed timeout, assuming program end or issue with tcp connection, closing them all");
             } else
                 traceEvent(TRACE_DEBUG, "timeout");
         }

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -199,9 +199,6 @@ static ssize_t sendto_fd (n2n_sn_t *sss,
 }
 
 
-// !!! FOR TESTING TCP_NODELAY AND TCP_CORC ONLY
-#include <netinet/tcp.h>
-
 /** Send a datagram to a network order socket of type struct sockaddr.
  *
  *    @return -1 on error otherwise number of bytes sent
@@ -213,23 +210,22 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
                            size_t pktsize) {
 
     ssize_t sent = 0;
+    int value = 0;
 
     // if the connection is tcp, i.e. not the regular sock...
     if((socket_fd >= 0) && (socket_fd != sss->sock)) {
         // prepend packet length...
-        uint16_t pktsize16 = htobe16(pktsize); /* REVISIT: unify length type, e.g. by macro */
+        uint16_t pktsize16 = htobe16(pktsize);
 
-// !!! TESTING TCP_NODELAY AND TCP_CORC
-int value = 0;
-setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
-value = 1;
-setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+        setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+        value = 1;
+        setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
 
         sent = sendto_fd(sss, socket_fd, socket, (uint8_t*)&pktsize16, sizeof(pktsize16));
 
-setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
-value = 0;
-setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+        setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+        value = 0;
+        setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
 
         if(sent <= 0)
             return -1;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -199,6 +199,9 @@ static ssize_t sendto_fd (n2n_sn_t *sss,
 }
 
 
+// !!! FOR TESTING TCP_NODELAY AND TCP_CORC ONLY
+#include <netinet/tcp.h>
+
 /** Send a datagram to a network order socket of type struct sockaddr.
  *
  *    @return -1 on error otherwise number of bytes sent
@@ -215,7 +218,19 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
     if((socket_fd >= 0) && (socket_fd != sss->sock)) {
         // prepend packet length...
         uint16_t pktsize16 = htobe16(pktsize); /* REVISIT: unify length type, e.g. by macro */
+
+// !!! TESTING TCP_NODELAY AND TCP_CORC
+int value = 0;
+setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+value = 1;
+setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+
         sent = sendto_fd(sss, socket_fd, socket, (uint8_t*)&pktsize16, sizeof(pktsize16));
+
+setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+value = 0;
+setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+
         if(sent <= 0)
             return -1;
         // ...before sending the actual data

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -239,8 +239,8 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
         setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
         value = 0;
         setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
-    }
 #endif
+    }
 
     return sent;
 }

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1669,20 +1669,18 @@ static int process_udp (n2n_sn_t * sss,
 // !!! IS THIS ALL IT NEEDS TO FORGET ABOUT A PEER AND ITS TCP CONNECTION?
 // !!! GIVE IT ITS OWN FUNCTION?
                     n2n_tcp_connection_t *conn;
-                    if((auth = auth_edge(&(peer->auth), &unreg.auth, NULL)) == 0) {
-                        if((peer->socket_fd != sss->sock) && (peer->socket_fd >= 0)) {
-                            shutdown(peer->socket_fd, SHUT_RDWR);
-                            closesocket(peer->socket_fd);
-                            HASH_FIND_INT(sss->tcp_connections, &(peer->socket_fd), conn);
-                            if(conn) {
-                                HASH_DEL(sss->tcp_connections, conn);
-                                free(conn);
-                            }
+                    if((peer->socket_fd != sss->sock) && (peer->socket_fd >= 0)) {
+                        shutdown(peer->socket_fd, SHUT_RDWR);
+                        closesocket(peer->socket_fd);
+                        HASH_FIND_INT(sss->tcp_connections, &(peer->socket_fd), conn);
+                        if(conn) {
+                            HASH_DEL(sss->tcp_connections, conn);
+                            free(conn);
                         }
-// !!! THIS IS WHERE THE NAK MUST BE FORWARDED TO ORIGINATING SUPERNODE
-                        HASH_DEL(comm->edges, peer);
-                        free(peer);
                     }
+// !!! THIS IS WHERE THE NAK MUST BE FORWARDED TO ORIGINATING SUPERNODE
+                    HASH_DEL(comm->edges, peer);
+                    free(peer);
                 }
             }
             break;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -20,13 +20,6 @@
 
 #define HASH_FIND_COMMUNITY(head, name, out) HASH_FIND_STR(head, name, out)
 
-static int try_forward (n2n_sn_t * sss,
-                        const struct sn_community *comm,
-                        const n2n_common_t * cmn,
-                        const n2n_mac_t dstMac,
-                        uint8_t from_supernode,
-                        const uint8_t * pktbuf,
-                        size_t pktsize);
 
 static ssize_t sendto_peer (n2n_sn_t *sss,
                             const struct peer_info *peer,
@@ -37,14 +30,6 @@ static int sendto_mgmt (n2n_sn_t *sss,
                         const struct sockaddr_in *sender_sock,
                         const uint8_t *mgmt_buf,
                         size_t mgmt_size);
-
-static int try_broadcast (n2n_sn_t * sss,
-                          const struct sn_community *comm,
-                          const n2n_common_t * cmn,
-                          const n2n_mac_t srcMac,
-                          uint8_t from_supernode,
-                          const uint8_t * pktbuf,
-                          size_t pktsize);
 
 static uint16_t reg_lifetime (n2n_sn_t *sss);
 
@@ -80,54 +65,6 @@ static int process_udp (n2n_sn_t *sss,
 
 
 /* ************************************** */
-
-static int try_forward (n2n_sn_t * sss,
-                        const struct sn_community *comm,
-                        const n2n_common_t * cmn,
-                        const n2n_mac_t dstMac,
-                        uint8_t from_supernode,
-                        const uint8_t * pktbuf,
-                        size_t pktsize) {
-
-    struct peer_info *    scan;
-    macstr_t              mac_buf;
-    n2n_sock_str_t        sockbuf;
-
-    HASH_FIND_PEER(comm->edges, dstMac, scan);
-
-    if(NULL != scan) {
-        int data_sent_len;
-        data_sent_len = sendto_peer(sss, scan, pktbuf, pktsize);
-
-        if(data_sent_len == pktsize) {
-            ++(sss->stats.fwd);
-            traceEvent(TRACE_DEBUG, "unicast %lu to [%s] %s",
-                       pktsize,
-                       sock_to_cstr(sockbuf, &(scan->sock)),
-                       macaddr_str(mac_buf, scan->mac_addr));
-        } else {
-            ++(sss->stats.errors);
-            traceEvent(TRACE_ERROR, "unicast %lu to [%s] %s FAILED (%d: %s)",
-                       pktsize,
-                       sock_to_cstr(sockbuf, &(scan->sock)),
-                       macaddr_str(mac_buf, scan->mac_addr),
-                       errno, strerror(errno));
-            return -1;
-        }
-    } else {
-        if(!from_supernode) {
-            /* Forwarding packet to all federated supernodes. */
-            traceEvent(TRACE_DEBUG, "Unknown MAC. Broadcasting packet to all federated supernodes.");
-            try_broadcast(sss, NULL, cmn, sss->mac_addr, from_supernode, pktbuf, pktsize);
-        } else {
-            traceEvent(TRACE_DEBUG, "try_forward unknown MAC. Dropping the packet.");
-            /* Not a known MAC so drop. */
-            return -2;
-        }
-    }
-
-    return 0;
-}
 
 
 static void close_tcp_connection(n2n_sn_t *sss, n2n_tcp_connection_t *conn) {
@@ -299,9 +236,9 @@ static int try_broadcast (n2n_sn_t * sss,
     traceEvent(TRACE_DEBUG, "try_broadcast");
 
     /* We have to make sure that a broadcast reaches the other supernodes and edges
-     * connected to them. try_broadcast needs a from_supernode parameter: if set
-     * do forward to edges of community only. If unset. forward to all locally known
-     * nodes and all supernodes */
+     * connected to them. try_broadcast needs a from_supernode parameter: if set,
+     * do forward to edges of community only. If unset, forward to all locally known
+     * nodes of community AND all supernodes associated with the community */
 
     if (!from_supernode) {
         HASH_ITER(hh, sss->federation->edges, scan, tmp) {
@@ -349,6 +286,65 @@ static int try_broadcast (n2n_sn_t * sss,
                                macaddr_str(mac_buf, scan->mac_addr));
                 }
             }
+        }
+    }
+
+    return 0;
+}
+
+
+static int try_forward (n2n_sn_t * sss,
+                        const struct sn_community *comm,
+                        const n2n_common_t * cmn,
+                        const n2n_mac_t dstMac,
+                        uint8_t from_supernode,
+                        const uint8_t * pktbuf,
+                        size_t pktsize) {
+
+    struct peer_info *             scan;
+    node_supernode_association_t   *assoc;
+    macstr_t                       mac_buf;
+    n2n_sock_str_t                 sockbuf;
+
+    HASH_FIND_PEER(comm->edges, dstMac, scan);
+
+    if(NULL != scan) {
+        int data_sent_len;
+        data_sent_len = sendto_peer(sss, scan, pktbuf, pktsize);
+
+        if(data_sent_len == pktsize) {
+            ++(sss->stats.fwd);
+            traceEvent(TRACE_DEBUG, "unicast %lu to [%s] %s",
+                       pktsize,
+                       sock_to_cstr(sockbuf, &(scan->sock)),
+                       macaddr_str(mac_buf, scan->mac_addr));
+        } else {
+            ++(sss->stats.errors);
+            traceEvent(TRACE_ERROR, "unicast %lu to [%s] %s FAILED (%d: %s)",
+                       pktsize,
+                       sock_to_cstr(sockbuf, &(scan->sock)),
+                       macaddr_str(mac_buf, scan->mac_addr),
+                       errno, strerror(errno));
+            return -1;
+        }
+    } else {
+        if(!from_supernode) {
+            // check if target edge is associated with a certain supernode
+            HASH_FIND(hh, comm->assoc, dstMac, sizeof(n2n_mac_t), assoc);
+            if(assoc) {
+                traceEvent(TRACE_DEBUG, "try_forward found mac address associated with a known supernode, forwarding packet to that supernode");
+                sendto_sock(sss, sss->sock,
+                            (const struct sockaddr*)&(assoc->sock),
+                            pktbuf, pktsize);
+            } else {
+                // forwarding packet to all federated supernodes
+                traceEvent(TRACE_DEBUG, "try_forward sees unknown mac address, broadcasting packet to all federated supernodes");
+                try_broadcast(sss, NULL, cmn, sss->mac_addr, from_supernode, pktbuf, pktsize);
+            }
+        } else {
+            traceEvent(TRACE_DEBUG, "try_forward sees unknown mac address in packet from a supernode, dropping the packet");
+            /* Not a known MAC so drop. */
+            return -2;
         }
     }
 
@@ -482,6 +478,29 @@ void sn_term (n2n_sn_t *sss) {
 #ifdef WIN32
     destroyWin32();
 #endif
+}
+
+void update_node_supernode_association (struct sn_community *comm,
+                                        n2n_mac_t *edgeMac, const struct sockaddr_in *sender_sock,
+                                        time_t now) {
+
+    node_supernode_association_t *assoc;
+
+    HASH_FIND(hh, comm->assoc, edgeMac, sizeof(n2n_mac_t), assoc);
+    if(!assoc) {
+        // create a new association
+        assoc = (node_supernode_association_t*)malloc(sizeof(node_supernode_association_t));
+        if(assoc) {
+            memcpy(&(assoc->mac), edgeMac, sizeof(n2n_mac_t));
+            memcpy((struct sockaddr_in*)&(assoc->sock), sender_sock, sizeof(struct sockaddr_in));
+            assoc->last_seen = now;
+            HASH_ADD(hh, comm->assoc, mac, sizeof(n2n_mac_t), assoc);
+        } else {
+            // already there, update socket and time only
+            memcpy((struct sockaddr_in*)&(assoc->sock), sender_sock, sizeof(struct sockaddr_in));
+            assoc->last_seen = now;
+        }
+    }
 }
 
 
@@ -1405,6 +1424,7 @@ static int process_udp (n2n_sn_t * sss,
             struct sn_community                    *fed;
             struct sn_community_regular_expression *re, *tmp_re;
             struct peer_info                       *peer, *tmp_peer, *p;
+            node_supernode_association_t           *assoc;
             int8_t                                 allowed_match = -1;
             uint8_t                                match = 0;
             int                                    match_length = 0;
@@ -1565,7 +1585,6 @@ static int process_udp (n2n_sn_t * sss,
                     if(!(cmn.flags & N2N_FLAGS_SOCKET)) {
                         // ... forward to all other supernodes (note try_broadcast()'s behavior with
                         //     NULL comm and from_supernode parameter)
-
                         // exception: do not forward auto ip draw
                         if(!is_null_mac(reg.edgeMac)) {
                             reg.sock.family = AF_INET;
@@ -1602,8 +1621,10 @@ static int process_udp (n2n_sn_t * sss,
                                    macaddr_str(mac_buf, reg.edgeMac),
                                    sock_to_cstr(sockbuf, &(ack.sock)));
                     } else {
-                        // this is an edge with valid authentication registering with another supernode
-                        // so we can delete it here if present (can happen)
+                        // this is an edge with valid authentication registering with another supernode, so ...
+                        // 1- ... associate it with that other supernode
+                        update_node_supernode_association(comm, &(reg.edgeMac), sender_sock, now);
+                        // 2- ... we can delete it from regular list if present (can happen)
                         HASH_FIND_PEER(comm->edges, reg.edgeMac, peer);
                         if(peer != NULL) {
                             if((peer->socket_fd != sss->sock) && (peer->socket_fd >= 0)) {
@@ -1986,6 +2007,9 @@ static int process_udp (n2n_sn_t * sss,
             HASH_FIND_PEER(comm->edges, pi.srcMac, peer);
             if(peer != NULL) {
                 if((comm->is_federation == IS_NO_FEDERATION) && (!is_null_mac(pi.srcMac))) {
+                    // snoop on the information to use for supernode forwarding (do not wait until first remote REGISTER_SUPER)
+                    update_node_supernode_association(comm, &(pi.mac), sender_sock, now);
+
                     // this is a PEER_INFO for one of the edges conencted to this supernode, forward,
                     // i.e. re-assemble (memcpy of udpbuf to encbuf could be sufficient as well)
 

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -1,4 +1,4 @@
-CC?=gcc
+CC=@CC@
 DEBUG?=-g3
 OPTIMIZATION?=-O2 #-march=native
 WARN?=-Wall


### PR DESCRIPTION
This pull request adds a more targeted packet forwarding between supernodes of a federation. It uses "associations" to remember the supernodes associated to each remotely registered edge. To keep memory requirements low, the list does not contain full peer information but only the socket and a time stamp which allows regular purging – also with a view to memory usage.

The associations are generated and renewed with each REGISTER_SUPER which is forwarded into the federation. As this only happens from time to time (every other 20 secondes), the supernode snoops on the PEER_INFOs being forwarded to faster build up associations.

Once an association is present, the supernode does **not** forward the PACKETs to **all** other federated supernodes anymore but only to the one associated to the target edge. Of course, forwarding happens only if no p2p is possible / allowed.

Broadcasts however are still forwarded to all supernodes. Experiments have shown that it a same-style automated "community-supernode association" intially even prevents communication as it starts with empty tables and broadcasted ARPs do not get through. One idea is that some meta communication between the supernodes could be required to even avoid this, some kind of FEDERATION_TALK message format exchanging current communities and other stats.

This code is based on the TCP code #627, so this code should be merged **after** the TCP code will have been merged.