### PR TITLE
adapted packet format

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -345,7 +345,7 @@ typedef struct n2n_PACKET {
 typedef struct n2n_REGISTER_SUPER {
     n2n_cookie_t       cookie;      /**< Link REGISTER_SUPER and REGISTER_SUPER_ACK */
     n2n_mac_t          edgeMac;     /**< MAC to register with edge sending socket */
-    n2n_sock_t         sock;        /**< Sending socket associated with srcMac */
+    n2n_sock_t         sock;        /**< Sending socket associated with edgeMac */
     n2n_ip_subnet_t    dev_addr;    /**< IP address of the tuntap adapter. */
     n2n_desc_t         dev_desc;    /**< Hint description correlated with the edge */
     n2n_auth_t         auth;        /**< Authentication scheme and tokens */
@@ -355,10 +355,10 @@ typedef struct n2n_REGISTER_SUPER {
 /* Linked with n2n_register_super_ack in n2n_pc_t. Only from supernode to edge. */
 typedef struct n2n_REGISTER_SUPER_ACK {
     n2n_cookie_t       cookie;      /**< Return cookie from REGISTER_SUPER */
-    n2n_mac_t          edgeMac;     /**< MAC registered to edge sending socket */
+    n2n_mac_t          srcMac;      /**< MAC of answering supernode */
     n2n_ip_subnet_t    dev_addr;    /**< Assign an IP address to the tuntap adapter of edge. */
     uint16_t           lifetime;    /**< How long the registration will live */
-    n2n_sock_t         sock;        /**< Sending sockets associated with edgeMac */
+    n2n_sock_t         sock;        /**< Sending sockets associated with edge */
     n2n_auth_t         auth;        /**< Authentication scheme and tokens */
 
     /** The packet format provides additional supernode definitions here.
@@ -366,8 +366,7 @@ typedef struct n2n_REGISTER_SUPER_ACK {
      * n2n_sock_t.
      */
     uint8_t            num_sn;      /**< Number of supernodes that were send
-                                      * even if we cannot store them all. If
-                                      * non-zero then sn_bak is valid. */
+                                       * even if we cannot store them all. */
 } n2n_REGISTER_SUPER_ACK_t;
 
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2383,7 +2383,9 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
 
                         handle_remote_auth(eee, sn, &(ra.auth));
 
+                        HASH_DEL(eee->conf.supernodes, eee->curr_sn);
                         memcpy(&eee->curr_sn->mac_addr, ra.srcMac, N2N_MAC_SIZE);
+                        HASH_ADD_PEER(eee->conf.supernodes, eee->curr_sn);
 
                         payload = (n2n_REGISTER_SUPER_ACK_payload_t*)tmpbuf;
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -478,7 +478,7 @@ int encode_REGISTER_SUPER_ACK (uint8_t *base,
 
     retval += encode_common(base, idx, common);
     retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
-    retval += encode_mac(base, idx, reg->edgeMac);
+    retval += encode_mac(base, idx, reg->srcMac);
     retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
     retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
     retval += encode_uint16(base, idx, reg->lifetime);
@@ -501,7 +501,7 @@ int decode_REGISTER_SUPER_ACK (n2n_REGISTER_SUPER_ACK_t *reg,
     memset(reg, 0, sizeof(n2n_REGISTER_SUPER_ACK_t));
 
     retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
-    retval += decode_mac(reg->edgeMac, base, rem, idx);
+    retval += decode_mac(reg->srcMac, base, rem, idx);
     retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
     retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
     retval += decode_uint16(&(reg->lifetime), base, rem, idx);


### PR DESCRIPTION
This pull request makes a change to packet format of REGISTER_SUPER_ACK:

The former `edgeMac` is renamed to `srcMac` and filled with the MAC address of the sending supernode instead of the edge's MAC.

The edge knows its own MAC address and can recognize that the packet is not mal-addressed because of the cookie (added corresponding handling to supernode-supernode ACKs as well). So, it does not need the former `edgeMac` filled with its own MAC address. By sending the supernode's `srcMac` instead, the edge can fill in this data into it's supernode list which helps to complete the list much faster especially for `-l` provided supernode entries.

**Please note that this breaks compatibility to previous _dev_ versions.**

Fixes #656.