### PR TITLE
Test platform mingw - For discussion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-18.04
           - macos-latest
+          - windows-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         name: Hack up a fake autoconf
         run: |
           echo true >autogen.sh
-          cp scripts/hack_fakeautoconf configure.sh
+          cp scripts/hack_fakeautoconf configure
 
       - name: generate a makefile and use it to install more packages
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,13 +76,19 @@ jobs:
           name: tests-out-${{matrix.os}}
           path: tests/*.out
 
-      - name: Generate coverage reports
+      - name: Generate coverage data
         run: |
           make cover
+        shell: bash
+
+      - if: runner.os != 'Windows'
+        name: Generate gcovr report
+        run: |
           make gcov
         shell: bash
 
-      - name: Upload gcovr report artifact
+      - if: runner.os != 'Windows'
+        name: Upload gcovr report artifact
         uses: actions/upload-artifact@v2
         with:
           name: coverage-${{matrix.os}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,13 +78,13 @@ jobs:
 
       - name: Generate coverage data
         run: |
-          make cover
+          make gcov
         shell: bash
 
       - if: runner.os != 'Windows'
         name: Generate gcovr report
         run: |
-          make gcov
+          make cover
         shell: bash
 
       - if: runner.os != 'Windows'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           echo true >autogen.sh
           cp scripts/hack_fakeautoconf configure
+        shell: bash
 
       - name: generate a makefile and use it to install more packages
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,13 @@ jobs:
         run: |
           brew install automake gcovr
 
+      - if: runner.os == 'Windows'
+        # This is a pretty big hammer, but gets the windows compile moving
+        name: Hack up a fake autoconf
+        run: |
+          echo true >autogen.sh
+          cp scripts/hack_fakeautoconf configure.sh
+
       - name: generate a makefile and use it to install more packages
         run: |
           ./autogen.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 configure
 configure.ac
 config.*
-Makefile
+./Makefile
+tools/Makefile
 autom4te.cache
 edge
 example_edge_embed_quick_edge_init

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,6 +6,8 @@ GIT_DESCRIBE=$(shell git describe --always --dirty)
 
 ########
 
+export CC
+export AR
 CC=@CC@
 AR=@AR@
 
@@ -29,7 +31,7 @@ CFLAGS+=$(DEBUG) $(OPTIMIZATION) $(WARN) $(OPTIONS) $(PLATOPTS)
 
 INSTALL=install
 MKDIR=mkdir -p
-OS := $(shell uname -s)
+OS := $(shell uname -o)
 
 INSTALL_PROG=$(INSTALL) -m755
 INSTALL_DOC=$(INSTALL) -m644
@@ -59,6 +61,13 @@ LDLIBS+=@N2N_LIBS@
 #For OpenSolaris (Solaris too?)
 ifeq ($(shell uname), SunOS)
 LDLIBS+=-lsocket -lnsl
+endif
+
+ifeq ($(OS),Msys)
+CFLAGS+=-I. -I./win32
+LDLIBS+=-lws2_32 -liphlpapi win32/n2n_win32.a
+N2N_DEPS+=win32/n2n_win32.a
+SUBDIRS+=win32
 endif
 
 APPS=edge
@@ -100,6 +109,8 @@ $(N2N_LIB): $(N2N_OBJS)
 	$(AR) rcs $(N2N_LIB) $(N2N_OBJS)
 #	$(RANLIB) $@
 
+win32/n2n_win32.a: win32
+
 test: tools
 	tools/test_harness
 
@@ -122,7 +133,7 @@ gcov:
 # This is the superset of all packages that might be needed.
 # It is a convinent target to use during development or from a CI/CD system
 build-dep:
-ifeq ($(OS),Linux)
+ifeq ($(OS),GNU/Linux)
 	sudo apt install build-essential autoconf libcap-dev libzstd-dev gcovr
 else
 	echo Not attempting to install dependancies for non dpkg system $(OS)
@@ -131,7 +142,7 @@ endif
 clean:
 	rm -rf $(N2N_OBJS) $(N2N_LIB) $(APPS) $(DOCS) coverage/ *.dSYM *~
 	rm -f tests/*.out src/*.gcno src/*.gcda
-	$(MAKE) -C tools clean
+	for dir in $(SUBDIRS); do $(MAKE) -C $$dir clean; done
 
 install: edge supernode edge.8.gz supernode.1.gz n2n.7.gz
 	echo "MANDIR=$(MANDIR)"

--- a/Makefile.in
+++ b/Makefile.in
@@ -31,7 +31,7 @@ CFLAGS+=$(DEBUG) $(OPTIMIZATION) $(WARN) $(OPTIONS) $(PLATOPTS)
 
 INSTALL=install
 MKDIR=mkdir -p
-OS := $(shell uname -o)
+OS := $(shell uname -s)
 
 ifndef OS
 # This could happen if the Makefile is unable to run "uname", which can
@@ -69,7 +69,7 @@ ifeq ($(shell uname), SunOS)
 LDLIBS+=-lsocket -lnsl
 endif
 
-ifeq ($(OS),Msys)
+ifeq ($(findstring MSYS_NT,$(OS)),MSYS_NT)
 CFLAGS+=-I. -I./win32
 LDLIBS+=$(abspath win32/n2n_win32.a)
 LDLIBS+=-lws2_32 -liphlpapi
@@ -143,7 +143,7 @@ gcov:
 # This is the superset of all packages that might be needed.
 # It is a convinent target to use during development or from a CI/CD system
 build-dep:
-ifeq ($(OS),GNU/Linux)
+ifeq ($(OS),Linux)
 	sudo apt install build-essential autoconf libcap-dev libzstd-dev gcovr
 else
 	echo Not attempting to install dependancies for non dpkg system $(OS)

--- a/Makefile.in
+++ b/Makefile.in
@@ -84,7 +84,10 @@ SUBDIRS+=tools
 .PHONY: steps build push all clean install est cover gcov build-dep
 all: $(APPS) $(DOCS) $(SUBDIRS)
 
-$(SUBDIRS): $(N2N_LIB)
+tools: $(N2N_LIB)
+	$(MAKE) -C $@
+
+win32:
 	$(MAKE) -C $@
 
 src/edge.o: $(N2N_DEPS)

--- a/Makefile.in
+++ b/Makefile.in
@@ -96,7 +96,7 @@ DOCS=edge.8.gz supernode.1.gz n2n.7.gz
 SUBDIRS+=tools
 
 .PHONY: $(SUBDIRS)
-.PHONY: steps build push all clean install est cover gcov build-dep
+.PHONY: steps build push all clean install test cover gcov build-dep
 all: $(APPS) $(DOCS) $(SUBDIRS)
 
 tools: $(N2N_LIB)

--- a/Makefile.in
+++ b/Makefile.in
@@ -33,6 +33,12 @@ INSTALL=install
 MKDIR=mkdir -p
 OS := $(shell uname -o)
 
+ifndef OS
+# This could happen if the Makefile is unable to run "uname", which can
+# happen if the shell has a bad path (or is the wrong shell)
+$(error Could not determine the OS, cannot continue)
+endif
+
 INSTALL_PROG=$(INSTALL) -m755
 INSTALL_DOC=$(INSTALL) -m644
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -31,12 +31,20 @@ CFLAGS+=$(DEBUG) $(OPTIMIZATION) $(WARN) $(OPTIONS) $(PLATOPTS)
 
 INSTALL=install
 MKDIR=mkdir -p
+
 OS := $(shell uname -s)
+
+export MINGW
+MINGW?=0
 
 ifndef OS
 # This could happen if the Makefile is unable to run "uname", which can
 # happen if the shell has a bad path (or is the wrong shell)
 $(error Could not determine the OS, cannot continue)
+endif
+
+ifeq ($(shell uname -o),Msys)
+MINGW=1
 endif
 
 INSTALL_PROG=$(INSTALL) -m755
@@ -69,8 +77,8 @@ ifeq ($(shell uname), SunOS)
 LDLIBS+=-lsocket -lnsl
 endif
 
-ifeq ($(findstring MSYS_NT,$(OS)),MSYS_NT)
-CFLAGS+=-I. -I./win32
+ifeq ($(MINGW),1)
+CFLAGS+=-I. -I./win32 -DWIN32
 LDLIBS+=$(abspath win32/n2n_win32.a)
 LDLIBS+=-lws2_32 -liphlpapi
 N2N_DEPS+=win32/n2n_win32.a

--- a/Makefile.in
+++ b/Makefile.in
@@ -29,31 +29,47 @@ endif
 WARN=-Wall
 CFLAGS+=$(DEBUG) $(OPTIMIZATION) $(WARN) $(OPTIONS) $(PLATOPTS)
 
-INSTALL=install
-MKDIR=mkdir -p
-
-OS := $(shell uname -s)
-
-export MINGW
-MINGW?=0
-
-ifndef OS
+# Quick sanity check on our build environment
+UNAME_S := $(shell uname -s)
+ifndef UNAME_S
 # This could happen if the Makefile is unable to run "uname", which can
 # happen if the shell has a bad path (or is the wrong shell)
-$(error Could not determine the OS, cannot continue)
+$(error Could not run uname command, cannot continue)
 endif
 
+# Any compile environment that needs different flags, libraries, includes or
+# other settings will get its own CONFIG_TARGET value.  For cross compiling,
+# this might be set externally to the Makefile, but if not set we try to
+# set a reasonable default.
+
+export CONFIG_TARGET
+ifndef CONFIG_TARGET
 ifeq ($(shell uname -o),Msys)
-MINGW=1
+CONFIG_TARGET=mingw
+else ifeq ($(shell uname -s),Darwin)
+CONFIG_TARGET=darwin
+else ifeq ($(shell uname), SunOS)
+CONFIG_TARGET=sunos
+else
+CONFIG_TARGET=generic
+endif
 endif
 
+export MKDIR
+export INSTALL
+export INSTALL_PROG
+export INSTALL_DOC
+export PREFIX
+export SBINDIR
+
+MKDIR=mkdir -p
+INSTALL=install
 INSTALL_PROG=$(INSTALL) -m755
 INSTALL_DOC=$(INSTALL) -m644
 
 # DESTDIR set in debian make system
 PREFIX?=$(DESTDIR)/usr
-#BINDIR=$(PREFIX)/bin
-ifeq ($(OS),Darwin)
+ifeq ($(CONFIG_TARGET),darwin)
 SBINDIR=$(PREFIX)/local/sbin
 else
 SBINDIR=$(PREFIX)/sbin
@@ -73,11 +89,11 @@ LDLIBS+=-ln2n
 LDLIBS+=@N2N_LIBS@
 
 #For OpenSolaris (Solaris too?)
-ifeq ($(shell uname), SunOS)
+ifeq ($(CONFIG_TARGET), sunos)
 LDLIBS+=-lsocket -lnsl
 endif
 
-ifeq ($(MINGW),1)
+ifeq ($(CONFIG_TARGET),mingw)
 CFLAGS+=-I. -I./win32 -DWIN32
 LDLIBS+=$(abspath win32/n2n_win32.a)
 LDLIBS+=-lws2_32 -liphlpapi
@@ -151,10 +167,12 @@ gcov:
 # This is the superset of all packages that might be needed.
 # It is a convinent target to use during development or from a CI/CD system
 build-dep:
-ifeq ($(OS),Linux)
+ifeq ($(CONFIG_TARGET),generic)
 	sudo apt install build-essential autoconf libcap-dev libzstd-dev gcovr
+else ifeq ($(CONFIG_TARGET),darwin)
+	brew install automake gcovr
 else
-	echo Not attempting to install dependancies for non dpkg system $(OS)
+	echo Not attempting to install dependancies for system $(CONFIG_TARGET)
 endif
 
 clean:

--- a/Makefile.in
+++ b/Makefile.in
@@ -65,7 +65,7 @@ endif
 
 ifeq ($(OS),Msys)
 CFLAGS+=-I. -I./win32
-LDLIBS+=-lws2_32 -liphlpapi win32/n2n_win32.a
+LDLIBS+=win32/n2n_win32.a -lws2_32 -liphlpapi
 N2N_DEPS+=win32/n2n_win32.a
 SUBDIRS+=win32
 endif

--- a/Makefile.in
+++ b/Makefile.in
@@ -125,7 +125,7 @@ build-dep:
 ifeq ($(OS),Linux)
 	sudo apt install build-essential autoconf libcap-dev libzstd-dev gcovr
 else
-	echo Not attempting to handle build dependancies for non dpkg systems
+	echo Not attempting to install dependancies for non dpkg system $(OS)
 endif
 
 clean:

--- a/Makefile.in
+++ b/Makefile.in
@@ -65,7 +65,8 @@ endif
 
 ifeq ($(OS),Msys)
 CFLAGS+=-I. -I./win32
-LDLIBS+=win32/n2n_win32.a -lws2_32 -liphlpapi
+LDLIBS+=$(abspath win32/n2n_win32.a)
+LDLIBS+=-lws2_32 -liphlpapi
 N2N_DEPS+=win32/n2n_win32.a
 SUBDIRS+=win32
 endif

--- a/Makefile.in
+++ b/Makefile.in
@@ -13,6 +13,9 @@ AR=@AR@
 #(thanks to Robert Gibbon)
 PLATOPTS_SPARC64=-mcpu=ultrasparc -pipe -fomit-frame-pointer -ffast-math -finline-functions -fweb -frename-registers -mapp-regs
 
+export CFLAGS
+export LDFLAGS
+
 CFLAGS=@CFLAGS@ -I ./include
 LDFLAGS=@LDFLAGS@ -L .
 
@@ -49,6 +52,7 @@ N2N_LIB=libn2n.a
 N2N_OBJS=$(patsubst src/%.c, src/%.o, $(wildcard src/*.c))
 N2N_DEPS=$(wildcard include/*.h) $(wildcard src/*.c) Makefile
 
+export LDLIBS
 LDLIBS+=-ln2n
 LDLIBS+=@N2N_LIBS@
 
@@ -65,10 +69,13 @@ APPS+=example_sn_embed
 
 DOCS=edge.8.gz supernode.1.gz n2n.7.gz
 
-.PHONY: steps build push all clean install tools test cover gcov build-dep
-all: $(APPS) $(DOCS) tools
+SUBDIRS+=tools
 
-tools: $(N2N_LIB)
+.PHONY: $(SUBDIRS)
+.PHONY: steps build push all clean install est cover gcov build-dep
+all: $(APPS) $(DOCS) $(SUBDIRS)
+
+$(SUBDIRS): $(N2N_LIB)
 	$(MAKE) -C $@
 
 src/edge.o: $(N2N_DEPS)

--- a/Makefile.in
+++ b/Makefile.in
@@ -13,7 +13,6 @@ AR=@AR@
 #(thanks to Robert Gibbon)
 PLATOPTS_SPARC64=-mcpu=ultrasparc -pipe -fomit-frame-pointer -ffast-math -finline-functions -fweb -frename-registers -mapp-regs
 
-N2N_OBJS_OPT=
 CFLAGS=@CFLAGS@ -I ./include
 LDFLAGS=@LDFLAGS@ -L .
 

--- a/configure.seed
+++ b/configure.seed
@@ -13,8 +13,13 @@ else
 GIT_RELEASE=${N2N_VERSION_SHORT}
 fi
 
-CC=gcc
-AR=ar
+if test "${CC+set}" != set; then
+    CC=gcc
+fi
+if test "${AR+set}" != set; then
+    AR=ar
+fi
+
 N2N_LIBS=
 
 AC_PROG_CC

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -80,6 +80,26 @@ Here is an example `edge.conf` file:
 -c=mycommunity
 -k=mysecretpass
 
+## Windows make and mingw
+
+This will produce a broken n2n build, but may be useful for testing and fixing this brokenness
+
+- Start with a fresh install of Windows 10 Pro with all patches applied as of 2021-09-29
+- Install Chocolatey (Following instructions on https://chocolatey.org/install)
+- from an admin cmd prompt
+    - choco install git mingw make
+- Start, Run, "bash"
+    - git clone https://github.com/hamishcoleman/n2n
+    - cd n2n
+    - git checkout test_platforms
+    - ./scripts/hack_fakeautoconf
+    - make
+    - make test
+
+The final make test will clearly show that there are errors in the calculated results
+from all the transform functions.
+
+
 # supernode IP address
 -l=1.2.3.4:5678
 

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -88,7 +88,7 @@ This will produce a broken n2n build, but may be useful for testing and fixing t
 - Install Chocolatey (Following instructions on https://chocolatey.org/install)
 - from an admin cmd prompt
     - choco install git mingw make
-- Start, Run, "bash"
+- All the remaining commands need be run from inside a bash shell (Either Start, Run, "bash" or "C:\Program Files\Git\usr\bin\bash")
     - git clone https://github.com/hamishcoleman/n2n
     - cd n2n
     - git checkout test_platform_mingw

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -100,13 +100,13 @@ See `edge.exe --help` and `supernode.exe --help` for a full list of supported op
 
 # Build on Windows (MinGW)
 
-These steps were test on a fresh install of Windows 10 Pro with all patches
+These steps were tested on a fresh install of Windows 10 Pro with all patches
 applied as of 2021-09-29.
 
 - Install Chocolatey (Following instructions on https://chocolatey.org/install)
 - from an admin cmd prompt
     - choco install git mingw make
-- All the remaining commands need be run from inside a bash shell ("C:\Program Files\Git\usr\bin\bash.exe")
+- All the remaining commands must be run from inside a bash shell ("C:\Program Files\Git\usr\bin\bash.exe")
     - git clone $THIS_REPO
     - cd n2n
     - ./scripts/hack_fakeautoconf

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -91,7 +91,7 @@ This will produce a broken n2n build, but may be useful for testing and fixing t
 - Start, Run, "bash"
     - git clone https://github.com/hamishcoleman/n2n
     - cd n2n
-    - git checkout test_platforms
+    - git checkout test_platform_mingw
     - ./scripts/hack_fakeautoconf
     - make
     - make test

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -113,6 +113,9 @@ applied as of 2021-09-29.
     - make
     - make test
 
+Due to the hack used to replace autotools on windows, any build created this
+way will currently have inaccurate build version numbers.
+
 Note: MinGW builds have a history of incompatibility reports with other OS
 builds, please see [#617](https://github.com/ntop/n2n/issues/617) and [#642](https://github.com/ntop/n2n/issues/642).
 However, if the tests pass, you should have a high confidence that your build

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -12,7 +12,7 @@ If you are on a modern version of macOS (i.e. Catalina), the commands above will
 For more information refer to vendor documentation or the [Apple Technical Note](https://developer.apple.com/library/content/technotes/tn2459/_index.html).
 
 
-# Build on Windows
+# Build on Windows (Visual Studio)
 
 ## Requirements
 
@@ -46,8 +46,9 @@ In order to run n2n, you will need the following:
 - If OpenSSL has been linked dynamically, the corresponding `.dll` file should be available
   onto the target computer.
   
-NOTE: Sticking to this tool chain ensures that resulting executables are able to communicate with Linux or other OS builds.
-Especialy MinGW builds are reported to not be compatible to other OS builds, please see [#617](https://github.com/ntop/n2n/issues/617) and [#642](https://github.com/ntop/n2n/issues/642).
+NOTE: Sticking to this tool chain has historically meant that resulting
+executables are more likely to be able to communicate with Linux or other
+OS builds, however efforts are being made to address this concern.
 
 ## Build (CLI)
 
@@ -80,26 +81,6 @@ Here is an example `edge.conf` file:
 -c=mycommunity
 -k=mysecretpass
 
-## Windows make and mingw
-
-This will produce a broken n2n build, but may be useful for testing and fixing this brokenness
-
-- Start with a fresh install of Windows 10 Pro with all patches applied as of 2021-09-29
-- Install Chocolatey (Following instructions on https://chocolatey.org/install)
-- from an admin cmd prompt
-    - choco install git mingw make
-- All the remaining commands need be run from inside a bash shell (Either Start, Run, "bash" or "C:\Program Files\Git\usr\bin\bash")
-    - git clone https://github.com/hamishcoleman/n2n
-    - cd n2n
-    - git checkout test_platform_mingw
-    - ./scripts/hack_fakeautoconf
-    - make
-    - make test
-
-The final make test will clearly show that there are errors in the calculated results
-from all the transform functions.
-
-
 # supernode IP address
 -l=1.2.3.4:5678
 
@@ -116,6 +97,26 @@ Here is an example `supernode.conf` file:
 ```
 
 See `edge.exe --help` and `supernode.exe --help` for a full list of supported options.
+
+# Build on Windows (MinGW)
+
+These steps were test on a fresh install of Windows 10 Pro with all patches
+applied as of 2021-09-29.
+
+- Install Chocolatey (Following instructions on https://chocolatey.org/install)
+- from an admin cmd prompt
+    - choco install git mingw make
+- All the remaining commands need be run from inside a bash shell ("C:\Program Files\Git\usr\bin\bash.exe")
+    - git clone $THIS_REPO
+    - cd n2n
+    - ./scripts/hack_fakeautoconf
+    - make
+    - make test
+
+Note: MinGW builds have a history of incompatibility reports with other OS
+builds, please see [#617](https://github.com/ntop/n2n/issues/617) and [#642](https://github.com/ntop/n2n/issues/642).
+However, if the tests pass, you should have a high confidence that your build
+will be compatible.
 
 # General Building Options
 

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -41,7 +41,7 @@
 #ifndef CMAKE_BUILD
 #include "config.h" /* Visual C++ */
 #else
-#include "win32/winconfig.h"
+#include "winconfig.h"
 #endif
 #define N2N_CAN_NAME_IFACE 1
 #undef N2N_HAVE_DAEMON
@@ -137,7 +137,7 @@
 #ifdef WIN32
 #include <winsock2.h>           /* for tcp */
 #define SHUT_RDWR   SD_BOTH     /* for tcp */
-#include "win32/wintap.h"
+#include "wintap.h"
 #include <sys/stat.h>
 #else
 #include <pwd.h>

--- a/include/n2n_wire.h
+++ b/include/n2n_wire.h
@@ -26,7 +26,7 @@
 #endif
 
 #if defined(WIN32)
-#include "win32/n2n_win32.h"
+#include "n2n_win32.h"
 #else /* #if defined(WIN32) */
 #include <netinet/in.h>
 #include <sys/socket.h> /* AF_INET and AF_INET6 */

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -4,7 +4,7 @@
 # like boiling the ocean.
 
 if [ "$RUNNER_OS" = "Windows" ]; then
-    CFLAGS="$CFLAGS -I . -I ./win32"
+    CFLAGS="$CFLAGS -I $(pwd)/. -I $(pwd)/win32"
 fi
 
 cat Makefile.in | sed \

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -5,6 +5,7 @@
 
 if [ "$RUNNER_OS" = "Windows" ]; then
     CFLAGS="$CFLAGS -I. -I./win32"
+    LDFLAGS="$LDFLAGS -lws2_32"
 fi
 
 cat Makefile.in | sed \
@@ -19,6 +20,7 @@ cat Makefile.in | sed \
 
 if [ "$RUNNER_OS" = "Windows" ]; then
     CFLAGS="$CFLAGS -I.. -I../win32"
+    #LDFLAGS inherited from above
 fi
 
 cat tools/Makefile.in | sed \

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -3,7 +3,8 @@
 # Specifically for windows, where installing autoconf looks suspiciously
 # like boiling the ocean.
 
-if [ "$RUNNER_OS" = "Windows" ]; then
+OS=$(uname -o)
+if [ "$OS" = "Msys" ]; then
     CFLAGS="$CFLAGS -I. -I./win32"
     LDLIBS="$LDLIBS -lws2_32 -liphlpapi"
 fi

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# Specifically for windows, where installing autoconf looks suspiciously
+# like boiling the ocean.
+
+
+cat Makefile.in | sed \
+    -e "s/@N2N_VERSION_SHORT@/FIXME/g" \
+    -e "s/@GIT_COMMITS@/FIXME/g" \
+    -e "s/@CC@/gcc/g" \
+    -e "s/@AR@/ar/g" \
+    -e "s/@CFLAGS@/$CFLAGS/g" \
+    -e "s/@LDFLAGS@/$LDFLAGS/g" \
+    -e "s/@N2N_LIBS@//g" \
+    > Makefile
+
+cat tools/Makefile.in | sed \
+    -e "s/@CC@/gcc/g" \
+    -e "s/@N2N_LIBS@//g" \
+    -e "s/@CFLAGS@/$CFLAGS/g" \
+    -e "s/@LDFLAGS@/$LDFLAGS/g" \
+    -e "s/@ADDITIONAL_TOOLS@//g" \
+    > tools/Makefile
+
+cat <<EOF >include/config.h
+#define PACKAGE_VERSION "FIXME"
+#define PACKAGE_OSNAME "FIXME"
+#define GIT_RELEASE "FIXME"
+EOF

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -19,16 +19,8 @@ cat Makefile.in | sed \
     -e "s%@N2N_LIBS@%$LDLIBS%g" \
     > Makefile
 
-if [ "$RUNNER_OS" = "Windows" ]; then
-    CFLAGS="$CFLAGS -I.. -I../win32"
-    #LDLIBS inherited from above
-fi
-
 cat tools/Makefile.in | sed \
     -e "s%@CC@%gcc%g" \
-    -e "s%@N2N_LIBS@%$LDLIBS%g" \
-    -e "s%@CFLAGS@%$CFLAGS%g" \
-    -e "s%@LDFLAGS@%$LDFLAGS%g" \
     -e "s%@ADDITIONAL_TOOLS@%%g" \
     > tools/Makefile
 

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -3,12 +3,6 @@
 # Specifically for windows, where installing autoconf looks suspiciously
 # like boiling the ocean.
 
-OS=$(uname -o)
-if [ "$OS" = "Msys" ]; then
-    CFLAGS="$CFLAGS -I. -I./win32"
-    LDLIBS="$LDLIBS -lws2_32 -liphlpapi"
-fi
-
 cat Makefile.in | sed \
     -e "s%@N2N_VERSION_SHORT@%FIXME%g" \
     -e "s%@GIT_COMMITS@%FIXME%g" \
@@ -20,7 +14,6 @@ cat Makefile.in | sed \
     > Makefile
 
 cat tools/Makefile.in | sed \
-    -e "s%@CC@%gcc%g" \
     -e "s%@ADDITIONAL_TOOLS@%%g" \
     > tools/Makefile
 

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -4,7 +4,7 @@
 # like boiling the ocean.
 
 if [ "$RUNNER_OS" == "Windows" ]; then
-    CFLAGS="$CFLAGS -I win32"
+    CFLAGS="$CFLAGS -I . -I ./win32"
 fi
 
 cat Makefile.in | sed \

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -3,7 +3,7 @@
 # Specifically for windows, where installing autoconf looks suspiciously
 # like boiling the ocean.
 
-if [ "$RUNNER_OS" == "Windows" ]; then
+if [ "$RUNNER_OS" = "Windows" ]; then
     CFLAGS="$CFLAGS -I . -I ./win32"
 fi
 
@@ -17,7 +17,7 @@ cat Makefile.in | sed \
     -e "s%@N2N_LIBS@%%g" \
     > Makefile
 
-cat tools%Makefile.in | sed \
+cat tools/Makefile.in | sed \
     -e "s%@CC@%gcc%g" \
     -e "s%@N2N_LIBS@%%g" \
     -e "s%@CFLAGS@%$CFLAGS%g" \

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -5,7 +5,7 @@
 
 if [ "$RUNNER_OS" = "Windows" ]; then
     CFLAGS="$CFLAGS -I. -I./win32"
-    LDFLAGS="$LDFLAGS -lws2_32"
+    LDLIBS="$LDLIBS -lws2_32"
 fi
 
 cat Makefile.in | sed \
@@ -15,17 +15,17 @@ cat Makefile.in | sed \
     -e "s%@AR@%ar%g" \
     -e "s%@CFLAGS@%$CFLAGS%g" \
     -e "s%@LDFLAGS@%$LDFLAGS%g" \
-    -e "s%@N2N_LIBS@%%g" \
+    -e "s%@N2N_LIBS@%$LDLIBS%g" \
     > Makefile
 
 if [ "$RUNNER_OS" = "Windows" ]; then
     CFLAGS="$CFLAGS -I.. -I../win32"
-    #LDFLAGS inherited from above
+    #LDLIBS inherited from above
 fi
 
 cat tools/Makefile.in | sed \
     -e "s%@CC@%gcc%g" \
-    -e "s%@N2N_LIBS@%%g" \
+    -e "s%@N2N_LIBS@%$LDLIBS%g" \
     -e "s%@CFLAGS@%$CFLAGS%g" \
     -e "s%@LDFLAGS@%$LDFLAGS%g" \
     -e "s%@ADDITIONAL_TOOLS@%%g" \

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -8,21 +8,21 @@ if [ "$RUNNER_OS" == "Windows" ]; then
 fi
 
 cat Makefile.in | sed \
-    -e "s/@N2N_VERSION_SHORT@/FIXME/g" \
-    -e "s/@GIT_COMMITS@/FIXME/g" \
-    -e "s/@CC@/gcc/g" \
-    -e "s/@AR@/ar/g" \
-    -e "s/@CFLAGS@/$CFLAGS/g" \
-    -e "s/@LDFLAGS@/$LDFLAGS/g" \
-    -e "s/@N2N_LIBS@//g" \
+    -e "s%@N2N_VERSION_SHORT@%FIXME%g" \
+    -e "s%@GIT_COMMITS@%FIXME%g" \
+    -e "s%@CC@%gcc%g" \
+    -e "s%@AR@%ar%g" \
+    -e "s%@CFLAGS@%$CFLAGS%g" \
+    -e "s%@LDFLAGS@%$LDFLAGS%g" \
+    -e "s%@N2N_LIBS@%%g" \
     > Makefile
 
-cat tools/Makefile.in | sed \
-    -e "s/@CC@/gcc/g" \
-    -e "s/@N2N_LIBS@//g" \
-    -e "s/@CFLAGS@/$CFLAGS/g" \
-    -e "s/@LDFLAGS@/$LDFLAGS/g" \
-    -e "s/@ADDITIONAL_TOOLS@//g" \
+cat tools%Makefile.in | sed \
+    -e "s%@CC@%gcc%g" \
+    -e "s%@N2N_LIBS@%%g" \
+    -e "s%@CFLAGS@%$CFLAGS%g" \
+    -e "s%@LDFLAGS@%$LDFLAGS%g" \
+    -e "s%@ADDITIONAL_TOOLS@%%g" \
     > tools/Makefile
 
 cat <<EOF >include/config.h

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -3,6 +3,9 @@
 # Specifically for windows, where installing autoconf looks suspiciously
 # like boiling the ocean.
 
+if [ "$RUNNER_OS" == "Windows" ]; then
+    CFLAGS="$CFLAGS -I win32"
+fi
 
 cat Makefile.in | sed \
     -e "s/@N2N_VERSION_SHORT@/FIXME/g" \

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -5,7 +5,7 @@
 
 if [ "$RUNNER_OS" = "Windows" ]; then
     CFLAGS="$CFLAGS -I. -I./win32"
-    LDLIBS="$LDLIBS -lws2_32"
+    LDLIBS="$LDLIBS -lws2_32 -liphlpapi"
 fi
 
 cat Makefile.in | sed \

--- a/scripts/hack_fakeautoconf
+++ b/scripts/hack_fakeautoconf
@@ -4,7 +4,7 @@
 # like boiling the ocean.
 
 if [ "$RUNNER_OS" = "Windows" ]; then
-    CFLAGS="$CFLAGS -I $(pwd)/. -I $(pwd)/win32"
+    CFLAGS="$CFLAGS -I. -I./win32"
 fi
 
 cat Makefile.in | sed \
@@ -16,6 +16,10 @@ cat Makefile.in | sed \
     -e "s%@LDFLAGS@%$LDFLAGS%g" \
     -e "s%@N2N_LIBS@%%g" \
     > Makefile
+
+if [ "$RUNNER_OS" = "Windows" ]; then
+    CFLAGS="$CFLAGS -I.. -I../win32"
+fi
 
 cat tools/Makefile.in | sed \
     -e "s%@CC@%gcc%g" \

--- a/src/edge.c
+++ b/src/edge.c
@@ -869,8 +869,8 @@ static int loadFromFile (const char *path, n2n_edge_conf_t *conf, n2n_tuntap_pri
 
 /* ************************************** */
 
-static void daemonize () {
 #ifndef WIN32
+static void daemonize () {
     int childpid;
 
     traceEvent(TRACE_NORMAL, "parent process is exiting (this is normal)");
@@ -911,8 +911,8 @@ static void daemonize () {
         } else /* father */
             exit(0);
     }
-#endif
 }
+#endif
 
 /* *************************************************** */
 
@@ -1258,9 +1258,6 @@ int main (int argc, char* argv[]) {
         setUseSyslog(1); /* traceEvent output now goes to syslog. */
         daemonize();
     }
-#endif /* #ifndef WIN32 */
-
-#ifndef WIN32
 
 #ifdef HAVE_LIBCAP
     /* Before dropping the privileges, retain capabilities to regain them in future. */

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -477,7 +477,7 @@ static ssize_t sendto_fd (n2n_sn_t *sss,
     ssize_t sent = 0;
     n2n_tcp_connection_t *conn;
 
-    sent = sendto(socket_fd, pktbuf, pktsize, 0 /* flags */,
+    sent = sendto(socket_fd, (void *)pktbuf, pktsize, 0 /* flags */,
                   socket, sizeof(struct sockaddr_in));
 
     if((sent <= 0) && (errno)) {
@@ -1634,7 +1634,7 @@ static int sendto_mgmt (n2n_sn_t *sss,
                         const uint8_t *mgmt_buf,
                         size_t mgmt_size) {
 
-    ssize_t r = sendto(sss->mgmt_sock, mgmt_buf, mgmt_size, 0 /*flags*/,
+    ssize_t r = sendto(sss->mgmt_sock, (void *)mgmt_buf, mgmt_size, 0 /*flags*/,
                        (struct sockaddr *)sender_sock, sizeof (struct sockaddr_in));
 
     if(r <= 0) {
@@ -2706,8 +2706,10 @@ int run_sn_loop (n2n_sn_t *sss, int *keep_running) {
         fd_set socket_mask;
         n2n_tcp_connection_t *conn, *tmp_conn;
 
+#ifdef N2N_HAVE_TCP
         SOCKET tmp_sock;
         n2n_sock_str_t sockbuf;
+#endif
         struct timeval wait_time;
         time_t before, now = 0;
 
@@ -2748,7 +2750,7 @@ int run_sn_loop (n2n_sn_t *sss, int *keep_running) {
                 socklen_t i;
 
                 i = sizeof(sender_sock);
-                bread = recvfrom(sss->sock, pktbuf, N2N_SN_PKTBUF_SIZE, 0 /*flags*/,
+                bread = recvfrom(sss->sock, (void *)pktbuf, N2N_SN_PKTBUF_SIZE, 0 /*flags*/,
                                  (struct sockaddr *)&sender_sock, (socklen_t *)&i);
 
                 if((bread < 0)
@@ -2873,7 +2875,7 @@ int run_sn_loop (n2n_sn_t *sss, int *keep_running) {
                 size_t i;
 
                 i = sizeof(sender_sock);
-                bread = recvfrom(sss->mgmt_sock, pktbuf, N2N_SN_PKTBUF_SIZE, 0 /*flags*/,
+                bread = recvfrom(sss->mgmt_sock, (void *)pktbuf, N2N_SN_PKTBUF_SIZE, 0 /*flags*/,
                                  (struct sockaddr *)&sender_sock, (socklen_t *)&i);
 
                 if(bread <= 0) {

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -1,4 +1,3 @@
-CC=@CC@
 DEBUG?=-g3
 
 OS:=$(shell uname -o)

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -1,7 +1,5 @@
 DEBUG?=-g3
 
-OS:=$(shell uname -o)
-
 INSTALL=install
 INSTALL_PROG=$(INSTALL) -m755
 MKDIR=mkdir -p
@@ -15,7 +13,7 @@ endif
 
 HEADERS=$(wildcard include/*.h)
 CFLAGS+=-I../include
-ifeq ($(findstring MSYS_NT,$(OS)),MSYS_NT)
+ifeq ($(MINGW),1)
 CFLAGS+=-I../win32 -I../
 endif
 CFLAGS+=$(DEBUG)

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -1,3 +1,7 @@
+#
+# This is not a standalone makefile, it must be called from the toplevel
+# makefile to inherit the correct environment
+
 DEBUG?=-g3
 
 INSTALL=install
@@ -14,7 +18,7 @@ endif
 HEADERS=$(wildcard include/*.h)
 CFLAGS+=-I../include
 ifeq ($(MINGW),1)
-CFLAGS+=-I../win32 -I../
+CFLAGS+=-I../win32
 endif
 CFLAGS+=$(DEBUG)
 LDFLAGS+=-L..

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -1,7 +1,5 @@
 CC=@CC@
 DEBUG?=-g3
-OPTIMIZATION?=-O2 #-march=native
-WARN?=-Wall
 
 INSTALL=install
 INSTALL_PROG=$(INSTALL) -m755
@@ -14,13 +12,10 @@ else
 SBINDIR=$(PREFIX)/sbin
 endif
 
-LDLIBS+=-ln2n
-LDLIBS+=@N2N_LIBS@
 HEADERS=$(wildcard include/*.h)
-CFLAGS+=-I../include @CFLAGS@
+CFLAGS+=-I../include
 LDFLAGS+=-L..
-CFLAGS+=$(DEBUG) $(OPTIMIZATION) $(WARN)
-LDFLAGS+=@LDFLAGS@
+CFLAGS+=$(DEBUG)
 
 N2N_LIB=../libn2n.a
 

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -16,7 +16,7 @@ endif
 HEADERS=$(wildcard include/*.h)
 CFLAGS+=-I../include
 ifeq ($(OS),Msys)
-CFLAGS+=-I../win32
+CFLAGS+=-I../win32 -I../
 endif
 CFLAGS+=$(DEBUG)
 LDFLAGS+=-L..

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -15,7 +15,7 @@ endif
 
 HEADERS=$(wildcard include/*.h)
 CFLAGS+=-I../include
-ifeq ($(OS),Msys)
+ifeq ($(findstring MSYS_NT,$(OS)),MSYS_NT)
 CFLAGS+=-I../win32 -I../
 endif
 CFLAGS+=$(DEBUG)

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -1,6 +1,8 @@
 CC=@CC@
 DEBUG?=-g3
 
+OS:=$(shell uname -o)
+
 INSTALL=install
 INSTALL_PROG=$(INSTALL) -m755
 MKDIR=mkdir -p
@@ -14,8 +16,11 @@ endif
 
 HEADERS=$(wildcard include/*.h)
 CFLAGS+=-I../include
-LDFLAGS+=-L..
+ifeq ($(OS),Msys)
+CFLAGS+=-I../win32
+endif
 CFLAGS+=$(DEBUG)
+LDFLAGS+=-L..
 
 N2N_LIB=../libn2n.a
 

--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -4,20 +4,9 @@
 
 DEBUG?=-g3
 
-INSTALL=install
-INSTALL_PROG=$(INSTALL) -m755
-MKDIR=mkdir -p
-
-PREFIX?=$(DESTDIR)/usr
-ifeq ($(OS),Darwin)
-SBINDIR=$(PREFIX)/local/sbin
-else
-SBINDIR=$(PREFIX)/sbin
-endif
-
 HEADERS=$(wildcard include/*.h)
 CFLAGS+=-I../include
-ifeq ($(MINGW),1)
+ifeq ($(CONFIG_TARGET),mingw)
 CFLAGS+=-I../win32
 endif
 CFLAGS+=$(DEBUG)

--- a/tools/n2n-benchmark.c
+++ b/tools/n2n-benchmark.c
@@ -16,7 +16,11 @@
  *
  */
 
+#ifndef _MSC_VER
+/* MinGW has undefined function gettimeofday() warnings without this header
+ * but Visual C++ doesnt even have the header */
 #include <sys/time.h>
+#endif
 
 #include "n2n.h"
 

--- a/tools/n2n-benchmark.c
+++ b/tools/n2n-benchmark.c
@@ -16,6 +16,8 @@
  *
  */
 
+#include <sys/time.h>
+
 #include "n2n.h"
 
 #define DURATION                2.5   // test duration per algorithm

--- a/tools/tests-compress.c
+++ b/tools/tests-compress.c
@@ -16,6 +16,8 @@
  *
  */
 
+#include <inttypes.h>
+
 #include <assert.h>
 
 #include "n2n.h"
@@ -78,7 +80,7 @@ void test_lzo1x() {
 
     assert(compression_len == 47);
 
-    printf("%s: output size = 0x%lx\n", test_name, compression_len);
+    printf("%s: output size = 0x%"PRIx64"\n", test_name, compression_len);
     fhexdump(0, compression_buffer, compression_len, stdout);
 
     uint8_t deflation_buffer[N2N_PKT_BUF_SIZE];
@@ -111,7 +113,7 @@ void test_zstd() {
 
     assert(compression_len == 33);
     
-    printf("%s: output size = 0x%lx\n", test_name, compression_len);
+    printf("%s: output size = 0x%"PRIx64"\n", test_name, compression_len);
     fhexdump(0, compression_buffer, compression_len, stdout);
 
     uint8_t deflation_buffer[N2N_PKT_BUF_SIZE];
@@ -148,7 +150,7 @@ int main(int argc, char * argv[]) {
     /* Also for compression (init moved here for ciphers get run before in case of lzo init error) */
     init_compression_for_benchmark();
 
-    printf("%s: input size = 0x%lx\n", "original", sizeof(PKT_CONTENT));
+    printf("%s: input size = 0x%"PRIx64"\n", "original", sizeof(PKT_CONTENT));
     fhexdump(0, PKT_CONTENT, sizeof(PKT_CONTENT), stdout);
     printf("\n");
 

--- a/tools/tests-hashing.c
+++ b/tools/tests-hashing.c
@@ -16,6 +16,8 @@
  *
  */
 
+#include <inttypes.h>
+
 #include "n2n.h"
 #include "hexdump.h"
 
@@ -43,7 +45,7 @@ void test_pearson(void *buf, unsigned int bufsize) {
 
     uint64_t hash = pearson_hash_64(buf, bufsize);
 
-    printf("%s: output = 0x%lx\n", test_name, hash);
+    printf("%s: output = 0x%"PRIx64"\n", test_name, hash);
 
     fprintf(stderr, "%s: tested\n", test_name);
     printf("\n");

--- a/tools/tests-hashing.c
+++ b/tools/tests-hashing.c
@@ -55,7 +55,7 @@ int main(int argc, char * argv[]) {
     pearson_hash_init();
 
     char *test_name = "environment";
-    printf("%s: input size = 0x%lx\n", test_name, sizeof(PKT_CONTENT));
+    printf("%s: input size = 0x%"PRIx64"\n", test_name, sizeof(PKT_CONTENT));
     fhexdump(0, PKT_CONTENT, sizeof(PKT_CONTENT), stdout);
     printf("\n");
 

--- a/tools/tests-transform.c
+++ b/tools/tests-transform.c
@@ -16,6 +16,8 @@
  *
  */
 
+#include <inttypes.h>
+
 #include "n2n.h"
 #include "hexdump.h"
 
@@ -63,7 +65,7 @@ int main(int argc, char * argv[]) {
     char *test_name = "environment";
     printf("%s: community_name = \"%s\"\n", test_name, conf.community_name);
     printf("%s: encrypt_key = \"%s\"\n", test_name, conf.encrypt_key);
-    printf("%s: input size = 0x%lx\n", test_name, sizeof(PKT_CONTENT));
+    printf("%s: input size = 0x%"PRIx64"\n", test_name, sizeof(PKT_CONTENT));
     fhexdump(0, PKT_CONTENT, sizeof(PKT_CONTENT), stdout);
     printf("\n");
 
@@ -111,7 +113,7 @@ static void run_transop_benchmark(const char *op_name, n2n_trans_op_t *op_fn, n2
         pktbuf+nw, N2N_PKT_BUF_SIZE-nw,
         PKT_CONTENT, sizeof(PKT_CONTENT), mac_buf);
     
-    printf("%s: output size = 0x%lx\n", op_name, nw);
+    printf("%s: output size = 0x%"PRIx64"\n", op_name, nw);
     fhexdump(0, pktbuf, nw, stdout);
 
     // decrpytion

--- a/tools/tests-wire.c
+++ b/tools/tests-wire.c
@@ -16,6 +16,8 @@
  *
  */
 
+#include <inttypes.h>
+
 #include "n2n.h"
 #include "hexdump.h"
 
@@ -47,8 +49,8 @@ void test_REGISTER(n2n_common_t *common) {
     size_t idx = 0;
     size_t retval = encode_REGISTER( pktbuf, &idx, common, &reg);
 
-    printf("%s: output retval = 0x%lx\n", test_name, retval);
-    printf("%s: output idx = 0x%lx\n", test_name, idx);
+    printf("%s: output retval = 0x%"PRIx64"\n", test_name, retval);
+    printf("%s: output idx = 0x%"PRIx64"\n", test_name, idx);
     fhexdump(0, pktbuf, idx, stdout);
 
     // TODO: decode_REGISTER() and print

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1,9 +1,12 @@
+#
+# This is not a standalone makefile, it must be called from the toplevel
+# makefile to inherit the correct environment
 
 CFLAGS+=-I../include
-CFLAGS+=-I../
 LDFLAGS+=-L..
 
 .PHONY: all clean install
+
 all: n2n_win32.a
 
 n2n_win32.a: getopt1.o getopt.o wintap.o

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1,0 +1,16 @@
+
+CFLAGS+=-I../include
+CFLAGS+=-I../
+LDFLAGS+=-L..
+
+.PHONY: all clean install
+all: n2n_win32.a
+
+n2n_win32.a: getopt1.o getopt.o wintap.o
+	$(AR) rcs $@ $+
+
+clean:
+	rm -rf n2n_win32.a *.o *.gcno *.gcda
+
+install:
+	true

--- a/win32/wintap.h
+++ b/win32/wintap.h
@@ -7,7 +7,9 @@
 
 #undef UNICODE
 #undef _UNICODE
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include <ws2tcpip.h>
 #include <stdio.h>


### PR DESCRIPTION
This updates the automated tests to run on windows/mingw.

Which has required a number of changes
- autoconf needed to be replaced for this build
- none of the configure options are available
- the Makefiles have been expanded and overhauled to add support for win32

Most importantly, while the build completes, the created library doesnt create the same transform output as a version built on ubuntu.  Which makes the build fail the tests.

I have also documented a simple set of steps to make the same build locally and this branch along with those instructions can be used to assist in debugging the issue with the transform.