### PR TITLE
narrowed sn's edge-last-seen update mechanism

### DIFF
--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1559,7 +1559,6 @@ static int process_udp (n2n_sn_t * sss,
             uint8_t                                ackbuf[N2N_SN_PKTBUF_SIZE];
             uint8_t                                payload_buf[REG_SUPER_ACK_PAYLOAD_SPACE];
             n2n_REGISTER_SUPER_ACK_payload_t       *payload;
-            uint8_t                                tmp_hash_buf[16] = {0};
             size_t                                 encx = 0;
             struct sn_community_regular_expression *re, *tmp_re;
             struct peer_info                       *peer, *tmp_peer, *p;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -738,7 +738,7 @@ static int update_edge (n2n_sn_t *sss,
         }
     }
 
-    if(scan != NULL) {
+    if((scan != NULL) && (ret != update_edge_auth_fail)) {
         scan->last_seen = now;
     }
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1559,6 +1559,7 @@ static int process_udp (n2n_sn_t * sss,
             uint8_t                                ackbuf[N2N_SN_PKTBUF_SIZE];
             uint8_t                                payload_buf[REG_SUPER_ACK_PAYLOAD_SPACE];
             n2n_REGISTER_SUPER_ACK_payload_t       *payload;
+            uint8_t                                tmp_hash_buf[16] = {0};
             size_t                                 encx = 0;
             struct sn_community_regular_expression *re, *tmp_re;
             struct peer_info                       *peer, *tmp_peer, *p;


### PR DESCRIPTION
This pull request changes supernode's behaviour for edge-last-seen update: Do not update if authentication failed.

Along with the latest change to not end edge on authentication failure, this will help to pass the authentication errors due to restart after premature edge end caused by `kill -9` etc. So, no need to **wait** and restart edge again, just restart – waiting happens inside edge accompanied by some auth error messages... I think this is better for unattended systems.