### PR TITLE
compile fix

### DIFF
--- a/src/random_numbers.c
+++ b/src/random_numbers.c
@@ -98,9 +98,9 @@ uint64_t n2n_seed (void) {
 
     uint64_t seed = 0;   /* this could even go uninitialized */
     uint64_t ret = 0;    /* this could even go uninitialized */
+    size_t i = 0;
 
 #ifdef SYS_getrandom
-    size_t i;
     int rc = -1;
     for(i = 0; (i < RND_RETRIES) && (rc != sizeof(seed)); i++) {
         rc = syscall (SYS_getrandom, &seed, sizeof(seed), GRND_NONBLOCK);


### PR DESCRIPTION
The `i` also gets used inside some other following blocks, so it should be defined within an overarching scope.