### PR TITLE
improved socket handling

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -116,6 +116,9 @@ enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 #define N2N_TCP_BACKLOG_QUEUE_SIZE   3         /* number of concurrently pending connections to be accepted */
                                                /* NOT the number of max. TCP connections                    */
 
+#define N2N_CLOSE_SOCKET_COUNTER_MAX 15        /* number of times of edge's reconnects to supernode after   */
+                                               /* which the socket explicitly is closed before reopening    */
+
 /* flag used in add_sn_to_list_by_mac_or_sock */
 enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -633,12 +633,13 @@ struct n2n_edge {
 
     /* Sockets */
     /* supernode socket is in        eee->curr_sn->sock (of type n2n_sock_t) */
-    int                              sock;
-    int                              udp_mgmt_sock;                      /**< socket for status info. */
+    SOCKET                           sock;
+    int                              close_socket_counter;               /**< counter for close-event before re-opening */
+    SOCKET                           udp_mgmt_sock;                      /**< socket for status info. */
 
 #ifndef SKIP_MULTICAST_PEERS_DISCOVERY
     n2n_sock_t                       multicast_peer;                     /**< Multicast peer group (for local edges) */
-    int                              udp_multicast_sock;                 /**< socket for local multicast registrations. */
+    SOCKET                           udp_multicast_sock;                 /**< socket for local multicast registrations. */
     int                              multicast_joined;                   /**< 1 if the group has been joined.*/
 #endif
 
@@ -716,6 +717,7 @@ typedef struct n2n_tcp_connection {
     UT_hash_handle hh; /* makes this structure hashable */
 } n2n_tcp_connection_t;
 
+
 typedef struct n2n_sn {
     time_t                                 start_time;      /* Used to measure uptime. */
     sn_stats_t                             stats;
@@ -723,10 +725,10 @@ typedef struct n2n_sn {
     n2n_mac_t                              mac_addr;
     uint16_t                               lport;           /* Local UDP port to bind to. */
     uint16_t                               mport;           /* Management UDP port to bind to. */
-    int                                    sock;            /* Main socket for UDP traffic with edges. */
-    int                                    tcp_sock;        /* auxiliary socket for optional TCP connections */
+    SOCKET                                 sock;            /* Main socket for UDP traffic with edges. */
+    SOCKET                                 tcp_sock;        /* auxiliary socket for optional TCP connections */
     n2n_tcp_connection_t                   *tcp_connections;/* list of established TCP connections */
-    int                                    mgmt_sock;       /* management socket. */
+    SOCKET                                 mgmt_sock;       /* management socket. */
     n2n_ip_subnet_t                        min_auto_ip_net; /* Address range of auto_ip service. */
     n2n_ip_subnet_t                        max_auto_ip_net; /* Address range of auto_ip service. */
 #ifndef WIN32


### PR DESCRIPTION
This pull requests rectifies socket file descriptor handling, especially on closure due to lost connection – a measure of error prevention in multi-NATed scenarios. It yields better and continuous local multicast peer detection as multicast socket does not get closed along with the main socket anymore.
