### PR TITLE
fixed edge stall

### DIFF
--- a/src/n2n.c
+++ b/src/n2n.c
@@ -482,9 +482,9 @@ size_t purge_peer_list (struct peer_info ** peer_list,
                         HASH_DEL(tcp_connections, conn);
                         free(conn);
                     }
+                    shutdown(scan->socket_fd, SHUT_RDWR);
+                    closesocket(scan->socket_fd);
                 }
-                shutdown(scan->socket_fd, SHUT_RDWR);
-                closesocket(scan->socket_fd);
             }
             HASH_DEL(*peer_list, scan);
             retval++;


### PR DESCRIPTION
This pull request fixes an edge stall that could have happened sometime after loss of supernode connection due to an unwanted closure of socket which is intended to be performed only for TCP connections.