### PR TITLE
Add some JSON interfaces to the edge management port

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
           ./autogen.sh
           ./configure
           make test
+          make lint.python
 
   test_linux:
     needs: smoketest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install essential
+        run: |
+          sudo apt-get install flake8
       - name: Run minimal test set
         run: |
           ./autogen.sh

--- a/Makefile.in
+++ b/Makefile.in
@@ -150,7 +150,7 @@ test: tools
 	tools/test_harness
 
 lint.python:
-	flake8 scripts/n2nctl
+	flake8 scripts/n2nctl scripts/n2nhttpd
 
 # To generate coverage information, run configure with
 # CFLAGS="-fprofile-arcs -ftest-coverage" LDFLAGS="--coverage"

--- a/Makefile.in
+++ b/Makefile.in
@@ -149,6 +149,9 @@ win32/n2n_win32.a: win32
 test: tools
 	tools/test_harness
 
+lint.python:
+	flake8 scripts/n2nctl
+
 # To generate coverage information, run configure with
 # CFLAGS="-fprofile-arcs -ftest-coverage" LDFLAGS="--coverage"
 # and run the desired tests.  Ensure that package gcovr is installed

--- a/Makefile.in
+++ b/Makefile.in
@@ -172,7 +172,7 @@ gcov:
 # It is a convinent target to use during development or from a CI/CD system
 build-dep:
 ifeq ($(CONFIG_TARGET),generic)
-	sudo apt install build-essential autoconf libcap-dev libzstd-dev gcovr
+	sudo apt install build-essential autoconf libcap-dev libzstd-dev gcovr flake8
 else ifeq ($(CONFIG_TARGET),darwin)
 	brew install automake gcovr
 else

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -17,7 +17,7 @@ def send_cmd(port, debug, cmd):
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
     tagstr = str(next_tag)
-    next_tag += 1
+    next_tag = (next_tag + 1) % 1000
 
     message = "{} {}".format(cmd, tagstr).encode('utf8')
     sock.sendto(message, ("127.0.0.1", 5644))

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Licensed under GPLv3
+#
+# Simple script to query the management interface of a running n2n edge node
+
+import argparse
+import socket
+import json
+import collections
+
+next_tag = 0
+
+
+def send_cmd(port, cmd):
+    global next_tag
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    tagstr = str(next_tag)
+    next_tag += 1
+
+    message = "{} {}".format(cmd, tagstr).encode('utf8')
+    sock.sendto(message, ("127.0.0.1", 5644))
+
+    # FIXME:
+    # - there is no timeout for any of the socket handling
+
+    begin, _ = sock.recvfrom(1024)
+    begin = json.loads(begin.decode('utf8'))
+    assert(begin['_tag'] == tagstr)
+    assert(begin['_type'] == 'begin')
+    assert(begin['_cmd'] == cmd)
+
+    result = list()
+
+    while True:
+        data, _ = sock.recvfrom(1024)
+        data = json.loads(data.decode('utf8'))
+        assert(data['_tag'] == tagstr)
+
+        if data['_type'] == 'unknowncmd':
+            raise ValueError('Unknown command {}'.format(cmd))
+
+        if data['_type'] == 'end':
+            return result
+
+        # remove our boring metadata
+        del data['_tag']
+        del data['_type']
+
+        result.append(data)
+
+
+def str_table(rows, columns):
+    """Given an array of dicts, do a simple table print"""
+    result = list()
+    widths = collections.defaultdict(lambda: 0)
+    for row in rows:
+        for col in columns:
+            if col in row:
+                widths[col] = max(widths[col], len(str(row[col])))
+
+    for col in columns:
+        if widths[col] == 0:
+            widths[col] = 1
+        result += "{:{}.{}} ".format(col, widths[col], widths[col])
+    result += "\n"
+
+    for row in rows:
+        for col in columns:
+            if col in row:
+                data = str(row[col])
+            else:
+                data = ''
+            result += "{:{}.{}} ".format(data, widths[col], widths[col])
+        result += "\n"
+
+    return ''.join(result)
+
+
+def subcmd_show_supernodes(args):
+    rows = send_cmd(args.port, 'j.super')
+    columns = [
+        'version',
+        'macaddr',
+        'sockaddr',
+        'uptime',
+    ]
+
+    return str_table(rows, columns)
+
+
+def subcmd_show_peers(args):
+    rows = send_cmd(args.port, 'j.peer')
+    columns = [
+        'mode',
+        'ip4addr',
+        'macaddr',
+        'sockaddr',
+        'desc',
+    ]
+
+    return str_table(rows, columns)
+
+
+subcmds = {
+    'supernodes': {
+        'func': subcmd_show_supernodes,
+        'help': 'Show the list of supernodes',
+    },
+    'peers': {
+        'func': subcmd_show_peers,
+        'help': 'Show the list of peers',
+    },
+}
+
+
+def main():
+    ap = argparse.ArgumentParser(
+            description='Query the running local n2n edge')
+    ap.add_argument('-t', '--port', action='store', default=5644,
+                    help='Management Port (default=5644)')
+
+    subcmd = ap.add_subparsers(help='Subcommand', dest='cmd')
+    subcmd.required = True
+
+    for key, value in subcmds.items():
+        value['parser'] = subcmd.add_parser(key, help=value['help'])
+        value['parser'].set_defaults(func=value['func'])
+
+    args = ap.parse_args()
+
+    result = args.func(args)
+    print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -44,6 +44,10 @@ def send_cmd(port, debug, cmd):
         if data['_type'] == 'end':
             return result
 
+        if data['_type'] != 'row':
+            raise ValueError('Unknown data type {} from '
+                             'edge'.format(data['_type']))
+
         # remove our boring metadata
         del data['_tag']
         del data['_type']

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -11,7 +11,7 @@ import collections
 next_tag = 0
 
 
-def send_cmd(port, cmd):
+def send_cmd(port, debug, cmd):
     global next_tag
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -48,6 +48,9 @@ def send_cmd(port, cmd):
         del data['_tag']
         del data['_type']
 
+        if debug:
+            print(data)
+
         result.append(data)
 
 
@@ -69,19 +72,20 @@ def str_table(rows, columns):
     for row in rows:
         for col in columns:
             if col in row:
-                data = str(row[col])
+                data = row[col]
             else:
                 data = ''
-            result += "{:{}.{}} ".format(data, widths[col], widths[col])
+            result += "{:{}} ".format(data, widths[col])
         result += "\n"
 
     return ''.join(result)
 
 
 def subcmd_show_supernodes(args):
-    rows = send_cmd(args.port, 'j.super')
+    rows = send_cmd(args.port, args.debug, 'j.super')
     columns = [
         'version',
+        'current',
         'macaddr',
         'sockaddr',
         'uptime',
@@ -91,7 +95,7 @@ def subcmd_show_supernodes(args):
 
 
 def subcmd_show_peers(args):
-    rows = send_cmd(args.port, 'j.peer')
+    rows = send_cmd(args.port, args.debug, 'j.peer')
     columns = [
         'mode',
         'ip4addr',
@@ -120,6 +124,8 @@ def main():
             description='Query the running local n2n edge')
     ap.add_argument('-t', '--port', action='store', default=5644,
                     help='Management Port (default=5644)')
+    ap.add_argument('-d', '--debug', action='store_true',
+                    help='Also show raw internal data')
 
     subcmd = ap.add_subparsers(help='Subcommand', dest='cmd')
     subcmd.required = True

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Licensed under GPLv3
+#
+# Simple http server to allow user control of n2n edge nodes
+#
+# Currently only for demonstration - needs javascript written to render the
+# results properly.
+#
+# Try it out with
+#   http://localhost:8080/edge/peer
+#   http://localhost:8080/edge/super
+
+import argparse
+import socket
+import json
+import socketserver
+import http.server
+
+from http import HTTPStatus
+
+next_tag = 0
+
+
+def send_cmd(port, debug, cmd):
+    """Send a text command to the edge and process the JSON reply packets"""
+    global next_tag
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    tagstr = str(next_tag)
+    next_tag = (next_tag + 1) % 1000
+
+    message = "{} {}".format(cmd, tagstr).encode('utf8')
+    sock.sendto(message, ("127.0.0.1", 5644))
+
+    # FIXME:
+    # - there is no timeout for any of the socket handling
+
+    begin, _ = sock.recvfrom(1024)
+    begin = json.loads(begin.decode('utf8'))
+    assert(begin['_tag'] == tagstr)
+    assert(begin['_type'] == 'begin')
+    assert(begin['_cmd'] == cmd)
+
+    result = list()
+
+    while True:
+        data, _ = sock.recvfrom(1024)
+        data = json.loads(data.decode('utf8'))
+        assert(data['_tag'] == tagstr)
+
+        if data['_type'] == 'unknowncmd':
+            raise ValueError('Unknown command {}'.format(cmd))
+
+        if data['_type'] == 'end':
+            return result
+
+        if data['_type'] != 'row':
+            raise ValueError('Unknown data type {} from '
+                             'edge'.format(data['_type']))
+
+        # remove our boring metadata
+        del data['_tag']
+        del data['_type']
+
+        if debug:
+            print(data)
+
+        result.append(data)
+
+
+class SimpleHandler(http.server.BaseHTTPRequestHandler):
+
+    def log_request(self, code='-', size='-'):
+        # Dont spam the output
+        pass
+
+    def do_GET(self):
+        url_tail = self.path
+        if url_tail.startswith("/edge/"):
+            tail = url_tail.split('/')
+            cmd = 'j.' + tail[2]
+
+            try:
+                data = send_cmd(5644, False, cmd)
+            except ValueError:
+                self.send_response(HTTPStatus.BAD_REQUEST)
+                self.end_headers()
+                self.wfile.write(b'Bad Command')
+                return
+
+            self.send_response(HTTPStatus.OK)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(data).encode('utf8'))
+
+
+def main():
+    ap = argparse.ArgumentParser(
+            description='Control the running local n2n edge via http')
+    # TODO - this needs to pass into the handler object
+    #ap.add_argument('-t', '--mgmtport', action='store', default=5644,
+    #                help='Management Port (default=5644)')
+    #ap.add_argument('-d', '--debug', action='store_true',
+    #                help='Also show raw internal data')
+    ap.add_argument('port', action='store',
+                    default=8080, type=int, nargs='?',
+                    help='Serve requests on TCP port (default 8080)')
+
+    args = ap.parse_args()
+
+    with socketserver.TCPServer(("", args.port), SimpleHandler) as httpd:
+        httpd.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -98,11 +98,11 @@ class SimpleHandler(http.server.BaseHTTPRequestHandler):
 def main():
     ap = argparse.ArgumentParser(
             description='Control the running local n2n edge via http')
-    # TODO - this needs to pass into the handler object
-    #ap.add_argument('-t', '--mgmtport', action='store', default=5644,
-    #                help='Management Port (default=5644)')
-    #ap.add_argument('-d', '--debug', action='store_true',
-    #                help='Also show raw internal data')
+    #  TODO - this needs to pass into the handler object
+    # ap.add_argument('-t', '--mgmtport', action='store', default=5644,
+    #                 help='Management Port (default=5644)')
+    # ap.add_argument('-d', '--debug', action='store_true',
+    #                 help='Also show raw internal data')
     ap.add_argument('port', action='store',
                     default=8080, type=int, nargs='?',
                     help='Serve requests on TCP port (default 8080)')


### PR DESCRIPTION
This allows a couple of things:
- allows the removal of presentation logic from inside the edge binary
- machine readable queries would help to allow automated tests (eg: once there is a stable protocol, we could confirm that the built binaries can establish a connection to the public supernode within a specified timeframe)