### PR TITLE
added more targeted routing for packet forwarding in federation

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -671,18 +671,28 @@ typedef struct sn_stats {
     time_t last_reg_super; /* Time when last REGISTER_SUPER was received. */
 } sn_stats_t;
 
-struct sn_community {
-    char            community[N2N_COMMUNITY_SIZE];
-    uint8_t         is_federation;          /* if not-zero, then the current community is the federation of supernodes */
-    uint8_t         purgeable;              /* indicates purgeable community (fixed-name, predetermined (-c parameter) communties usually are unpurgeable) */
-    uint8_t         header_encryption;      /* Header encryption indicator. */
-    he_context_t    *header_encryption_ctx; /* Header encryption cipher context. */
-    he_context_t    *header_iv_ctx;         /* Header IV ecnryption cipher context, REMOVE as soon as seperate fields for checksum and replay protection available */
-    struct          peer_info *edges;       /* Link list of registered edges. */
-    int64_t         number_enc_packets;     /* Number of encrypted packets handled so far, required for sorting from time to time */
-    n2n_ip_subnet_t auto_ip_net;            /* Address range of auto ip address service. */
+typedef struct node_supernode_association {
+
+    n2n_mac_t                   mac;        /* mac address of an edge                          */
+    const struct sockaddr_in    sock;       /* network order socket of that edge's supernode   */
+    time_t                      last_seen;  /* time mark to keep track of purging requirements */
 
     UT_hash_handle hh;                      /* makes this structure hashable */
+} node_supernode_association_t;
+
+struct sn_community {
+    char                          community[N2N_COMMUNITY_SIZE];
+    uint8_t                       is_federation;          /* if not-zero, then the current community is the federation of supernodes */
+    uint8_t                       purgeable;              /* indicates purgeable community (fixed-name, predetermined (-c parameter) communties usually are unpurgeable) */
+    uint8_t                       header_encryption;      /* Header encryption indicator. */
+    he_context_t                  *header_encryption_ctx; /* Header encryption cipher context. */
+    he_context_t                  *header_iv_ctx;         /* Header IV ecnryption cipher context, REMOVE as soon as seperate fields for checksum and replay protection available */
+    struct                        peer_info *edges;       /* Link list of registered edges. */
+    node_supernode_association_t  *assoc;            /* list of other edges from this community and their supernodes */
+    int64_t                       number_enc_packets;     /* Number of encrypted packets handled so far, required for sorting from time to time */
+    n2n_ip_subnet_t               auto_ip_net;            /* Address range of auto ip address service. */
+
+    UT_hash_handle hh;                                    /* makes this structure hashable */
 };
 
 /* Typedef'd pointer to get abstract datatype. */


### PR DESCRIPTION
This pull request adds a more targeted packet forwarding between supernodes of a federation. It uses "associations" to remember the supernodes associated to each remotely registered edge. To keep memory requirements low, the list does not contain full peer information but only the socket and a time stamp which allows regular purging – also with a view to memory usage.

The associations are generated and renewed with each REGISTER_SUPER which is forwarded into the federation. As this only happens from time to time (every other 20 secondes), the supernode snoops on the PEER_INFOs being forwarded to faster build up associations.

Once an association is present, the supernode does not forward the PACKETs to all other federated supernodes anymore but only to the one associated to the target edge. Of course, forwarding happens only if no p2p is possible / allowed.

Broadcasts however are still forwarded to all supernodes. Experiments have shown that it a same-style automated "community-supernode association" intially even prevents communication as it starts with empty tables and broadcasted ARPs do not get through. One idea is that some meta communication between the supernodes could be required to even avoid this, some kind of FEDERATION_TALK message format exchanging current communities and other stats.

This code is based on the TCP code #627, so this code should be merged after the TCP code will have been merged.