### PR TITLE
Turn on -Wall and address most messages

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -22,6 +22,7 @@ ifeq ($(OPENSSL_CFLAGS), 0)
   CFLAGS+=$(shell pkg-config --cflags-only-I openssl)
 endif
 
+WARN=-Wall
 CFLAGS+=$(DEBUG) $(OPTIMIZATION) $(WARN) $(OPTIONS) $(PLATOPTS)
 
 INSTALL=install

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -272,7 +272,7 @@ int quick_edge_init (char *device_name, char *community_name,
                      int *keep_on_running);
 int comm_init (struct sn_community *comm, char *cmn);
 int sn_init_defaults (n2n_sn_t *sss);
-int sn_init (n2n_sn_t *sss);
+void sn_init (n2n_sn_t *sss);
 void sn_term (n2n_sn_t *sss);
 int supernode2sock (n2n_sock_t * sn, const n2n_sn_name_t addrIn);
 struct peer_info* add_sn_to_list_by_mac_or_sock (struct peer_info **sn_list, n2n_sock_t *sock, const n2n_mac_t mac, int *skip_add);

--- a/src/auth.c
+++ b/src/auth.c
@@ -136,7 +136,6 @@ int generate_shared_secret (n2n_private_public_key_t shared, n2n_private_public_
 int bind_private_key_to_username (n2n_private_public_key_t prv, uint8_t *username) {
 
     uint8_t tmp[32];
-    size_t i;
 
     pearson_hash_256(tmp, username, strlen(username));
     memxor(prv, tmp, sizeof(n2n_private_public_key_t));

--- a/src/curve25519.c
+++ b/src/curve25519.c
@@ -200,7 +200,6 @@ static void mainloop (unsigned int work[64], const unsigned char e[32]) {
     unsigned int s[32];
     unsigned int t[32];
     unsigned int u[32];
-    unsigned int i;
     unsigned int j;
     unsigned int b;
     int pos;

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -308,7 +308,6 @@ n2n_edge_t* edge_init (const n2n_edge_conf_t *conf, int *rv) {
     n2n_edge_t *eee = calloc(1, sizeof(n2n_edge_t));
     int rc = -1, i = 0;
     struct peer_info *scan, *tmp;
-    size_t idx = 0;
     uint8_t tmp_key[N2N_AUTH_CHALLENGE_SIZE];
 
     if((rc = edge_verify_conf(conf)) != 0) {
@@ -793,8 +792,6 @@ static void peer_set_p2p_confirmed (n2n_edge_t * eee,
 
 // provides the current / a new local auth token
 static int get_local_auth (n2n_edge_t *eee, n2n_auth_t *auth) {
-
-    static const uint8_t null_block[16] = { 0 };
 
     switch(eee->conf.auth.scheme) {
         case n2n_auth_simple_id:
@@ -1724,6 +1721,7 @@ static int handle_PACKET (n2n_edge_t * eee,
 /* ************************************** */
 
 
+#if 0
 #ifndef WIN32
 
 static char *get_ip_from_arp (dec_ip_str_t buf, const n2n_mac_t req_mac) {
@@ -1759,6 +1757,7 @@ static char *get_ip_from_arp (dec_ip_str_t buf, const n2n_mac_t req_mac) {
     return buf;
 }
 
+#endif
 #endif
 
 
@@ -2681,8 +2680,6 @@ void process_udp (n2n_edge_t *eee, const struct sockaddr_in *sender_sock, const 
             case MSG_TYPE_REGISTER_SUPER_NAK: {
 
                 n2n_REGISTER_SUPER_NAK_t nak;
-                struct peer_info *peer, *scan;
-
 
                 if(!(eee->sn_wait)) {
                     traceEvent(TRACE_DEBUG, "Rx REGISTER_SUPER_NAK with no outstanding REGISTER_SUPER");
@@ -3525,8 +3522,8 @@ static int edge_init_routes_linux (n2n_edge_t *eee, n2n_route_t *routes, uint16_
 
 /* ************************************** */
 
-static int edge_init_routes_win (n2n_edge_t *eee, n2n_route_t *routes, uint16_t num_routes, uint8_t verb /* 0 = add, 1 = delete */) {
 #ifdef WIN32
+static int edge_init_routes_win (n2n_edge_t *eee, n2n_route_t *routes, uint16_t num_routes, uint8_t verb /* 0 = add, 1 = delete */) {
     int i;
     struct in_addr net_addr, gateway;
     char c_net_addr[32];
@@ -3562,10 +3559,10 @@ static int edge_init_routes_win (n2n_edge_t *eee, n2n_route_t *routes, uint16_t 
             system(cmd);
         }
     }
-#endif // WIN32
 
     return (0);
 }
+#endif // WIN32
 
 /* ************************************** */
 

--- a/src/header_encryption.c
+++ b/src/header_encryption.c
@@ -82,7 +82,6 @@ int packet_header_encrypt (uint8_t packet[], uint16_t header_len, uint16_t packe
                            he_context_t *ctx, he_context_t *ctx_iv,
                            uint64_t stamp) {
 
-    static const uint8_t null_block[16] = { 0 };
     uint32_t *p32 = (uint32_t*)packet;
     uint64_t *p64 = (uint64_t*)packet;
     uint64_t checksum = 0;

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -65,8 +65,7 @@ int detect_local_ip_address (n2n_sock_t* out_sock, const n2n_edge_t* eee) {
 
     struct sockaddr_in local_sock;
     struct sockaddr_in sn_sock;
-    int sock_len = sizeof(local_sock);
-    int port = 0;
+    socklen_t sock_len = sizeof(local_sock);
     SOCKET probe_sock;
 
     out_sock->family = AF_INVALID;
@@ -350,8 +349,8 @@ int supernode2sock (n2n_sock_t *sn, const n2n_sn_name_t addrIn) {
             rv = -3;
         }
     } else {
-        traceEvent(TRACE_WARNING, "supernode2sock sees malformed supernode parameter (-l <host:port>) %s %s:%s",
-                   addr, supernode_host, supernode_port);
+        traceEvent(TRACE_WARNING, "supernode2sock sees malformed supernode parameter (-l <host:port>) %s",
+                   addrIn);
         rv = -4;
     }
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -307,7 +307,7 @@ int load_allowed_sn_community (n2n_sn_t *sss) {
     re_register_and_purge_supernodes(sss, sss->federation, &any_time, any_time, 1 /* forced */);
 
     // format definition for possible user-key entries
-    sprintf(format, "%c %%%ds %%%ds", N2N_USER_KEY_LINE_STARTER, N2N_DESC_SIZE - 1, sizeof(ascii_public_key)-1);
+    sprintf(format, "%c %%%ds %%%lds", N2N_USER_KEY_LINE_STARTER, N2N_DESC_SIZE - 1, sizeof(ascii_public_key)-1);
 
     while((line = fgets(buffer, sizeof(buffer), fd)) != NULL) {
         int len = strlen(line);
@@ -730,10 +730,6 @@ int comm_init (struct sn_community *comm, char *cmn) {
 
 /** Initialise the supernode structure */
 int sn_init_defaults (n2n_sn_t *sss) {
-
-    int i;
-    size_t idx;
-
 #ifdef WIN32
     initWin32();
 #endif
@@ -790,7 +786,7 @@ int sn_init_defaults (n2n_sn_t *sss) {
 
 
 /** Initialise the supernode */
-int sn_init (n2n_sn_t *sss) {
+void sn_init (n2n_sn_t *sss) {
 
     if(resolve_create_thread(&(sss->resolve_parameter), sss->federation->edges) == 0) {
          traceEvent(TRACE_NORMAL, "successfully created resolver thread");
@@ -1356,7 +1352,6 @@ static int re_register_and_purge_supernodes (n2n_sn_t *sss, struct sn_community 
             size_t idx;
             /* ssize_t sent; */
             n2n_common_t cmn;
-            n2n_cookie_t cookie;
             n2n_REGISTER_SUPER_t reg;
             n2n_sock_str_t sockbuf;
 
@@ -2701,7 +2696,7 @@ int run_sn_loop (n2n_sn_t *sss, int *keep_running) {
         ssize_t bread;
         int max_sock;
         fd_set socket_mask;
-        n2n_tcp_connection_t *conn, *next, *tmp_conn;
+        n2n_tcp_connection_t *conn, *tmp_conn;
 
         SOCKET tmp_sock;
         n2n_sock_str_t sockbuf;

--- a/src/tuntap_linux.c
+++ b/src/tuntap_linux.c
@@ -148,7 +148,6 @@ int tuntap_open (tuntap_dev *device,
         // set an explicit random MAC to know the exact MAC in use, manually
         // reading the MAC address is not safe as it may change internally
         // also after the TAP interface UP status has been notified
-        int i;
 
         memrnd(device->mac_addr, N2N_MAC_SIZE);
 


### PR DESCRIPTION
Most of what is still generating messages is the many miss-matches between the string functions wanting signed char and the n2n callers often using unsigned char - which has a style component to the choice of how to address.