### PR TITLE
fixed optional SKIP_MULTICAST_PEERS_DISCOVERY macro

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -168,3 +168,18 @@ Your specific ARM mileage may vary, so it can be enabled by configuring the defi
 `./configure CFLAGS="-DSPECK_ARM_NEON"`
 
 Just make sure that the correct architecture is set, too. `-march=native` usually works quite well.
+
+## Disable Nulticast Local Peer Detection
+
+For better local peer detection, the edges try to detect local peers by sending REGISTER
+packets to a certain multicast address. Also, edges listen to this address to eventually
+fetch such packets.
+
+If these packets disturb network's peace or even get forwarded by (other) edges through the
+n2n network, this behavior can be disabled, just add
+
+`-DSKIP_MULTICAST_PEERS_DISCOVERY`
+
+to your `CFLAGS` when configuring, e.g.
+
+`./configure --with-zstd CFLAGS="-O3 -march=native -DSKIP_MULTICAST_PEERS_DISCOVERY"`

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2314,7 +2314,11 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
      * hop as sender. */
     orig_sender = &sender;
 
+#ifdef SKIP_MULTICAST_PEERS_DISCOVERY
+    via_multicast = 0;
+#else
     via_multicast = (in_sock == eee->udp_multicast_sock);
+#endif
 
     traceEvent(TRACE_DEBUG, "Rx N2N_UDP of size %d from [%s]",
                (signed int)udp_size, sock_to_cstr(sockbuf1, &sender));
@@ -2785,7 +2789,11 @@ int fetch_and_eventually_process_data (n2n_edge_t *eee, SOCKET sock,
 
     size_t bread = 0;
 
-    if((!eee->conf.connect_tcp) || (sock == eee->udp_multicast_sock)) {
+    if((!eee->conf.connect_tcp)
+#ifndef SKIP_MULTICAST_PEERS_DISCOVERY
+    || (sock == eee->udp_multicast_sock)
+#endif
+      ) {
         // udp
         struct sockaddr_in sender_sock;
         socklen_t i;


### PR DESCRIPTION
This pull request allows proper use of `SKIP_MULTICAST_PEERS_DISCOVERY` macro for configuration, e.g.

`-DSKIP_MULTICAST_PEERS_DISCOVERY`

to disable local multicast peer detection (listening as well as querying).