### PR TITLE
fine-tuned REGISTER cookie handling

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -165,9 +165,12 @@ enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 #define N2N_PRIVATE_PUBLIC_KEY_SIZE 32
 #define N2N_USER_KEY_LINE_STARTER  '*'
 #define N2N_MAC_SIZE               6
-#define N2N_LOCAL_REG_COOKIE       0x00100000
-#define N2N_REGULAR_REG_COOKIE     0x01000000
-#define N2N_FORWARDED_REG_COOKIE   0x10000000
+#define N2N_NO_REG_COOKIE          0x00000000
+#define N2N_FORWARDED_REG_COOKIE   0x00001000
+#define N2N_PORT_REG_COOKIE        0x00004000
+#define N2N_REGULAR_REG_COOKIE     0x00010000
+#define N2N_MCAST_REG_COOKIE       0x00400000
+#define N2N_LOCAL_REG_COOKIE       0x01000000
 #define N2N_DESC_SIZE              16
 #define N2N_PKT_BUF_SIZE           2048
 #define N2N_SOCKBUF_SIZE           64  /* string representation of INET or INET6 sockets */

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -437,7 +437,6 @@ struct peer_info {
     n2n_sock_t                       sock;
     SOCKET                           socket_fd;
     n2n_sock_t                       preferred_sock;
-    time_t                           last_local_reg;
     n2n_cookie_t                     last_cookie;
     n2n_auth_t                       auth;
     int                              timeout;


### PR DESCRIPTION
... to handle them as REGISTER's 'embarkation port indicator' in a more general way