### PR TITLE
rearranged thread-related code

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -269,6 +269,7 @@ int quick_edge_init (char *device_name, char *community_name,
                      char *supernode_ip_address_port,
                      int *keep_on_running);
 int comm_init (struct sn_community *comm, char *cmn);
+int sn_init_defaults (n2n_sn_t *sss);
 int sn_init (n2n_sn_t *sss);
 void sn_term (n2n_sn_t *sss);
 int supernode2sock (n2n_sock_t * sn, const n2n_sn_name_t addrIn);

--- a/src/edge.c
+++ b/src/edge.c
@@ -50,7 +50,6 @@ int supernode_disconnect (n2n_edge_t *eee);
 int fetch_and_eventually_process_data (n2n_edge_t *eee, SOCKET sock,
                                        uint8_t *pktbuf, uint16_t *expected, uint16_t *position,
                                        time_t now);
-int resolve_create_thread (n2n_resolve_parameter_t **param, struct peer_info *sn_list);
 int resolve_check (n2n_resolve_parameter_t *param, uint8_t resolution_request, time_t now);
 int edge_init_routes (n2n_edge_t *eee, n2n_route_t *routes, uint16_t num_routes);
 
@@ -1039,10 +1038,6 @@ int main (int argc, char* argv[]) {
     if((eee = edge_init(&conf, &rc)) == NULL) {
         traceEvent(TRACE_ERROR, "failed in edge_init");
         exit(1);
-    }
-
-    if(resolve_create_thread(&(eee->resolve_parameter), eee->conf.supernodes) == 0) {
-         traceEvent(TRACE_NORMAL, "successfully created resolver thread");
     }
 
     memcpy(&(eee->tuntap_priv_conf), &ec, sizeof(ec));

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -26,6 +26,7 @@ static HEAP_ALLOC (wrkmem, LZO1X_1_MEM_COMPRESS);
 
 /* ************************************** */
 
+int resolve_create_thread (n2n_resolve_parameter_t **param, struct peer_info *sn_list);
 int resolve_check (n2n_resolve_parameter_t *param, uint8_t resolution_request, time_t now);
 int resolve_cancel_thread (n2n_resolve_parameter_t *param);
 
@@ -416,6 +417,10 @@ n2n_edge_t* edge_init (const n2n_edge_conf_t *conf, int *rv) {
     if(edge_init_sockets(eee) < 0) {
         traceEvent(TRACE_ERROR, "socket setup failed");
         goto edge_init_error;
+    }
+
+    if(resolve_create_thread(&(eee->resolve_parameter), eee->conf.supernodes) == 0) {
+         traceEvent(TRACE_NORMAL, "successfully created resolver thread");
     }
 
     eee->network_traffic_filter = create_network_traffic_filter();

--- a/src/example_sn_embed.c
+++ b/src/example_sn_embed.c
@@ -25,7 +25,7 @@ int main () {
         n2n_sn_t sss_node;
         int rc;
 
-        sn_init(&sss_node);
+        sn_init_defaults(&sss_node);
         sss_node.daemon = 0;   // Whether to daemonize
         sss_node.lport = 1234; // Main UDP listen port
 
@@ -38,6 +38,8 @@ int main () {
         if(-1 == sss_node.mgmt_sock) {
             exit(-2);
         }
+
+        sn_init(&sss_node);
 
         keep_running = 1;
         rc = run_sn_loop(&sss_node, &keep_running);

--- a/src/sn.c
+++ b/src/sn.c
@@ -527,7 +527,7 @@ int main (int argc, char * const argv[]) {
     struct peer_info *scan, *tmp;
 
 
-    sn_init(&sss_node);
+    sn_init_defaults(&sss_node);
     add_federation_to_communities(&sss_node);
 
     if((argc >= 2) && (argv[1][0] != '-')) {
@@ -635,9 +635,7 @@ int main (int argc, char * const argv[]) {
     }
 #endif
 
-    if(resolve_create_thread(&(sss_node.resolve_parameter), sss_node.federation->edges) == 0) {
-         traceEvent(TRACE_NORMAL, "successfully created resolver thread");
-    }
+    sn_init(&sss_node);
 
     traceEvent(TRACE_NORMAL, "supernode started");
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -20,6 +20,7 @@
 
 #define HASH_FIND_COMMUNITY(head, name, out) HASH_FIND_STR(head, name, out)
 
+int resolve_create_thread (n2n_resolve_parameter_t **param, struct peer_info *sn_list);
 int resolve_check (n2n_resolve_parameter_t *param, uint8_t resolution_request, time_t now);
 int resolve_cancel_thread (n2n_resolve_parameter_t *param);
 
@@ -727,7 +728,7 @@ int comm_init (struct sn_community *comm, char *cmn) {
 
 
 /** Initialise the supernode structure */
-int sn_init(n2n_sn_t *sss) {
+int sn_init_defaults (n2n_sn_t *sss) {
 
     int i;
     size_t idx;
@@ -784,6 +785,15 @@ int sn_init(n2n_sn_t *sss) {
     sss->mac_addr[0] |= 0x02;    /* Set locally-assigned bit */
 
     return 0; /* OK */
+}
+
+
+/** Initialise the supernode */
+int sn_init (n2n_sn_t *sss) {
+
+    if(resolve_create_thread(&(sss->resolve_parameter), sss->federation->edges) == 0) {
+         traceEvent(TRACE_NORMAL, "successfully created resolver thread");
+    }
 }
 
 


### PR DESCRIPTION
This pull request rearranges resolver thread initialization code and by the way, it adopts the set-default/init scheme from edge's start-up to supernode.