### PR TITLE
added a flag field to QUERY_PEER

### DIFF
--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -421,6 +421,7 @@ typedef struct n2n_PEER_INFO {
 
 
 typedef struct n2n_QUERY_PEER {
+    uint16_t                      aflags;
     n2n_mac_t                     srcMac;
     n2n_sock_t                    sock;
     n2n_mac_t                     targetMac;

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1148,7 +1148,7 @@ void send_query_peer (n2n_edge_t * eee,
     uint8_t pktbuf[N2N_PKT_BUF_SIZE];
     size_t idx;
     n2n_common_t cmn = {0};
-    n2n_QUERY_PEER_t query = {{0}};
+    n2n_QUERY_PEER_t query = {0};
     struct peer_info *peer, *tmp;
     int n_o_pings = 0;
     int n_o_top_sn = 0;

--- a/src/wire.c
+++ b/src/wire.c
@@ -703,6 +703,7 @@ int encode_QUERY_PEER (uint8_t * base,
     int retval = 0;
 
     retval += encode_common(base, idx, common);
+    retval += encode_uint16(base, idx, pkt->aflags);
     retval += encode_mac(base, idx, pkt->srcMac);
     retval += encode_mac(base, idx, pkt->targetMac);
 
@@ -718,6 +719,7 @@ int decode_QUERY_PEER (n2n_QUERY_PEER_t * pkt,
     size_t retval = 0;
     memset(pkt, 0, sizeof(n2n_QUERY_PEER_t));
 
+    retval += decode_uint16(&(pkt->aflags), base, rem, idx);
     retval += decode_mac(pkt->srcMac, base, rem, idx);
     retval += decode_mac(pkt->targetMac, base, rem, idx);
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -703,9 +703,9 @@ int encode_QUERY_PEER (uint8_t * base,
     int retval = 0;
 
     retval += encode_common(base, idx, common);
-    retval += encode_uint16(base, idx, pkt->aflags);
     retval += encode_mac(base, idx, pkt->srcMac);
     retval += encode_mac(base, idx, pkt->targetMac);
+    retval += encode_uint16(base, idx, pkt->aflags);
 
     return retval;
 }
@@ -719,9 +719,9 @@ int decode_QUERY_PEER (n2n_QUERY_PEER_t * pkt,
     size_t retval = 0;
     memset(pkt, 0, sizeof(n2n_QUERY_PEER_t));
 
-    retval += decode_uint16(&(pkt->aflags), base, rem, idx);
     retval += decode_mac(pkt->srcMac, base, rem, idx);
     retval += decode_mac(pkt->targetMac, base, rem, idx);
+    retval += decode_uint16(&(pkt->aflags), base, rem, idx);
 
     return retval;
 }


### PR DESCRIPTION
Last minute change to add an additional flag field to QUERY_PEER for later use (p2p enhancement signaling). To keep up compatibility, this bit-field is added at packet's end even though it seems like an unusual place for flags.