### PR TITLE
fixed compile warnings

### DIFF
--- a/src/aes.c
+++ b/src/aes.c
@@ -546,7 +546,6 @@ int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
     // one block remaining
     if(n) {
         __m128i tmp = _mm_loadu_si128((__m128i*)in);
-        __m128i old_in = tmp;
 
         tmp = _mm_xor_si128           (tmp, ctx->rk_dec[ 0]);
         tmp = _mm_aesdec_si128        (tmp, ctx->rk_dec[ 1]);
@@ -566,7 +565,7 @@ int aes_cbc_decrypt (unsigned char *out, const unsigned char *in, size_t in_len,
                 tmp = _mm_aesdec_si128(tmp, ctx->rk_dec[13]);
             }
         }
-        tmp = _mm_aesdeclast_si128     (tmp, ctx->rk_enc[ 0]);
+        tmp = _mm_aesdeclast_si128    (tmp, ctx->rk_enc[ 0]);
 
         tmp = _mm_xor_si128 (tmp, ivec);
 

--- a/src/edge.c
+++ b/src/edge.c
@@ -849,7 +849,7 @@ int main (int argc, char* argv[]) {
     n2n_tuntap_priv_config_t ec;  /* config used for standalone program execution */
     uint8_t runlevel = 0;         /* bootstrap: runlevel */
     uint8_t seek_answer = 1;      /*            expecting answer from supernode */
-    time_t now, last_action;      /*            timeout */
+    time_t now, last_action = 0;  /*            timeout */
     macstr_t mac_buf;             /*            output mac address */
     fd_set socket_mask;           /*            for supernode answer */
     struct timeval wait_time;     /*            timeout for sn answer */

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2401,7 +2401,7 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
                             sn = add_sn_to_list_by_mac_or_sock(&(eee->conf.supernodes), &(payload->sock), payload->mac, &skip_add);
 
                             if(skip_add == SN_ADD_ADDED) {
-                                sn->ip_addr = calloc(1,N2N_EDGE_SN_HOST_SIZE);
+                                sn->ip_addr = calloc(1, N2N_EDGE_SN_HOST_SIZE);
                                 if(sn->ip_addr != NULL) {
                                     inet_ntop(payload->sock.family,
                                               (payload->sock.family == AF_INET) ? (void*)&(payload->sock.addr.v4) : (void*)&(payload->sock.addr.v6),

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1571,6 +1571,7 @@ static int process_udp (n2n_sn_t * sss,
                            macaddr_str(mac_buf, reg.edgeMac),
                            sock_to_cstr(sockbuf, &(ack.sock)));
 
+                ret_value = update_edge_no_change;
                 if(!is_null_mac(reg.edgeMac)) {
                     if(cmn.flags & N2N_FLAGS_SOCKET) {
                         ret_value = update_edge(sss, &reg, comm, &(ack.sock), socket_fd, &(ack.auth), SN_ADD_SKIP, now);
@@ -1755,15 +1756,13 @@ static int process_udp (n2n_sn_t * sss,
                        sock_to_cstr(sockbuf1, &sender),
                        sock_to_cstr(sockbuf2, orig_sender));
 
-            if(comm->is_federation == IS_FEDERATION) {
-                skip_add = SN_ADD_SKIP;
-                scan = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), &sender, ack.srcMac, &skip_add);
-                if(scan != NULL) {
-                    scan->last_seen = now;
-                } else {
-                    traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK due to an unknown supernode.");
-                    break;
-                }
+            skip_add = SN_ADD_SKIP;
+            scan = add_sn_to_list_by_mac_or_sock(&(sss->federation->edges), &sender, ack.srcMac, &skip_add);
+            if(scan != NULL) {
+                scan->last_seen = now;
+            } else {
+                traceEvent(TRACE_DEBUG, "process_udp dropped REGISTER_SUPER_ACK due to an unknown supernode.");
+                break;
             }
 
             if(0 == memcmp(ack.cookie, scan->last_cookie, N2N_COOKIE_SIZE)) {


### PR DESCRIPTION
This pull request fixes some compile warnings, in one case by removing an even superfluous `if` clause (negated condition gets checked few lines above as kick-out).