### PR TITLE
fixed unrelated error message

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -633,13 +633,13 @@ struct n2n_edge {
 
     /* Sockets */
     /* supernode socket is in        eee->curr_sn->sock (of type n2n_sock_t) */
-    SOCKET                           sock;
+    int                              sock;
     int                              close_socket_counter;               /**< counter for close-event before re-opening */
-    SOCKET                           udp_mgmt_sock;                      /**< socket for status info. */
+    int                              udp_mgmt_sock;                      /**< socket for status info. */
 
 #ifndef SKIP_MULTICAST_PEERS_DISCOVERY
     n2n_sock_t                       multicast_peer;                     /**< Multicast peer group (for local edges) */
-    SOCKET                           udp_multicast_sock;                 /**< socket for local multicast registrations. */
+    int                              udp_multicast_sock;                 /**< socket for local multicast registrations. */
     int                              multicast_joined;                   /**< 1 if the group has been joined.*/
 #endif
 
@@ -707,7 +707,7 @@ struct sn_community_regular_expression {
 
 
 typedef struct n2n_tcp_connection {
-    SOCKET socket_fd;       /* file descriptor for tcp socket */
+    int    socket_fd;       /* file descriptor for tcp socket */
     struct sockaddr sock;   /* network order socket */
 
     uint16_t expected;                                    /* number of bytes expected to be read */
@@ -725,10 +725,10 @@ typedef struct n2n_sn {
     n2n_mac_t                              mac_addr;
     uint16_t                               lport;           /* Local UDP port to bind to. */
     uint16_t                               mport;           /* Management UDP port to bind to. */
-    SOCKET                                 sock;            /* Main socket for UDP traffic with edges. */
-    SOCKET                                 tcp_sock;        /* auxiliary socket for optional TCP connections */
+    int                                    sock;            /* Main socket for UDP traffic with edges. */
+    int                                    tcp_sock;        /* auxiliary socket for optional TCP connections */
     n2n_tcp_connection_t                   *tcp_connections;/* list of established TCP connections */
-    SOCKET                                 mgmt_sock;       /* management socket. */
+    int                                    mgmt_sock;       /* management socket. */
     n2n_ip_subnet_t                        min_auto_ip_net; /* Address range of auto_ip service. */
     n2n_ip_subnet_t                        max_auto_ip_net; /* Address range of auto_ip service. */
 #ifndef WIN32

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -831,7 +831,7 @@ static ssize_t sendto_fd (n2n_edge_t *eee, const void *buf,
         sent = sendto(eee->sock, buf, len, 0 /*flags*/,
                       (struct sockaddr *)dest, sizeof(struct sockaddr_in));
 
-        if(sent <= 0) {
+        if((sent <= 0) && (errno)) {
             char * c = strerror(errno);
             traceEvent(TRACE_ERROR, "sendto_fd sendto failed (%d) %s", errno, c);
 #ifdef WIN32
@@ -2562,7 +2562,7 @@ int fetch_and_eventually_process_data (n2n_edge_t *eee, SOCKET sock,
         bread = recvfrom(sock,
                          pktbuf + *position, *expected - *position, 0 /*flags*/,
                         (struct sockaddr *)&sender_sock, (socklen_t *)&i);
-        if(bread <= 0) {
+        if((bread <= 0) && (errno)) {
             traceEvent(TRACE_ERROR, "fetch_and_eventually_process_data's recvfrom() failed %d errno %d (%s)", bread, errno, strerror(errno));
 #ifdef WIN32
             traceEvent(TRACE_ERROR, "fetch_and_eventually_process_data's WSAGetLastError(): %u", WSAGetLastError());

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -113,7 +113,7 @@ static ssize_t sendto_fd (n2n_sn_t *sss,
     sent = sendto(socket_fd, pktbuf, pktsize, 0 /* flags */,
                   socket, sizeof(struct sockaddr_in));
 
-    if(sent <= 0) {
+    if((sent <= 0) && (errno)) {
         char * c = strerror(errno);
         traceEvent(TRACE_ERROR, "sendto_fd failed (%d) %s", errno, c);
 #ifdef WIN32
@@ -2153,7 +2153,7 @@ int run_sn_loop (n2n_sn_t *sss, int *keep_running) {
                                      conn->buffer + conn->position, conn->expected - conn->position, 0 /*flags*/,
                                      (struct sockaddr *)&sender_sock, (socklen_t *)&i);
 
-                    if(bread <= 0) {
+                    if((bread <= 0) && (errno)) {
                         traceEvent(TRACE_ERROR, "recvfrom() failed %d errno %d (%s)", bread, errno, strerror(errno));
 #ifdef WIN32
                         traceEvent(TRACE_ERROR, "WSAGetLastError(): %u", WSAGetLastError());


### PR DESCRIPTION
This pull request hopefully fixes #652.

Since implementation of TCP which needs to catch errors also on "0 bytes sent"-return value, the logic for occuring errors at sending data has slightly changed resulting in an error message when there was no error (just 0 bytes sent / received).

