### PR TITLE
increased resilience to supernode failure

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -426,6 +426,7 @@ struct peer_info {
     SN_SELECTION_CRITERION_DATA_TYPE selection_criterion;
     uint64_t                         last_valid_time_stamp;
     char                             *ip_addr;
+    uint8_t                          local;
 
     UT_hash_handle     hh; /* makes this structure hashable */
 };


### PR DESCRIPTION
This pull request makes edges keep up peer-to-peer connections to known peers by re-REGISTERing in case of sudden supernode connection loss. Also, while no supernode is around, broadcast packets are forwarded to all known peer edges then.

Internally, local edges, i.e. those that answer multicast REGISTERs, get marked as `local`. That way, the edge can check if external edges, i.e. non-local, are around which then leads to less socket-reopenings (which we want to avoid in this scenario as they would change the own external p2p-socket which could break the still existing p2p-links).

Test scenario: Run normal scenario until p2p connection is reached, stop supernode. Edges can still ping for a long time, even after a longer break. In rare cases, it took a while (~10 secondes) until ping resumed working – but that might be special about author's scenario.

_I wish I could spell..._ :wink: