### PR TITLE
experimental

### DIFF
--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -130,6 +130,9 @@ enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 /* flag used in add_sn_to_list_by_mac_or_sock */
 enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 
+#define N2N_AFLAGS_PASS_THROUGH    1 /* indicate that QUERY_PEER is to be passed through to the edge in question      */
+                                     /* if set in PEER_INFO, it indicates the same for the corresponding QUERY_PEER   */
+
 #define N2N_NETMASK_STR_SIZE      16 /* dotted decimal 12 numbers + 3 dots */
 #define N2N_MACNAMSIZ             18 /* AA:BB:CC:DD:EE:FF + NULL*/
 #define N2N_IF_MODE_SIZE          16 /* static | dhcp */

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -135,8 +135,8 @@ enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 
 #define N2N_RECEPTOR_SOCKETS     400 /* number of receptor sockets to be temporarily opened */
 #define N2N_RECEPTOR_REGISTERS  2000 /* number of REGISTERs sent to the assumed recpetor sockets */
-#define N2N_RECEPTOR_TIME          4 /* secondes to keep the receptor sockets open */
-#define N2N_RECEPTOR_FREQUENCY     2 /* determines, how often to try establishing a connection through  receptor sockets */
+#define N2N_RECEPTOR_TIME         15 /* seconds to keep the receptor sockets open */
+#define N2N_RECEPTOR_FREQUENCY     1 /* determines, how often to try establishing a connection through receptor sockets */
 
 #define N2N_NETMASK_STR_SIZE      16 /* dotted decimal 12 numbers + 3 dots */
 #define N2N_MACNAMSIZ             18 /* AA:BB:CC:DD:EE:FF + NULL*/

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -133,6 +133,11 @@ enum skip_add{SN_ADD = 0, SN_ADD_SKIP = 1, SN_ADD_ADDED = 2};
 #define N2N_AFLAGS_PASS_THROUGH    1 /* indicate that QUERY_PEER is to be passed through to the edge in question      */
                                      /* if set in PEER_INFO, it indicates the same for the corresponding QUERY_PEER   */
 
+#define N2N_RECEPTOR_SOCKETS     400 /* number of receptor sockets to be temporarily opened */
+#define N2N_RECEPTOR_REGISTERS  2000 /* number of REGISTERs sent to the assumed recpetor sockets */
+#define N2N_RECEPTOR_TIME          4 /* secondes to keep the receptor sockets open */
+#define N2N_RECEPTOR_FREQUENCY     2 /* determines, how often to try establishing a connection through  receptor sockets */
+
 #define N2N_NETMASK_STR_SIZE      16 /* dotted decimal 12 numbers + 3 dots */
 #define N2N_MACNAMSIZ             18 /* AA:BB:CC:DD:EE:FF + NULL*/
 #define N2N_IF_MODE_SIZE          16 /* static | dhcp */

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -444,6 +444,7 @@ struct peer_info {
     time_t                           last_seen;
     time_t                           last_p2p;
     time_t                           last_sent_query;
+    uint8_t                          query_number;             /* number of PEER_QUERies sent so far, can roll-over */
     SN_SELECTION_CRITERION_DATA_TYPE selection_criterion;
     uint64_t                         last_valid_time_stamp;
     char                             *ip_addr;
@@ -707,6 +708,8 @@ struct n2n_edge {
     int                              udp_multicast_sock;                 /**< socket for local multicast registrations. */
     int                              multicast_joined;                   /**< 1 if the group has been joined.*/
 #endif
+
+    n2n_sock_t                       external_sock;                      /**< the socket the supernode sees the edge at */
 
     /* Peers */
     struct peer_info *               known_peers;                        /**< Edges we are connected to. */

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -638,8 +638,18 @@ typedef struct n2n_receptor_socket {
     n2n_mac_t  mac;          /* mac of remote edge */
     time_t     opened;       /* the time at which the socket has been opened */
 
-    UT_hash_handle hh; /* makes this structure hashable */
+    UT_hash_handle hh;       /* makes this structure hashable */
 } n2n_receptor_socket_t;
+
+
+typedef struct n2n_receptor_register {
+    n2n_mac_t  mac;          /* mac of remote edge */
+    n2n_sock_t sock;         /* sock of remote edge (port to be altered) */
+    time_t     started;      /* the time at which the edge started to send REGISTERs */
+    time_t     last;         /* the time at which the edge sent REGISTERs the last time*/
+
+    UT_hash_handle hh;       /* makes this structure hashable */
+} n2n_receptor_register_t;
 
 
 /* *************************************************** */
@@ -723,6 +733,7 @@ struct n2n_edge {
 
     n2n_sock_t                       external_sock;                      /**< the socket the supernode sees the edge at */
     n2n_receptor_socket_t            *receptor_sockets;                  /**< list of currently opened receptor sockets */
+    n2n_receptor_register_t          *receptor_registers;                /**< list of edges to whose receptor sockets REGISTERs need to be sent */
 
     /* Peers */
     struct peer_info *               known_peers;                        /**< Edges we are connected to. */

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -633,6 +633,18 @@ typedef struct n2n_resolve_parameter {
 /* *************************************************** */
 
 
+typedef struct n2n_receptor_socket {
+    SOCKET     socket_fd;    /* file descriptor for tcp socket */
+    n2n_mac_t  mac;          /* mac of remote edge */
+    time_t     opened;       /* the time at which the socket has been opened */
+
+    UT_hash_handle hh; /* makes this structure hashable */
+} n2n_receptor_socket_t;
+
+
+/* *************************************************** */
+
+
 typedef struct n2n_edge_conf {
     struct peer_info         *supernodes;            /**< List of supernodes */
     n2n_route_t              *routes;                /**< Networks to route through n2n */
@@ -665,7 +677,7 @@ typedef struct n2n_edge_conf {
     uint8_t                  preferred_sock_auto;    /**< indicates desired auto detect for preferred sock */
     int                      local_port;
     int                      mgmt_port;
-    uint8_t                  connect_tcp;            /** connection to supernode 0 = UDP; 1 = TCP */
+    uint8_t                  connect_tcp;            /**< connection to supernode 0 = UDP; 1 = TCP */
     n2n_auth_t               auth;
     filter_rule_t            *network_traffic_filter_rules;
     int                      metric;                /**< Network interface metric (Windows only). */
@@ -710,6 +722,7 @@ struct n2n_edge {
 #endif
 
     n2n_sock_t                       external_sock;                      /**< the socket the supernode sees the edge at */
+    n2n_receptor_socket_t            *receptor_sockets;                  /**< list of currently opened receptor sockets */
 
     /* Peers */
     struct peer_info *               known_peers;                        /**< Edges we are connected to. */

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -2577,9 +2577,12 @@ static int process_udp (n2n_sn_t * sss,
                 if(scan) {
                     if(query.aflags & N2N_AFLAGS_PASS_THROUGH) {
                         // pass on to edge
-// !!!
                         memcpy(&cmn2, &cmn, sizeof(n2n_common_t));
-                        cmn2.flags |= N2N_FLAGS_FROM_SUPERNODE;
+                        cmn2.flags |= N2N_FLAGS_FROM_SUPERNODE | N2N_FLAGS_SOCKET;
+
+                        query.sock.family = AF_INET;
+                        query.sock.port = ntohs(sender_sock->sin_port);
+                        memcpy(query.sock.addr.v4, &(sender_sock->sin_addr.s_addr), IPV4_SIZE);
 
                         encode_QUERY_PEER(encbuf, &encx, &cmn2, &query);
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -706,6 +706,9 @@ int encode_QUERY_PEER (uint8_t * base,
     retval += encode_mac(base, idx, pkt->srcMac);
     retval += encode_mac(base, idx, pkt->targetMac);
     retval += encode_uint16(base, idx, pkt->aflags);
+    if(common->flags & N2N_FLAGS_SOCKET) {
+        retval += encode_sock(base, idx, &pkt->sock);
+    }
 
     return retval;
 }
@@ -722,6 +725,9 @@ int decode_QUERY_PEER (n2n_QUERY_PEER_t * pkt,
     retval += decode_mac(pkt->srcMac, base, rem, idx);
     retval += decode_mac(pkt->targetMac, base, rem, idx);
     retval += decode_uint16(&(pkt->aflags), base, rem, idx);
+    if(cmn->flags & N2N_FLAGS_SOCKET) {
+        retval += decode_sock(&pkt->sock, base, rem, idx);
+    }
 
     return retval;
 }


### PR DESCRIPTION
This pull request shall implement some experimental idea to enhance p2p experience.

Basically, it extends the idea of port prediction as found with `-L` to a much bigger extent, namely by increasing the number of listening sockets as well as replacing the prediction algorithm by using random and a lot more REGISTER attempts.

Work in progress (thus draft) and being built in increments, will definitely take a while. For testing, the current code can always be downloaded [here](https://github.com/Logan007/n2n/archive/xpReg.zip) as provided by github's autopacker.

The first commit only adds the capability to pass through a specially flagged QUERY_PEER to the queried edge itself (so, no effect on p2p yet). As QUERY_PEER is sent out only in case of non-working p2p, this can signal the other edge to take some action. The also flagged PEER_INFO answer lets the originally sending edge know when to start taking some action as well.