### PR TITLE
drop non portable SOL_TCP / fix MacOS v2

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -155,16 +155,10 @@
 #include "sn_selection.h"
 #include "network_traffic_filter.h"
 
+/* ************************************** */
+
 #include "header_encryption.h"
 #include "tf.h"
-
-/* ************************************** */
-
-#if !defined(SOL_TCP) && defined(IPPROTO_TCP)
-#define SOL_TCP IPPROTO_TCP
-#endif
-
-/* ************************************** */
 
 #ifndef TRACE_ERROR
 #define TRACE_ERROR       0, __FILE__, __LINE__

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -137,7 +137,6 @@
 #ifdef WIN32
 #include <winsock2.h>           /* for tcp */
 #define SHUT_RDWR   SD_BOTH     /* for tcp */
-#define SOL_TCP     IPPROTO_TCP /* for tcp */
 #include "win32/wintap.h"
 #include <sys/stat.h>
 #else

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -888,10 +888,10 @@ static ssize_t sendto_sock (n2n_edge_t *eee, const void * buf,
     // if the connection is tcp, i.e. not the regular sock...
     if(eee->conf.connect_tcp) {
 
-        setsockopt(eee->sock, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+        setsockopt(eee->sock, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value));
         value = 1;
 #ifndef WIN32
-        setsockopt(eee->sock, SOL_TCP, TCP_CORK, &value, sizeof(value));
+        setsockopt(eee->sock, IPPROTO_TCP, TCP_CORK, &value, sizeof(value));
 #endif
 
         // prepend packet length...
@@ -907,10 +907,10 @@ static ssize_t sendto_sock (n2n_edge_t *eee, const void * buf,
     // if the connection is tcp, i.e. not the regular sock...
     if(eee->conf.connect_tcp) {
         value = 1; /* value should still be set to 1 */
-        setsockopt(eee->sock, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+        setsockopt(eee->sock, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value));
 #ifndef WIN32
         value = 0;
-        setsockopt(eee->sock, SOL_TCP, TCP_CORK, &value, sizeof(value));
+        setsockopt(eee->sock, IPPROTO_TCP, TCP_CORK, &value, sizeof(value));
 #endif
     }
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -890,7 +890,7 @@ static ssize_t sendto_sock (n2n_edge_t *eee, const void * buf,
 
         setsockopt(eee->sock, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
         value = 1;
-#if !defined(WIN32) && !defined(__APPLE__)
+#ifndef WIN32
         setsockopt(eee->sock, SOL_TCP, TCP_CORK, &value, sizeof(value));
 #endif
 
@@ -908,7 +908,7 @@ static ssize_t sendto_sock (n2n_edge_t *eee, const void * buf,
     if(eee->conf.connect_tcp) {
         value = 1; /* value should still be set to 1 */
         setsockopt(eee->sock, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
-#if !defined(WIN32) && !defined(__APPLE__)
+#ifndef WIN32
         value = 0;
         setsockopt(eee->sock, SOL_TCP, TCP_CORK, &value, sizeof(value));
 #endif

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -890,7 +890,7 @@ static ssize_t sendto_sock (n2n_edge_t *eee, const void * buf,
 
         setsockopt(eee->sock, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value));
         value = 1;
-#ifndef WIN32
+#ifdef LINUX
         setsockopt(eee->sock, IPPROTO_TCP, TCP_CORK, &value, sizeof(value));
 #endif
 
@@ -908,7 +908,7 @@ static ssize_t sendto_sock (n2n_edge_t *eee, const void * buf,
     if(eee->conf.connect_tcp) {
         value = 1; /* value should still be set to 1 */
         setsockopt(eee->sock, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value));
-#ifndef WIN32
+#ifdef LINUX
         value = 0;
         setsockopt(eee->sock, IPPROTO_TCP, TCP_CORK, &value, sizeof(value));
 #endif

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -149,10 +149,10 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
     // if the connection is tcp, i.e. not the regular sock...
     if((socket_fd >= 0) && (socket_fd != sss->sock)) {
 
-        setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+        setsockopt(socket_fd, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value));
         value = 1;
 #ifndef WIN32
-        setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+        setsockopt(socket_fd, IPPROTO_TCP, TCP_CORK, &value, sizeof(value));
 #endif
 
         // prepend packet length...
@@ -169,10 +169,10 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
     // if the connection is tcp, i.e. not the regular sock...
     if((socket_fd >= 0) && (socket_fd != sss->sock)) {
         value = 1; /* value should still be set to 1 */
-        setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
+        setsockopt(socket_fd, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value));
 #ifndef WIN32
         value = 0;
-        setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
+        setsockopt(socket_fd, IPPROTO_TCP, TCP_CORK, &value, sizeof(value));
 #endif
     }
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -151,7 +151,7 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
 
         setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
         value = 1;
-#if !defined(WIN32) && !defined(__APPLE__)
+#ifndef WIN32
         setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
 #endif
 
@@ -170,7 +170,7 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
     if((socket_fd >= 0) && (socket_fd != sss->sock)) {
         value = 1; /* value should still be set to 1 */
         setsockopt(socket_fd, SOL_TCP, TCP_NODELAY, &value, sizeof(value));
-#if !defined(WIN32) && !defined(__APPLE__)
+#ifndef WIN32
         value = 0;
         setsockopt(socket_fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
 #endif

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -151,7 +151,7 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
 
         setsockopt(socket_fd, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value));
         value = 1;
-#ifndef WIN32
+#ifdef LINUX
         setsockopt(socket_fd, IPPROTO_TCP, TCP_CORK, &value, sizeof(value));
 #endif
 
@@ -170,7 +170,7 @@ static ssize_t sendto_sock(n2n_sn_t *sss,
     if((socket_fd >= 0) && (socket_fd != sss->sock)) {
         value = 1; /* value should still be set to 1 */
         setsockopt(socket_fd, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value));
-#ifndef WIN32
+#ifdef LINUX
         value = 0;
         setsockopt(socket_fd, IPPROTO_TCP, TCP_CORK, &value, sizeof(value));
 #endif


### PR DESCRIPTION
Building for MacOS was broken for some time and fixed in 53e930db105df0e1103d8b6de9d5cb223c744d49. In parallel I worked on a similar fix, triggered by failing CI-builds.
This new approach seems more clean and portable than the previous as it drops using "SOL_TCP" completely. This way we can stop redefining it for specific platforms.

2nd issue is making use on TCP_CORK only when building on Linux, as it seems a Linux-specific and non-portable feature (https://linux.die.net/man/7/tcp). Defining it "use it when on Linux" seems more easy to read than "don't use it when not on Linux"
> TCP_CORK (since Linux 2.2)
    If set, don't send out partial frames. All queued partial frames are sent when the option is cleared again. This is useful for prepending headers before calling sendfile(2), or for throughput optimization. As currently implemented, there is a 200 millisecond ceiling on the time for which output is corked by TCP_CORK. If this ceiling is reached, then queued data is automatically transmitted. This option can be combined with TCP_NODELAY only since Linux 2.5.71. This option should not be used in code intended to be portable. 