### PR TITLE
Reduce the number of artifacts to a reasonable number

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -17,20 +17,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            TARGET: x86_64-unknown-linux-musl
-            COMPILER: gcc
-            LINKER: gcc
-          - os: ubuntu-latest
-            TARGET: armv7-unknown-linux-musleabihf
-            COMPILER: arm-linux-gnueabihf-gcc-5
-            LINKER: gcc-5-arm-linux-gnueabihf
           - os: windows-latest
-            COMPILER: cl
-            LINKER: cl
           - os: macos-latest
-            TARGET: x86_64-apple-darwin
-            COMPILER: clang
-            LINKER: clang
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: tests-out
-          path: tests/${{ matrix.os }}
+          path: tests
 
       - name: Generate coverage reports
         run: |
@@ -128,7 +128,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: tests-out
-          path: tests/${{ matrix.os }}
+          path: tests
 
       - name: Generate coverage reports
         run: |
@@ -195,7 +195,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: tests-out
-          path: tests/${{ matrix.os }}
+          path: tests
 
       - name: Generate coverage data
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Upload dpkg
         uses: actions/upload-artifact@v2
         with:
-          name: package-dpkg-${{ matrix.arch }}
+          name: packages-dpkg
           path: packages/debian/*.deb
 
   package_rpm:
@@ -261,7 +261,7 @@ jobs:
       - name: Upload rpm
         uses: actions/upload-artifact@v2
         with:
-          name: package-rpm-x86_64
+          name: packages-rpm
           path: rpmbuild/RPMS/x86_64/*.rpm
 
   binaries_windows:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,11 +54,18 @@ jobs:
         shell: bash
 
       - if: ${{ always() }}
+        name: Move test outputs to an arch specific location
+        shell: bash
+        run: |
+          mkdir -p tests/${{ matrix.os }}
+          mv tests/*.out tests/${{ matrix.os }}
+
+      - if: ${{ always() }}
         name: Upload tests output
         uses: actions/upload-artifact@v2
         with:
-          name: tests-out-${{matrix.os}}
-          path: tests/*.out
+          name: tests-out
+          path: tests/${{ matrix.os }}
 
       - name: Generate coverage reports
         run: |
@@ -110,11 +117,18 @@ jobs:
         shell: bash
 
       - if: ${{ always() }}
+        name: Move test outputs to an arch specific location
+        shell: bash
+        run: |
+          mkdir -p tests/${{ matrix.os }}
+          mv tests/*.out tests/${{ matrix.os }}
+
+      - if: ${{ always() }}
         name: Upload tests output
         uses: actions/upload-artifact@v2
         with:
-          name: tests-out-${{matrix.os}}
-          path: tests/*.out
+          name: tests-out
+          path: tests/${{ matrix.os }}
 
       - name: Generate coverage reports
         run: |
@@ -170,11 +184,18 @@ jobs:
         shell: bash
 
       - if: ${{ always() }}
+        name: Move test outputs to an arch specific location
+        shell: bash
+        run: |
+          mkdir -p tests/${{ matrix.os }}
+          mv tests/*.out tests/${{ matrix.os }}
+
+      - if: ${{ always() }}
         name: Upload tests output
         uses: actions/upload-artifact@v2
         with:
-          name: tests-out-${{matrix.os}}
-          path: tests/*.out
+          name: tests-out
+          path: tests/${{ matrix.os }}
 
       - name: Generate coverage data
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,13 +63,13 @@ jobs:
       - name: Generate coverage reports
         run: |
           make gcov
-          make cover
+          make cover COVERAGEDIR=coverage/${{ matrix.os }}
         shell: bash
 
       - name: Upload gcovr report artifact
         uses: actions/upload-artifact@v2
         with:
-          name: coverage-${{matrix.os}}
+          name: coverage
           path: coverage
 
       - name: Upload data to codecov
@@ -119,13 +119,13 @@ jobs:
       - name: Generate coverage reports
         run: |
           make gcov
-          make cover
+          make cover COVERAGEDIR=coverage/${{ matrix.os }}
         shell: bash
 
       - name: Upload gcovr report artifact
         uses: actions/upload-artifact@v2
         with:
-          name: coverage-${{matrix.os}}
+          name: coverage
           path: coverage
 
       - name: Upload data to codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -281,12 +281,12 @@ jobs:
       - name: Create binary dir
         shell: bash
         run: |
-          make install DESTDIR=binaries
+          make install DESTDIR=binaries/x86_64-pc-mingw64
 
-      - name: Upload binary zip
+      - name: Upload binary artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: binaries-x86_64-pc-mingw64
+          name: binaries
           path: binaries
 
   binaries_macos:
@@ -311,12 +311,12 @@ jobs:
       - name: Create binary dir
         shell: bash
         run: |
-          make install DESTDIR=binaries
+          make install DESTDIR=binaries/x86_64-apple-darwin
 
-      - name: Upload binary zip
+      - name: Upload binary artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: binaries-x86_64-apple-darwin
+          name: binaries
           path: binaries
 
   binaries_linux_crosscompile:
@@ -356,10 +356,10 @@ jobs:
       - name: Create binary dir
         shell: bash
         run: |
-          make install DESTDIR=binaries
+          make install DESTDIR=binaries/${{ matrix.arch }}
 
-      - name: Upload binary zip
+      - name: Upload binary artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: binaries-${{ matrix.arch }}
+          name: binaries
           path: binaries

--- a/Makefile.in
+++ b/Makefile.in
@@ -110,6 +110,8 @@ DOCS=edge.8.gz supernode.1.gz n2n.7.gz
 
 SUBDIRS+=tools
 
+COVERAGEDIR?=coverage
+
 .PHONY: $(SUBDIRS)
 .PHONY: steps build push all clean install test cover gcov build-dep
 all: $(APPS) $(DOCS) $(SUBDIRS)
@@ -152,8 +154,8 @@ test: tools
 # and run the desired tests.  Ensure that package gcovr is installed
 # and then run "make cover"
 cover:
-	mkdir -p coverage
-	gcovr -s --html --html-details --output=coverage/index.html
+	mkdir -p $(COVERAGEDIR)
+	gcovr -s --html --html-details --output=$(COVERAGEDIR)/index.html
 
 # Use coverage data to generate gcov text report files.
 # Unfortunately, these end up in the wrong directory due to the
@@ -175,7 +177,7 @@ else
 endif
 
 clean:
-	rm -rf $(N2N_OBJS) $(N2N_LIB) $(APPS) $(DOCS) coverage/ *.dSYM *~
+	rm -rf $(N2N_OBJS) $(N2N_LIB) $(APPS) $(DOCS) $(COVERAGEDIR)/ *.dSYM *~
 	rm -f tests/*.out src/*.gcno src/*.gcda
 	for dir in $(SUBDIRS); do $(MAKE) -C $$dir clean; done
 


### PR DESCRIPTION
Combine all the similar artefacts into the same named buckets to create less total artefacts.

This will also help in the future if we start using tagged releases to automatically publish artefacts as release assets