### PR TITLE
Update n2n.c

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -178,6 +178,14 @@ enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 #define N2N_IFNAMSIZ               16 /* 15 chars * NULL */
 #endif
 
+#ifdef _MSC_VER
+#define N2N_THREAD_RETURN_DATATYPE       DWORD WINAPI
+#define N2N_THREAD_PARAMETER_DATATYPE    LPVOID
+#else
+#define N2N_THREAD_RETURN_DATATYPE        void*
+#define N2N_THREAD_PARAMETER_DATATYPE     void*
+#endif
+
 #define SN_SELECTION_CRITERION_DATA_TYPE    uint32_t
 #define SN_SELECTION_CRITERION_BUF_SIZE     16
 

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -312,7 +312,7 @@ int supernode2sock (n2n_sock_t *sn, const n2n_sn_name_t addrIn) {
     return rv;
 }
 
-upda
+
 N2N_THREAD_RETURN_DATATYPE resolve_thread(N2N_THREAD_PARAMETER_DATATYPE p) {
 
 #ifdef HAVE_PTHREAD

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -312,6 +312,7 @@ int supernode2sock (n2n_sock_t *sn, const n2n_sn_name_t addrIn) {
     return rv;
 }
 
+upda
 N2N_THREAD_RETURN_DATATYPE resolve_thread(N2N_THREAD_PARAMETER_DATATYPE p) {
 
 #ifdef HAVE_PTHREAD

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -312,9 +312,11 @@ int supernode2sock (n2n_sock_t *sn, const n2n_sn_name_t addrIn) {
     return rv;
 }
 
-
+#if defined(_MSC_VER)
+DWORD WINAPI resolve_thread(LPVOID p) {
+#else
 void *resolve_thread (void *p) {
-
+#endif
 #ifdef HAVE_PTHREAD
     n2n_resolve_parameter_t *param = (n2n_resolve_parameter_t*)p;
     n2n_resolve_ip_sock_t   *entry, *tmp_entry;

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -312,11 +312,8 @@ int supernode2sock (n2n_sock_t *sn, const n2n_sn_name_t addrIn) {
     return rv;
 }
 
-#if defined(_MSC_VER)
-DWORD WINAPI resolve_thread(LPVOID p) {
-#else
-void *resolve_thread (void *p) {
-#endif
+N2N_THREAD_RETURN_DATATYPE resolve_thread(N2N_THREAD_PARAMETER_DATATYPE p) {
+
 #ifdef HAVE_PTHREAD
     n2n_resolve_parameter_t *param = (n2n_resolve_parameter_t*)p;
     n2n_resolve_ip_sock_t   *entry, *tmp_entry;


### PR DESCRIPTION
fix  #735
fix  #733

CMake + VS 2015   Mingw is not used.
The compiler failed to compile on Windows. The error is as follows:
file n2n.c line 397
// create thread
ret = pthread_create(&((*param)->id), NULL, resolve_thread, (void *)*param);
if(ret) {
traceEvent(TRACE_WARNING, "resolve_create_thread failed to create resolver thread with error number %d", ret);
return -1;
}
build error info:
Severity	Code	Description	File	Project	Line
Error	C2440	'function': cannot convert from 'void *(__cdecl *)(void *)' to 'LPTHREAD_START_ROUTINE'
\n2n\src\n2n.c	n2n	397