### PR TITLE
fixed MinGW compile

### DIFF
--- a/include/portable_endian.h
+++ b/include/portable_endian.h
@@ -135,8 +135,8 @@
 #       define be32toh(x) _byteswap_ulong(x)
 #       define le32toh(x) (x)
 
-#       define htobe64(x) _byteswap_uint64(x)
-#       define be64toh(x) _byteswap_uint64(x)
+#       define htobe64(x) (((uint64_t)htonl(((uint32_t)(((uint64_t)(x)) >> 32))) & 0x00000000FFFFFFFFULL) | (((uint64_t)htonl(((uint32_t)(x)))) << 32))
+#       define be64toh(x) (((uint64_t)htonl(((uint32_t)(((uint64_t)(x)) >> 32))) & 0x00000000FFFFFFFFULL) | (((uint64_t)htonl(((uint32_t)(x)))) << 32))
 #       define htole64(x) (x)
 #       define le64toh(x) (x)
 


### PR DESCRIPTION
For yet unknown reason, `_byteswap_uint64()`  does not work as expected if compiled with MinGW. Even the replacement taken from  a few lines above (line 49) requires adjustment in terms of nulling the upper bits. As if _arithmetic_ shifting kicks in at some place (due to different typing?).