### PR TITLE
added forwarded REGISTER cookie type

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -167,6 +167,7 @@ enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 #define N2N_MAC_SIZE               6
 #define N2N_LOCAL_REG_COOKIE       0x00100000
 #define N2N_REGULAR_REG_COOKIE     0x01000000
+#define N2N_FORWARDED_REG_COOKIE   0x10000000
 #define N2N_DESC_SIZE              16
 #define N2N_PKT_BUF_SIZE           2048
 #define N2N_SOCKBUF_SIZE           64  /* string representation of INET or INET6 sockets */

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -696,7 +696,7 @@ static void register_with_new_peer (n2n_edge_t *eee,
                 /* Normal STUN */
                 send_register(eee, &(scan->sock), mac, N2N_REGULAR_REG_COOKIE);
             }
-            send_register(eee, &(eee->curr_sn->sock), mac, N2N_REGULAR_REG_COOKIE);
+            send_register(eee, &(eee->curr_sn->sock), mac, N2N_FORWARDED_REG_COOKIE);
         } else {
             /* P2P register, send directly */
             send_register(eee, &(scan->sock), mac, N2N_REGULAR_REG_COOKIE);

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2049,7 +2049,7 @@ static int check_query_peer_info (n2n_edge_t *eee, time_t now, n2n_mac_t mac) {
     }
 
     if(now - scan->last_sent_query > eee->conf.register_interval) {
-        send_register(eee, &(eee->curr_sn->sock), mac, N2N_REGULAR_REG_COOKIE);
+        send_register(eee, &(eee->curr_sn->sock), mac, N2N_FORWARDED_REG_COOKIE);
         send_query_peer(eee, scan->mac_addr);
         scan->last_sent_query = now;
         return(0);


### PR DESCRIPTION
This change helps to distinguish different paths REGISTERs took and optionally handle them differently.