### PR TITLE
Add some crosscompiled binary outputs to the autobuild

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Upload dpkg
         uses: actions/upload-artifact@v2
         with:
-          name: package-dpkg-x86_64-pc-linux-gnu
+          name: package-dpkg-amd64
           path: packages/debian/*.deb
 
   package_rpm:
@@ -162,7 +162,7 @@ jobs:
       - name: Upload rpm
         uses: actions/upload-artifact@v2
         with:
-          name: package-rpm-x86_64-pc-linux-gnu
+          name: package-rpm-x86_64
           path: rpmbuild/RPMS/x86_64/*.rpm
 
   package_windows:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -230,6 +230,14 @@ jobs:
         arch:
           - arm-linux-gnueabi
 
+          # I assume these architectures produce working code, but this has
+          # not been directly confirmed.
+          # They are compiled dynamically against normal libc, so will not
+          # work on openwrt.
+          - aarch64-linux-gnu
+          - mips-linux-gnu
+          - mipsel-linux-gnu
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,7 @@ jobs:
 
   package_rpm:
     needs: fulltest
-    name: Packages for Redhat/RPM
+    name: Package for Redhat/RPM
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,3 +219,40 @@ jobs:
         with:
           name: package-amd64-macos
           path: package
+
+  package_crosscompile_linux:
+    needs: fulltest
+    name: Binaries for linux
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        arch:
+          - arm-linux-gnueabi
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install cross compiler
+        run: |
+          sudo apt-get install binutils-${{ matrix.arch }} gcc-${{ matrix.arch }}
+
+      - name: Configure and Build
+        shell: bash
+        run: |
+          ./autogen.sh
+          export CC=${{ matrix.arch }}-gcc
+          export AR=${{ matrix.arch }}-ar
+          ./configure --host ${{ matrix.arch }}
+          make
+
+      - name: Create binary dir
+        shell: bash
+        run: |
+          make install DESTDIR=binaries
+
+      - name: Upload binary zip
+        uses: actions/upload-artifact@v2
+        with:
+          name: binaries-${{ matrix.arch }}
+          path: binaries

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
 
   package_dpkg:
     needs: fulltest
-    name: Create packages for Debian/Ubuntu
+    name: Package for Debian/Ubuntu
     runs-on: ubuntu-latest
 
     steps:
@@ -126,12 +126,12 @@ jobs:
       - name: Upload dpkg
         uses: actions/upload-artifact@v2
         with:
-          name: package-amd64-dpkg
+          name: package-dpkg-x86_64-pc-linux-gnu
           path: packages/debian/*.deb
 
   package_rpm:
     needs: fulltest
-    name: Create packages for Redhat
+    name: Packages for Redhat/RPM
     runs-on: ubuntu-latest
 
     steps:
@@ -162,12 +162,12 @@ jobs:
       - name: Upload rpm
         uses: actions/upload-artifact@v2
         with:
-          name: package-amd64-rpm
+          name: package-rpm-x86_64-pc-linux-gnu
           path: rpmbuild/RPMS/x86_64/*.rpm
 
   package_windows:
     needs: fulltest
-    name: Create packages for Windows
+    name: Binaries for Windows (x86_64-pc-mingw64)
     runs-on: windows-latest
 
     steps:
@@ -182,17 +182,17 @@ jobs:
       - name: Create binary dir
         shell: bash
         run: |
-          make install DESTDIR=package
+          make install DESTDIR=binaries
 
       - name: Upload binary zip
         uses: actions/upload-artifact@v2
         with:
-          name: package-amd64-windows
-          path: package
+          name: binaries-x86_64-pc-mingw64
+          path: binaries
 
   package_macos:
     needs: fulltest
-    name: Create packages for MacOS
+    name: Binaries for MacOS (x86_64-apple-darwin)
     runs-on: macos-latest
 
     steps:
@@ -212,13 +212,13 @@ jobs:
       - name: Create binary dir
         shell: bash
         run: |
-          make install DESTDIR=package
+          make install DESTDIR=binaries
 
       - name: Upload binary zip
         uses: actions/upload-artifact@v2
         with:
-          name: package-amd64-macos
-          path: package
+          name: binaries-x86_64-apple-darwin
+          path: binaries
 
   package_crosscompile_linux:
     needs: fulltest

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -207,3 +207,31 @@ n2n network, this behavior can be disabled, just add
 to your `CFLAGS` when configuring, e.g.
 
 `./configure --with-zstd CFLAGS="-O3 -march=native -DSKIP_MULTICAST_PEERS_DISCOVERY"`
+
+# Cross compiling on Linux
+
+## Using the Makefiles and Autoconf
+
+The Makefiles are all setup to allow cross compiling of this code.  You
+will need to have the cross compiler, binutils and any additional libraries
+desired installed for the target architecture.  Then you can run the `./configure`
+with the appropriate CC and AR environment and the right `--host` option.
+
+If compiling on Debian or Ubuntu, this can be as simple as the following example:
+
+```
+HOST_TRIPLET=arm-linux-gnueabi
+sudo apt-get install binutils-$HOST_TRIPLET gcc-$HOST_TRIPLET
+./autogen.sh
+export CC=$HOST_TRIPLET-gcc
+export AR=$HOST_TRIPLET-ar
+./configure --host $HOST_TRIPLET
+make
+```
+
+A good starting point to determine the host triplet for your destination platform
+can be found by copying the `./config.guess` script to it and running it on the
+destination.
+
+This is not a good way to produce binaries for embedded environments (like OpenWRT)
+as they will often use a different libc environment.


### PR DESCRIPTION
Hopefully this will also demonstrate how to do a cross compile with the makefiles.  

The cross compile process is summarised as:
```
HOST_TRIPLET=arm-linux-gnueabi
sudo apt-get install binutils-$HOST_TRIPLET gcc-$HOST_TRIPLET
./autogen.sh
export CC=$HOST_TRIPLET-gcc
export AR=$HOST_TRIPLET-ar
./configure --host $HOST_TRIPLET
make
```
