### PR TITLE
fixed small memory issue

### DIFF
--- a/src/sn.c
+++ b/src/sn.c
@@ -79,6 +79,8 @@ static int load_allowed_sn_community (n2n_sn_t *sss) {
 	        break;
             }
         }
+        // the loop above does not always determine correct 'len'
+        len = strlen(line);
 
         // cut off any IP sub-network upfront
         cmn_str = (char*)calloc(len + 1, sizeof(char));


### PR DESCRIPTION
Found that a `len` value and the following `calloc()` were too small by one in some cases (while supernode reading community file).

_"uh oh, evil..."_ : With a view to PR number :wink: