### PR TITLE
modified route setup

### DIFF
--- a/src/edge.c
+++ b/src/edge.c
@@ -52,6 +52,7 @@ int fetch_and_eventually_process_data (n2n_edge_t *eee, SOCKET sock,
                                        time_t now);
 int resolve_create_thread (n2n_resolve_parameter_t **param, struct peer_info *sn_list);
 int resolve_check (n2n_resolve_parameter_t *param, uint8_t resolution_request, time_t now);
+int edge_init_routes (n2n_edge_t *eee, n2n_route_t *routes, uint16_t num_routes);
 
 /* ***************************************************** */
 
@@ -1137,7 +1138,7 @@ int main (int argc, char* argv[]) {
             }
         }
 
-        if(runlevel == 4) { /* configure the TUNTAP device */
+        if(runlevel == 4) { /* configure the TUNTAP device, including routes */
             if(tuntap_open(&tuntap, eee->tuntap_priv_conf.tuntap_dev_name, eee->tuntap_priv_conf.ip_mode,
                            eee->tuntap_priv_conf.ip_addr, eee->tuntap_priv_conf.netmask,
                            eee->tuntap_priv_conf.device_mac, eee->tuntap_priv_conf.mtu
@@ -1151,6 +1152,11 @@ int main (int argc, char* argv[]) {
                                      eee->tuntap_priv_conf.ip_addr,
                                      eee->tuntap_priv_conf.netmask,
                                      macaddr_str(mac_buf, eee->device.mac_addr));
+            // routes
+            if(edge_init_routes(eee, eee->conf.routes, eee->conf.num_routes) < 0) {
+                traceEvent(TRACE_ERROR, "routes setup failed");
+                exit(1);
+            }
             runlevel = 5;
             // no more answers required
             seek_answer = 0;

--- a/win32/n2n_win32.h
+++ b/win32/n2n_win32.h
@@ -24,7 +24,7 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <winioctl.h>
-
+#include <iptypes.h>
 
 #include "wintap.h"
 
@@ -70,6 +70,7 @@ typedef struct tuntap_dev {
 	HANDLE          device_handle;
 	char            *device_name;
 	char            *ifName;
+        int             if_idx;
 	OVERLAPPED      overlap_read, overlap_write;
 	n2n_mac_t       mac_addr;
 	uint32_t        ip_addr;

--- a/win32/wintap.c
+++ b/win32/wintap.c
@@ -253,6 +253,30 @@ int open_wintap(struct tuntap_dev *device,
 
   /* ************************************** */
 
+  /* interface index, required for routing */
+
+  ULONG buffer_len = 0;
+  IP_ADAPTER_INFO *buffer;
+
+  // get required buffer size and allocate buffer
+  GetAdaptersInfo(NULL, &buffer_len);
+  buffer = malloc(buffer_len);
+
+  // find device by name and get its index
+  if(buffer && !GetAdaptersInfo(buffer, &buffer_len)) {
+    IP_ADAPTER_INFO *i;
+    for(i = buffer; i != NULL; i = i->Next) {
+      if(!strcmp(device->device_name, i->AdapterName)) {
+        device->if_idx = i->Index;
+        break;
+      }
+    }
+  }
+
+  free(buffer);
+
+  /* ************************************** */
+
   if(device_mac[0])
     set_interface_mac(device, device_mac);
 


### PR DESCRIPTION
This pull request modifies route setup. It is moved to after tap device setup happened (bootstrap area in `edge.c`'s `main()`) to make sure that all the required tap device properties already are available.

Also, for the sake of proper route setup, tap interface index is being caught during tap interface ouverture on Windows.

Fixes #709.
Fixes #528.