### PR TITLE
added preferred socket handling

### DIFF
--- a/edge.8
+++ b/edge.8
@@ -44,6 +44,11 @@ TOS for packets, e.g. 0x48 for SSH like priority
 enable PMTU discovery, it can reduce fragmentation but
 causes connections to stall if not properly supported
 .TP
+\fB\-e \fR<\fIlocal ip\fR>
+advertises the provided local IP address as preferred,
+useful if multicast peer detection is not available, e.g.
+disabled on routers
+.TP
 \fB\-S1\fR ... \fB\-S2\fR
 do not connect p2p, always use the supernode,
 \-S1 = via UDP, \-S2 = via TCP

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -166,6 +166,8 @@ enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 #define N2N_USER_KEY_LINE_STARTER  '*'
 #define N2N_MAC_SIZE               6
 #define N2N_COOKIE_SIZE            4
+#define N2N_REGULAR_REG_COOKIE     0x00000000
+#define N2N_LOCAL_REG_COOKIE       0x00000001
 #define N2N_DESC_SIZE              16
 #define N2N_PKT_BUF_SIZE           2048
 #define N2N_SOCKBUF_SIZE           64  /* string representation of INET or INET6 sockets */

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -165,7 +165,6 @@ enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 #define N2N_PRIVATE_PUBLIC_KEY_SIZE 32
 #define N2N_USER_KEY_LINE_STARTER  '*'
 #define N2N_MAC_SIZE               6
-#define N2N_COOKIE_SIZE            4
 #define N2N_REGULAR_REG_COOKIE     0x00000000
 #define N2N_LOCAL_REG_COOKIE       0x00000001
 #define N2N_DESC_SIZE              16

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -20,6 +20,14 @@
 #define _N2N_TYPEDEFS_H_
 
 
+typedef uint8_t  n2n_community_t[N2N_COMMUNITY_SIZE];
+typedef uint8_t  n2n_private_public_key_t[N2N_PRIVATE_PUBLIC_KEY_SIZE];
+typedef uint8_t  n2n_mac_t[N2N_MAC_SIZE];
+typedef uint32_t n2n_cookie_t;
+typedef uint8_t  n2n_desc_t[N2N_DESC_SIZE];
+typedef char     n2n_sock_str_t[N2N_SOCKBUF_SIZE]; /* tracing string buffer */
+
+
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include "getopt.h"
 
@@ -110,12 +118,6 @@ typedef unsigned long in_addr_t;
 #pragma pack(push,1)
 #endif
 
-typedef uint8_t  n2n_community_t[N2N_COMMUNITY_SIZE];
-typedef uint8_t  n2n_private_public_key_t[N2N_PRIVATE_PUBLIC_KEY_SIZE];
-typedef uint8_t  n2n_mac_t[N2N_MAC_SIZE];
-typedef uint32_t n2n_cookie_t;
-typedef uint8_t  n2n_desc_t[N2N_DESC_SIZE];
-typedef char     n2n_sock_str_t[N2N_SOCKBUF_SIZE]; /* tracing string buffer */
 
 // those are definitely not typedefs (with a view to the filename) but neither are they defines
 static const n2n_mac_t broadcast_mac      = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -20,21 +20,6 @@
 #define _N2N_TYPEDEFS_H_
 
 
-
-typedef uint8_t n2n_community_t[N2N_COMMUNITY_SIZE];
-typedef uint8_t n2n_private_public_key_t[N2N_PRIVATE_PUBLIC_KEY_SIZE];
-typedef uint8_t n2n_mac_t[N2N_MAC_SIZE];
-typedef uint8_t n2n_cookie_t[N2N_COOKIE_SIZE];
-typedef uint8_t n2n_desc_t[N2N_DESC_SIZE];
-typedef char    n2n_sock_str_t[N2N_SOCKBUF_SIZE]; /* tracing string buffer */
-
-// those are definitely not typedefs (with a view to the filename) but neither are they defines
-static const n2n_mac_t broadcast_mac      = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-static const n2n_mac_t multicast_mac      = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0x00 }; /* First 3 bytes are meaningful */
-static const n2n_mac_t ipv6_multicast_mac = { 0x33, 0x33, 0x00, 0x00, 0x00, 0x00 }; /* First 2 bytes are meaningful */
-static const n2n_mac_t null_mac           = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-
-
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include "getopt.h"
 
@@ -124,6 +109,20 @@ typedef unsigned long in_addr_t;
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #pragma pack(push,1)
 #endif
+
+typedef uint8_t  n2n_community_t[N2N_COMMUNITY_SIZE];
+typedef uint8_t  n2n_private_public_key_t[N2N_PRIVATE_PUBLIC_KEY_SIZE];
+typedef uint8_t  n2n_mac_t[N2N_MAC_SIZE];
+typedef uint32_t n2n_cookie_t;
+typedef uint8_t  n2n_desc_t[N2N_DESC_SIZE];
+typedef char     n2n_sock_str_t[N2N_SOCKBUF_SIZE]; /* tracing string buffer */
+
+// those are definitely not typedefs (with a view to the filename) but neither are they defines
+static const n2n_mac_t broadcast_mac      = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+static const n2n_mac_t multicast_mac      = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0x00 }; /* First 3 bytes are meaningful */
+static const n2n_mac_t ipv6_multicast_mac = { 0x33, 0x33, 0x00, 0x00, 0x00, 0x00 }; /* First 2 bytes are meaningful */
+static const n2n_mac_t null_mac           = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
 
 #define ETH_ADDR_LEN 6
 

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -328,7 +328,7 @@ typedef struct n2n_REGISTER {
     n2n_cookie_t       cookie;      /**< Link REGISTER and REGISTER_ACK */
     n2n_mac_t          srcMac;      /**< MAC of registering party */
     n2n_mac_t          dstMac;      /**< MAC of target edge */
-    n2n_sock_t         sock;        /**< REVISIT: unused? */
+    n2n_sock_t         sock;        /**< Supernode's view of edge socket OR edge's preferred local socket */
     n2n_ip_subnet_t    dev_addr;    /**< IP address of the tuntap adapter. */
     n2n_desc_t         dev_desc;    /**< Hint description correlated with the edge */
 } n2n_REGISTER_t;
@@ -408,6 +408,7 @@ typedef struct n2n_PEER_INFO {
     n2n_mac_t                        srcMac;
     n2n_mac_t                        mac;
     n2n_sock_t                       sock;
+    n2n_sock_t                       preferred_sock;
     SN_SELECTION_CRITERION_DATA_TYPE data;
 } n2n_PEER_INFO_t;
 
@@ -426,6 +427,8 @@ struct peer_info {
     n2n_desc_t                       dev_desc;
     n2n_sock_t                       sock;
     SOCKET                           socket_fd;
+    n2n_sock_t                       preferred_sock;
+    time_t                           last_local_reg;
     n2n_cookie_t                     last_cookie;
     n2n_auth_t                       auth;
     int                              timeout;
@@ -647,6 +650,7 @@ typedef struct n2n_edge_conf {
     int                      register_interval;      /**< Interval for supernode registration, also used for UDP NAT hole punching. */
     int                      register_ttl;           /**< TTL for registration packet when UDP NAT hole punching through supernode. */
     in_addr_t                bind_address;           /**< The address to bind to if provided (-b) */
+    n2n_sock_t               preferred_sock;         /**< propagated local sock for better p2p in LAN (-e) */
     int                      local_port;
     int                      mgmt_port;
     uint8_t                  connect_tcp;            /** connection to supernode 0 = UDP; 1 = TCP */

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -91,6 +91,15 @@ int decode_mac (n2n_mac_t out,
                 size_t * rem,
                 size_t * idx);
 
+int encode_cookie (uint8_t * base,
+                   size_t * idx,
+                   const n2n_cookie_t c);
+
+int decode_cookie (n2n_cookie_t * out,
+                   const uint8_t * base,
+                   size_t * rem,
+                   size_t * idx);
+
 int encode_common (uint8_t * base,
                    size_t * idx,
                    const n2n_common_t * common);

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2494,9 +2494,10 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
                      * a valid channel. We still use check_peer_registration_needed below
                      * to double check this.
                      */
-                    traceEvent(TRACE_INFO, "[p2p] Rx REGISTER from %s [%s]",
+                    traceEvent(TRACE_INFO, "[p2p] Rx REGISTER from %s [%s]%s",
                                            macaddr_str(mac_buf1, reg.srcMac),
-                                           sock_to_cstr(sockbuf1, &sender));
+                                           sock_to_cstr(sockbuf1, &sender),
+                                           (reg.cookie == N2N_LOCAL_REG_COOKIE) ? " (local)" : "");
                     find_and_remove_peer(&eee->pending_peers, reg.srcMac);
 
                     /* NOTE: only ACK to peers */
@@ -2528,11 +2529,13 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
                 if(is_valid_peer_sock(&ra.sock))
                     orig_sender = &(ra.sock);
 
-                traceEvent(TRACE_INFO, "Rx REGISTER_ACK from %s [%s] to %s via [%s]",
+                traceEvent(TRACE_INFO, "Rx REGISTER_ACK from %s [%s] to %s via [%s]%s",
                            macaddr_str(mac_buf1, ra.srcMac),
                            sock_to_cstr(sockbuf2, orig_sender),
                            macaddr_str(mac_buf2, ra.dstMac),
-                           sock_to_cstr(sockbuf1, &sender));
+                           sock_to_cstr(sockbuf1, &sender),
+                          (ra.cookie == N2N_LOCAL_REG_COOKIE) ? " (local)" : "");
+
 
                 peer_set_p2p_confirmed(eee, ra.srcMac,
                                       ra.cookie,

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -2136,7 +2136,7 @@ static int process_udp (n2n_sn_t * sss,
             // check authentication
             ret_value = update_edge_no_change;
             if(comm->is_federation != IS_FEDERATION) { /* REVISIT: auth among supernodes is not implemented yet */
-                if(cmn.flags & N2N_FLAGS_SOCKET) {
+                if(cmn.flags & N2N_FLAGS_FROM_SUPERNODE) {
                     ret_value = update_edge(sss, &reg, comm, &(ack.sock), socket_fd, &(ack.auth), SN_ADD_SKIP, now);
                 } else {
                     // do not add in case of null mac (edge asking for ip address)
@@ -2166,8 +2166,10 @@ static int process_udp (n2n_sn_t * sss,
                 traceEvent(TRACE_DEBUG, "Tx REGISTER_SUPER_NAK for %s",
                            macaddr_str(mac_buf, reg.edgeMac));
             } else {
-                // if this is not already forwarded from a supernode, ...
-                if(!(cmn.flags & N2N_FLAGS_SOCKET)) {
+                // if this is not already from a supernode ...
+                // and not from federation, ...
+                if(!(cmn.flags & N2N_FLAGS_FROM_SUPERNODE)
+                  &&(comm->is_federation != IS_FEDERATION)) {
                     // ... forward to all other supernodes (note try_broadcast()'s behavior with
                     //     NULL comm and from_supernode parameter)
                     // exception: do not forward auto ip draw

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -2168,8 +2168,7 @@ static int process_udp (n2n_sn_t * sss,
             } else {
                 // if this is not already from a supernode ...
                 // and not from federation, ...
-                if(!(cmn.flags & N2N_FLAGS_FROM_SUPERNODE)
-                  &&(comm->is_federation != IS_FEDERATION)) {
+                if((!(cmn.flags & N2N_FLAGS_FROM_SUPERNODE)) || (!(cmn.flags & N2N_FLAGS_SOCKET))) {
                     // ... forward to all other supernodes (note try_broadcast()'s behavior with
                     //     NULL comm and from_supernode parameter)
                     // exception: do not forward auto ip draw

--- a/src/wire.c
+++ b/src/wire.c
@@ -171,15 +171,14 @@ int decode_buf (uint8_t * out,
 }
 
 
-
-int encode_mac (uint8_t * base,
+int encode_mac (uint8_t * base,  /* n2n_mac_t is typedefed array type which is always passed by reference */
                 size_t * idx,
                 const n2n_mac_t m) {
 
     return encode_buf(base, idx, m, N2N_MAC_SIZE);
 }
 
-int decode_mac (n2n_mac_t out, /* n2n_mac_t is typedefed array type which is always passed by reference */
+int decode_mac (n2n_mac_t out,
                 const uint8_t * base,
                 size_t * rem,
                 size_t * idx) {
@@ -187,6 +186,20 @@ int decode_mac (n2n_mac_t out, /* n2n_mac_t is typedefed array type which is alw
     return decode_buf(out, N2N_MAC_SIZE, base, rem, idx);
 }
 
+int encode_cookie (uint8_t * base,
+                   size_t * idx,
+                   const n2n_cookie_t c) {
+
+    return encode_uint32(base, idx, c);
+}
+
+int decode_cookie (n2n_cookie_t * out,  /* cookies are typedef'd as uint32_t which needs to correspond to this code */
+                   const uint8_t * base,
+                   size_t * rem,
+                   size_t * idx) {
+
+    return decode_uint32(out, base, rem, idx);
+}
 
 
 int encode_common (uint8_t * base,
@@ -300,7 +313,7 @@ int encode_REGISTER (uint8_t *base,
     int retval = 0;
 
     retval += encode_common(base, idx, common);
-    retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
+    retval += encode_cookie(base, idx, reg->cookie);
     retval += encode_mac(base, idx, reg->srcMac);
     retval += encode_mac(base, idx, reg->dstMac);
     if(common->flags & N2N_FLAGS_SOCKET) {
@@ -323,7 +336,7 @@ int decode_REGISTER (n2n_REGISTER_t *reg,
     size_t retval = 0;
     memset(reg, 0, sizeof(n2n_REGISTER_t));
 
-    retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+    retval += decode_cookie(&reg->cookie, base, rem, idx);
     retval += decode_mac(reg->srcMac, base, rem, idx);
     retval += decode_mac(reg->dstMac, base, rem, idx);
     if(cmn->flags & N2N_FLAGS_SOCKET) {
@@ -345,7 +358,7 @@ int encode_REGISTER_SUPER (uint8_t *base,
     int retval = 0;
 
     retval += encode_common(base, idx, common);
-    retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
+    retval += encode_cookie(base, idx, reg->cookie);
     retval += encode_mac(base, idx, reg->edgeMac);
     if(common->flags & N2N_FLAGS_SOCKET) {
         retval += encode_sock(base, idx, &(reg->sock));
@@ -371,7 +384,7 @@ int decode_REGISTER_SUPER (n2n_REGISTER_SUPER_t *reg,
     size_t retval = 0;
     memset(reg, 0, sizeof(n2n_REGISTER_SUPER_t));
 
-    retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+    retval += decode_cookie(&reg->cookie, base, rem, idx);
     retval += decode_mac(reg->edgeMac, base, rem, idx);
     if(cmn->flags & N2N_FLAGS_SOCKET) {
         retval += decode_sock(&(reg->sock), base, rem, idx);
@@ -431,7 +444,7 @@ int encode_REGISTER_ACK (uint8_t *base,
     int retval = 0;
 
     retval += encode_common(base, idx, common);
-    retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
+    retval += encode_cookie(base, idx, reg->cookie);
     retval += encode_mac(base, idx, reg->dstMac);
     retval += encode_mac(base, idx, reg->srcMac);
 
@@ -455,7 +468,7 @@ int decode_REGISTER_ACK (n2n_REGISTER_ACK_t *reg,
     size_t retval = 0;
     memset(reg, 0, sizeof(n2n_REGISTER_ACK_t));
 
-    retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+    retval += decode_cookie(&reg->cookie, base, rem, idx);
     retval += decode_mac(reg->dstMac, base, rem, idx);
     retval += decode_mac(reg->srcMac, base, rem, idx);
 
@@ -479,7 +492,7 @@ int encode_REGISTER_SUPER_ACK (uint8_t *base,
     int retval = 0;
 
     retval += encode_common(base, idx, common);
-    retval += encode_buf(base, idx, reg->cookie, N2N_COOKIE_SIZE);
+    retval += encode_cookie(base, idx, reg->cookie);
     retval += encode_mac(base, idx, reg->srcMac);
     retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
     retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
@@ -510,7 +523,7 @@ int decode_REGISTER_SUPER_ACK (n2n_REGISTER_SUPER_ACK_t *reg,
     size_t retval = 0;
     memset(reg, 0, sizeof(n2n_REGISTER_SUPER_ACK_t));
 
-    retval += decode_buf(reg->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+    retval += decode_cookie(&reg->cookie, base, rem, idx);
     retval += decode_mac(reg->srcMac, base, rem, idx);
     retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
     retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
@@ -541,7 +554,7 @@ int encode_REGISTER_SUPER_NAK (uint8_t *base,
     int retval = 0;
 
     retval += encode_common(base, idx, common);
-    retval += encode_buf(base, idx, nak->cookie, N2N_COOKIE_SIZE);
+    retval += encode_cookie(base, idx, nak->cookie);
     retval += encode_mac(base, idx, nak->srcMac);
 
     retval += encode_uint16(base, idx, nak->auth.scheme);
@@ -561,7 +574,7 @@ int decode_REGISTER_SUPER_NAK (n2n_REGISTER_SUPER_NAK_t *nak,
     size_t retval = 0;
     memset(nak, 0, sizeof(n2n_REGISTER_SUPER_NAK_t));
 
-    retval += decode_buf(nak->cookie, N2N_COOKIE_SIZE, base, rem, idx);
+    retval += decode_cookie(&nak->cookie, base, rem, idx);
     retval += decode_mac(nak->srcMac, base, rem, idx);
 
     retval += decode_uint16(&(nak->auth.scheme), base, rem, idx);


### PR DESCRIPTION
This pull request shall take care of a preferred local socket as discussed over at [that other issue](https://github.com/ntop/n2n/issues/562#issuecomment-907795902) #562.

First commit makes supernode's  current REGISTER_SUPER handling independent from SOCKET flag for we can use this flag to indicate a preferred socket in the REGISTER_SUPER from edge to supernode (no additional flag required).

~~This is still work in progress, thus marked as draft pull  request. You can [download](https://github.com/Logan007/n2n/archive/prefSock.zip) the code of current pull request state to test.~~

[...]

_EDIT_:

Merged for better accessibility, e.g. for testing.

`-e <local IP address>` makes the edge advertise this pr**e**ferred local IP address via the supernodes to all other edges which then can try to connect directly. Just in case multicast peer detection does not work properly due to local network setup constraints. Please note that this feature reveals details of your local network topology (internal real IP addresses) to possibly untrusted supernodes.