### PR TITLE
fortified user/pw auth scheme

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -105,6 +105,9 @@ enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 #define HEADER_ENCRYPTION_NONE                1
 #define HEADER_ENCRYPTION_ENABLED             2
 
+/* REGISTER_SUPER_ACK packet hash length with user/pw auth, up to 16 bytes */
+#define N2N_REG_SUP_HASH_CHECK_LEN           16
+
 #define DEFAULT_MTU     1290
 
 #define HASH_ADD_PEER(head,add) \

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1141,6 +1141,7 @@ void send_query_peer (n2n_edge_t * eee,
 void send_register_super (n2n_edge_t *eee) {
 
     uint8_t pktbuf[N2N_PKT_BUF_SIZE] = {0};
+    uint8_t hash_buf[16] = {0};
     size_t idx;
     /* ssize_t sent; */
     n2n_common_t cmn;
@@ -1172,10 +1173,17 @@ void send_register_super (n2n_edge_t *eee) {
     traceEvent(TRACE_DEBUG, "send REGISTER_SUPER to %s",
                sock_to_cstr(sockbuf, &(eee->curr_sn->sock)));
 
-    if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED)
+    if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED) {
         packet_header_encrypt(pktbuf, idx, idx,
                               eee->conf.header_encryption_ctx_static, eee->conf.header_iv_ctx_static,
                               time_stamp());
+
+        if(eee->conf.shared_secret) {
+            pearson_hash_128(hash_buf, pktbuf, idx);
+            speck_128_encrypt(hash_buf, (speck_context_t*)eee->conf.shared_secret_ctx);
+            encode_buf(pktbuf, &idx, hash_buf, N2N_REG_SUP_HASH_CHECK_LEN);
+        }
+    }
 
     /* sent = */ sendto_sock(eee, pktbuf, idx, &(eee->curr_sn->sock));
 }
@@ -2259,6 +2267,7 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
     n2n_sock_str_t        sockbuf2; /* don't clobber sockbuf1 if writing two addresses to trace */
     macstr_t              mac_buf1;
     macstr_t              mac_buf2;
+    uint8_t               hash_buf[16];
     size_t                rem;
     size_t                idx;
     size_t                msg_type;
@@ -2295,16 +2304,24 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
 
     if(eee->conf.header_encryption == HEADER_ENCRYPTION_ENABLED) {
         // match with static (1) or dynamic (2) ctx?
-        header_enc = packet_header_decrypt(udp_buf, udp_size,
-                                           (char *)eee->conf.community_name,
-                                           eee->conf.header_encryption_ctx_static, eee->conf.header_iv_ctx_static,
-                                           &stamp);
-        if(!header_enc)
-            if(packet_header_decrypt(udp_buf, udp_size,
+        // check dynamic first as it is identical to static in normal header encryption mode
+        if(packet_header_decrypt(udp_buf, udp_size,
                                      (char *)eee->conf.community_name,
                                      eee->conf.header_encryption_ctx_dynamic, eee->conf.header_iv_ctx_dynamic,
                                      &stamp)) {
-                header_enc = 2;
+                header_enc = 2; /* not accurate with normal header encryption but does not matter */
+        }
+        if(!header_enc) {
+            // check static now (very likely to be REGISTER_SUPER_ACK, REGISTER_SUPER_NAK or invalid)
+            if(eee->conf.shared_secret) {
+                // hash the still encrypted packet to eventually be able to check it later (required for REGISTER_SUPER_ACK with user/pw auth)
+                pearson_hash_128(hash_buf, udp_buf, max(0, (int)udp_size - (int)N2N_REG_SUP_HASH_CHECK_LEN));
+            }
+            header_enc = packet_header_decrypt(udp_buf, max(0, (int)udp_size - (int)N2N_REG_SUP_HASH_CHECK_LEN),
+                                           (char *)eee->conf.community_name,
+                                           eee->conf.header_encryption_ctx_static, eee->conf.header_iv_ctx_static,
+                                           &stamp);
+            header_enc = 1;
         }
         if(!header_enc) {
             traceEvent(TRACE_DEBUG, "readFromIPSocket failed to decrypt header.");
@@ -2500,6 +2517,15 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
                     }
                 }
 
+                // hash check (user/pw auth only)
+                if(eee->conf.shared_secret) {
+                    speck_128_encrypt(hash_buf, (speck_context_t*)eee->conf.shared_secret_ctx);
+                    if(memcmp(hash_buf, udp_buf + udp_size - N2N_REG_SUP_HASH_CHECK_LEN /* length is has already been checked */, N2N_REG_SUP_HASH_CHECK_LEN)) {
+                        traceEvent(TRACE_INFO, "Rx REGISTER_SUPER_ACK with wrong hash.");
+                        return;
+                    }
+                }
+
                 if(memcmp(ra.cookie, eee->curr_sn->last_cookie, N2N_COOKIE_SIZE)) {
                     traceEvent(TRACE_INFO, "Rx REGISTER_SUPER_ACK with wrong or old cookie.");
                     return;
@@ -2624,7 +2650,9 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
                     } else {
                         traceEvent(TRACE_ERROR, "Authentication error. MAC or IP address already in use or not released yet by supernode.");
                     }
-                    exit(1);
+                    // REVISIT: the following portion is too harsh, repeated error warning should be sufficient until it eventually is resolved,
+                    //           preventing de-auth attacks
+                    /* exit(1); this is too harsh, repeated error warning should be sufficient until it eventually is resolved, preventing de-auth attacks
                 } else {
                     HASH_FIND_PEER(eee->known_peers, nak.srcMac, peer);
                     if(peer != NULL) {
@@ -2633,7 +2661,7 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
                     HASH_FIND_PEER(eee->pending_peers, nak.srcMac, scan);
                     if(scan != NULL) {
                         HASH_DEL(eee->pending_peers, scan);
-                    }
+                    } */
                 }
                 break;
             }

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1559,7 +1559,6 @@ static int process_udp (n2n_sn_t * sss,
             uint8_t                                ackbuf[N2N_SN_PKTBUF_SIZE];
             uint8_t                                payload_buf[REG_SUPER_ACK_PAYLOAD_SPACE];
             n2n_REGISTER_SUPER_ACK_payload_t       *payload;
-            uint8_t                                tmp_hash_buf[16] = {0};
             size_t                                 encx = 0;
             struct sn_community_regular_expression *re, *tmp_re;
             struct peer_info                       *peer, *tmp_peer, *p;


### PR DESCRIPTION
This pull request adds an encrpyted hash to the REGISTER_SUPER and REGISTER_SUPER_ACK and REGISTER_SUPER_NAK packets in user/pw-mode only.

In user/pw auth scheme, those packets get encrypted with the static key which is still known to a lost or stolen edge. We can prevent creation of fake packets as the outer hash is encrypted with the shared secret (only shared between federated supernodes and the edge) so authenticity can be checked.

It does not make sense to secure REGISTER_SUPER_NAK packets (they get empty hash) as those packets usually are send out if credentials are wrong (and thus the keys, including the shared secret). So, to prevent de-auth attacks, the edge does not exit on REGISTER_SUPER_NAK anymore but outputs ERROR or WARNING as long as those packets are received. This might even help in case of MAC/IP address spoofing protection as the underlying condition might be resolved anyway after roughly two minutes when supernode has forgotten information on previously not cleanly exited edge.