### PR TITLE
make edge restore original metric value (-x) at program's end

### DIFF
--- a/win32/n2n_win32.h
+++ b/win32/n2n_win32.h
@@ -21,14 +21,19 @@
 #include <inttypes.h>
 #endif /* #if defined(__MINGW32__) */
 
+
 #include <winsock2.h>
 #include <windows.h>
-#include <winioctl.h>
-#include <iptypes.h>
+#include <ws2def.h>
+#include <ws2ipdef.h>
 #if defined(_MSC_VER)
 #include <Iphlpapi.h>
 #pragma comment(lib,"Iphlpapi.lib")
 #endif
+#include <netioapi.h>
+#include <winioctl.h>
+#include <iptypes.h>
+
 
 #include "wintap.h"
 
@@ -81,6 +86,7 @@ typedef struct tuntap_dev {
 	uint32_t        device_mask;
 	unsigned int    mtu;
 	unsigned int    metric;
+        unsigned int    metric_original;
 } tuntap_dev;
 
 


### PR DESCRIPTION
This pull request makes the edge memorize the original interface metric value at program start and restores it at the end again if a custom interface metric was provided (`-x <metric>`, Windows only).

As helpful as the custom metric setting is e.g. for online gaming (make Windows broad-/multicast over TAP), restoration of original value is as important as well e.g. to play over real LAN after edge has finished.

The metric value can be checked using `netsh interface ipv4 show interface <TAP interface name>` command. The interface name is shown at the end of `edge --help` output, it was `TAP` in my case, not sure if this is a default name.

The used API to the IP Interface Entries is available from Windows Vista on. This should be no issue as we [dropped](https://github.com/ntop/n2n/pull/717#issuecomment-877683968) XP support a while ago. Also, instead of `netsh`ing to the `system` command line, this API might also come in useful to set all the other properties of the Windosw TAP device in `win32/wintap.c`, but I did not look any deeper into that.

Resolves #637.