### PR TITLE
merged edge's '-b' into '-p' command line option

### DIFF
--- a/edge.8
+++ b/edge.8
@@ -28,10 +28,14 @@ truncated to take the first 16 bytes.
 sets the n2n supernode IP address and port to register to. Multiple supernodes
 can be specified.
 .TP
-\fB\-p \fR<\fIlocal port\fR>
+\fB\-p \fR[<\fIlocal_ip_address\fR>:]<\fIlocal_port\fR>
 binds edge to the given UDP port. Useful for keeping the same external socket
 across restarts of edge. This allows peer edges which know the edge socket to
-continue p2p operation without going back to the supernode.
+continue p2p operation without going back to the supernode. Also, home router's
+port forwarding feature can refer to that fixed port.
+Optionally, the edge can bind to the provided local ip address only. This is
+useful in case restriction to a certain LAN or WiFi interface is desired.
+By default, the edge binds to any interface.
 .TP
 \fB\-T \fR<\fItos\fR>
 TOS for packets, e.g. 0x48 for SSH like priority
@@ -39,10 +43,6 @@ TOS for packets, e.g. 0x48 for SSH like priority
 \fB\-D\fR
 enable PMTU discovery, it can reduce fragmentation but
 causes connections to stall if not properly supported
-.TP
-\fB\-b \fR<\fIbind ip\fR>
-binds edge to the provided local IP address only, defaults to 'any' ip address
-if not provided
 .TP
 \fB\-S1\fR ... \fB\-S2\fR
 do not connect p2p, always use the supernode,


### PR DESCRIPTION
This pull request merges the [recently added `-b`](https://github.com/ntop/n2n/pull/753) command line option into `-p` command line option as both deal with binding the local edge to some local port and / or local IP address.

Usage covers

`-p <port>`, e.g. `-p 12345`with unspecified IP address binding to ANY of hosts's available IP addresses (`INADDR_ANY`),
`-p <ip>:<port>`, e.g. `-p 192.168.0.100:12345` with 192.168.0.100 being an IP address local to the host, and
`-p <ip>`, e.g. `-p 192.168.0.100` with unspecified port falling back to an OS assigned one.

Removes `-b`.

Addresses #771.