### PR TITLE
made n2n react more swiftly to (D)DNS changes

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -599,13 +599,16 @@ typedef struct n2n_resolve_ip_sock {
 
 // structure to hold resolver thread's parameters
 typedef struct n2n_resolve_parameter {
-    n2n_resolve_ip_sock_t   *list;        /* pointer to list of to be resolved nodes */
-    uint8_t                 changed;      /* indicates a change */
+    n2n_resolve_ip_sock_t   *list;         /* pointer to list of to be resolved nodes */
+    uint8_t                 changed;       /* indicates a change */
 #ifdef HAVE_PTHREAD
-    pthread_t               id;           /* thread id */
-    pthread_mutex_t         access;       /* mutex for shared access */
+    pthread_t               id;            /* thread id */
+    pthread_mutex_t         access;        /* mutex for shared access */
 #endif
-    time_t                  last_checked; /* last time the resolver completed */
+    uint8_t                 request;       /* flags main thread's need for intermediate resolution */
+    time_t                  check_interval;/* interval to checik resolover results */
+    time_t                  last_checked;  /* last time the resolver results were cheked */
+    time_t                  last_resolved; /* last time the resolver completed */
 } n2n_resolve_parameter_t;
 
 
@@ -700,6 +703,7 @@ struct n2n_edge {
     struct n2n_edge_stats            stats;                              /**< Statistics */
 
     n2n_resolve_parameter_t          *resolve_parameter;                 /**< Pointer to name resolver's parameter block */
+    uint8_t                          resolution_request;                 /**< Flag an immediate DNS resolution request */
 
     n2n_tuntap_priv_config_t         tuntap_priv_conf;                   /**< Tuntap config */
 

--- a/src/edge.c
+++ b/src/edge.c
@@ -51,7 +51,7 @@ int fetch_and_eventually_process_data (n2n_edge_t *eee, SOCKET sock,
                                        uint8_t *pktbuf, uint16_t *expected, uint16_t *position,
                                        time_t now);
 int resolve_create_thread (n2n_resolve_parameter_t **param, struct peer_info *sn_list);
-int resolve_check (n2n_resolve_parameter_t *param, time_t now);
+int resolve_check (n2n_resolve_parameter_t *param, uint8_t resolution_request, time_t now);
 
 /* ***************************************************** */
 
@@ -1174,7 +1174,7 @@ int main (int argc, char* argv[]) {
         }
         seek_answer = 1;
 
-        resolve_check(eee->resolve_parameter, now);
+        resolve_check(eee->resolve_parameter, 0 /* no intermediate resolution requirement at this point */, now);
     }
     // allow a higher number of pings for first regular round of ping
     // to quicker get an inital 'supernode selection criterion overview'

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -20,7 +20,7 @@
 
 #define HASH_FIND_COMMUNITY(head, name, out) HASH_FIND_STR(head, name, out)
 
-int resolve_check (n2n_resolve_parameter_t *param, time_t now);
+int resolve_check (n2n_resolve_parameter_t *param, uint8_t resolution_request, time_t now);
 int resolve_cancel_thread (n2n_resolve_parameter_t *param);
 
 static ssize_t sendto_peer (n2n_sn_t *sss,
@@ -2364,7 +2364,7 @@ int run_sn_loop (n2n_sn_t *sss, int *keep_running) {
         re_register_and_purge_supernodes(sss, sss->federation, &last_re_reg_and_purge, now);
         purge_expired_communities(sss, &last_purge_edges, now);
         sort_communities(sss, &last_sort_communities, now);
-        resolve_check(sss->resolve_parameter, now);
+        resolve_check(sss->resolve_parameter, 0 /* presumably, no special resolution requirement */, now);
     } /* while */
 
     sn_term(sss);


### PR DESCRIPTION
This pull request adds a way to signal an immediate name resolution request to the separate DNS resolver thread in case the supernode cannot be reached. By consequence, dynamic name changes are caught much earlier than by the previous periodic checking routine.

Resolves #703.