### PR TITLE
allowed (temporarily) initially non-resolving supernode names

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -62,6 +62,7 @@
 
 #define SORT_COMMUNITIES_INTERVAL        90 /* sec. until supernode sorts communities' hash list again */
 
+#define AF_INVALID                       -1 /* to mark a socket invalid by an invalid address family (do not use AF_UNSPEC, it could turn into auto-detect) */
 #define N2N_RESOLVE_INTERVAL            300 /* seconds until edge and supernode try to resolve supernode names again */
 #define N2N_RESOLVE_CHECK_INTERVAL       30 /* seconds until main loop checking in on changes from resolver thread */
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -226,7 +226,7 @@ int supernode_connect(n2n_edge_t *eee) {
             eee->cb.sock_opened(eee);
 
         struct sockaddr_in sock;
-        sock.sin_family = AF_INET;
+        sock.sin_family = eee->curr_sn->sock.family;
         sock.sin_port = htons(eee->curr_sn->sock.port);
         memcpy(&(sock.sin_addr.s_addr), &(eee->curr_sn->sock.addr.v4), IPV4_SIZE);
 
@@ -3502,10 +3502,10 @@ int edge_conf_add_supernode (n2n_edge_conf_t *conf, const char *ip_and_port) {
     sock = (n2n_sock_t*)calloc(1,sizeof(n2n_sock_t));
     rv = supernode2sock(sock, ip_and_port);
 
-    if(rv != 0) {
-        traceEvent(TRACE_WARNING, "Invalid supernode address");
+    if(rv < -2) { /* we accept resolver failure as it might resolve later */
+        traceEvent(TRACE_WARNING, "Invalid supernode parameter.");
         free(sock);
-        return(1);
+        return 1;
     }
 
     skip_add = SN_ADD;
@@ -3527,7 +3527,7 @@ int edge_conf_add_supernode (n2n_edge_conf_t *conf, const char *ip_and_port) {
     traceEvent(TRACE_NORMAL, "Adding supernode = %s", sn->ip_addr);
     conf->sn_num++;
 
-    return(0);
+    return 0;
 }
 
 /* ************************************** */

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1657,6 +1657,8 @@ static int process_udp (n2n_sn_t * sss,
                     skip--;
                     continue;
                 }
+                if(peer->sock.family == AF_INVALID)
+                    continue; /* do not add unresolved supernodes to payload */
                 if(memcmp(&(peer->sock), &(ack.sock), sizeof(n2n_sock_t)) == 0) continue; /* a supernode doesn't add itself to the payload */
                 if((now - peer->last_seen) >= LAST_SEEN_SN_NEW) continue;  /* skip long-time-not-seen supernodes.
                                                                             * We need to allow for a little extra time because supernodes sometimes exceed


### PR DESCRIPTION
By adding an invalid address familiy `AF_INVALID` to sockets, this pull request allows to handle (temporarily) non-resolving supernode names / addresses and the corresponding sockets.

While a once successfully resolved supernode name does not fall back to a non-resolved state (later occurring resolver errors  have already been ignored), initial failure anyway produces a socket but with `AF_INVALID` address family (instead if AF_INET). This way, the OS does not operate on this socket (special treatment for TCP case at edge required) and we do not need to guard each and every socket use for a valid socket – the OS does it for us.

Non-resolving supernode names will produce recurring warning messages to the user.

This also is to the benefit of smaller systems without runlevel support where edge and supernode might be started before network / name resolution is up or available.

This (hopefully) resolves #683.