### PR TITLE
add callback function for hin2n to protect socket

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -516,6 +516,9 @@ typedef struct n2n_edge_callbacks {
 
     /* Called periodically in the main loop. */
     void (*main_loop_period)(n2n_edge_t *eee, time_t now);
+
+    /* Called when a new socket to supernode is created. */
+    void (*sock_opened)(n2n_edge_t *eee);
 } n2n_edge_callbacks_t;
 
 typedef struct n2n_tuntap_priv_config {

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -219,7 +219,8 @@ int supernode_connect(n2n_edge_t *eee) {
             return -1;
         }
 
-        eee->cb.sock_opened(eee);
+        if(eee->cb.sock_opened)
+            eee->cb.sock_opened(eee);
 
         struct sockaddr_in sock;
         sock.sin_family = AF_INET;

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -219,6 +219,8 @@ int supernode_connect(n2n_edge_t *eee) {
             return -1;
         }
 
+        eee->cb.sock_opened(eee);
+
         struct sockaddr_in sock;
         sock.sin_family = AF_INET;
         sock.sin_port = htons(eee->curr_sn->sock.port);


### PR DESCRIPTION
Hello guys.
I'm trying to develop hin2n (an android APP which based on n2n source code plays the role as **edge** ) to adapt to the latest n2n source code.
But I met a problem - when edge create a socket to supernode, the socket must be protected at once, or the APP will crash.
I've tried this code and it works with hin2n well.
I will also submit a pull request to hin2n when I complete the adaptation.