### PR TITLE
Cleanup and Documentation for JSON management API

### DIFF
--- a/doc/ManagementAPI.md
+++ b/doc/ManagementAPI.md
@@ -1,0 +1,175 @@
+# Management API
+
+This document is focused on the machine readable API interfaces. 
+
+Both the edge and the supernode provide a management interface UDP port.
+These interfaces have some documentation on their non machine readable
+commands in the respective daemon man pages.
+
+Default Ports:
+- UDP/5644 - edge
+- UDP/5645 - supernode
+
+## JSON Query interface
+
+As part of the management interface, A machine readable API exists for the
+edge daemon.  It takes a simple text request and replies with JSON formatted
+data.
+
+The request is in simple text so that the daemon does not need to include any
+complex parser.
+
+The replies are all in JSON so that the data is fully machine readable and
+the schema can be updated as needed - the burden is entirely on the client
+to handle different replies with different fields.  It is expected that
+any client software will be written in higher level programming languages
+where this flexibility is easy to provide.
+
+Since the API is over UDP, the replies are structured so that each part of
+the reply is clearly tagged as belonging to one request and there is a
+clear begin and end marker for the reply.  This is expected to support the
+future possibilities of pipelined and overlapping transactions as well as
+pub/sub asynchronous event channels.
+
+The replies will also handle some small amount of re-ordering of the
+packets, but that is not an specific goal of the protocol.
+
+With a small amount of effort, the API is intended to be human readable,
+but this is intended for debugging.
+
+## Request API
+
+The request is a single UDP packet containing one line of text with at least
+three space separated fields.  Any text after the third field is available for
+the API method to use for additional parameters 
+
+Fields:
+- Message Type
+- Options
+- Method
+- Optional Additional Parameters
+
+The maximum length of the entire line of text is 80 octets.
+
+### Message Type
+
+This is a single octet that is either "r" for a read (or query) method
+call or "w" for a write (or change) method call.
+
+To simplify the interface, the reply from both read and write calls to the
+same method is expected to contain the same data.  In the case of a write
+call, the reply will contain the new state after making the requested change.
+
+### Options
+
+The options field is a colon separated set of options for this request.  Only
+the first subfield (the "tag") is mandatory.  The second subfield is a set
+of flags that describe which optional subfields are present.
+If there are no additional subfields then the flags can be omitted.
+
+SubFields:
+- Message Tag
+- Optional Message Flags (defaults to 0)
+- Optional Authentication Key
+
+#### Message Tag
+
+Each request provides a tag value.  Any non error reply associated with this
+request will include this tag value, allowing all related messages to be
+collected within the client.
+
+Where possible, the error replies will also include this tag, however some
+errors occur before the tag is parsed.
+
+The tag is not interpreted by the daemon, it is simply echoed back in all
+the replies.  It is expected to be a short string that the client chooses
+to be unique amongst all recent or still outstanding requests.
+
+One possible client implementation is a number between 0 and 999, incremented
+for each request and wrapping around to zero when it is greater than 999.
+
+#### Message Flags
+
+This subfield is a set of bit flags that are hex-encoded and describe any
+remaining optional subfields.
+
+Currently, only one flag is defined.  The presence of that flag indicates
+that an authentication key subfield is also present.
+
+Values:
+- 0 - No additional subfields are present
+- 1 - One additional field, containing the authentication key
+
+#### Authentication Key
+
+A simple string password that is provided by the client to authenticate
+this request.  See the Authentication section below for more discussion.
+
+#### Example Options value
+
+e.g:
+    `102:1:PassWord`
+
+### Example Request string
+
+e.g:
+    `r 103:1:PassWord peer`
+
+## Reply API
+
+Each UDP packet in the reply is a complete and valid JSON dictionary
+containing a fragment of information related to the entire reply.
+
+### Common metadata
+
+There are two keys in each dictionary containing metadata.  First
+is the `_tag`, containing the Message Tag from the original request.
+Second is the `_type` whic identifies the expected contents of this
+packet.
+
+### `_type: error`
+
+If an error condition occurs, a packet with a `error` key describing
+the error will be sent.  This usually also indicates that there will
+be no more substantial data arriving related to this request.
+
+e.g:
+    `{"_tag":"107","_type":"error","error":"badauth"}`
+
+### `_type: begin`
+
+Before the start of any substantial data packets, a `begin` packet is
+sent.  For consistency checking, the method in the request is echoed
+back in the `error` key.
+
+e.g:
+    `{"_tag":"108","_type":"begin","cmd":"peer"}`
+
+For simplicity in decoding, if a `begin` packet is sent, all attempts
+are made to ensure that a final `end` packet is also sent.
+
+### `_type: end`
+
+After the last substantial data packet, a final `end` packet is sent
+to signal to the client that this reply is finished.
+
+e.g:
+    `{"_tag":"108","_type":"end"}`
+
+### `_type: row`
+
+The substantial bulk of the data in the reply is contained within one or
+more `row` packets.  The non metadata contents of each `row` packet is
+defined entirely by the method called and may change from version to version.
+
+e.g:
+    `{"_tag":"108","_type":"row","mode":"p2p","ip4addr":"10.135.98.84","macaddr":"86:56:21:E4:AA:39","sockaddr":"192.168.7.191:41701","desc":"client4","lastseen":1584682200}`
+
+## Authentication
+
+Some API requests will make global changes to the running daemon and may
+affect the availability of the n2n networking.  Therefore the machine
+readable API include an authentication component.
+
+Currently, the only authentication is a simple password that the client
+must provide.

--- a/doc/Scripts.md
+++ b/doc/Scripts.md
@@ -1,0 +1,41 @@
+# Scripts
+
+There are a number of useful scripts included with the distribution.
+Some of these scripts are only useful during build and development, but
+other scripts are intended for end users to be able to use.  These scripts
+may be installed with n2n as part of your operating system package.
+
+Short descriptions of these scripts are below.
+
+## `scripts/hack_fakeautoconf`
+
+This shell script is used during development to help build on Windows
+systems.  An example of how to use it is shown in
+the [Duilding document](Building.md)
+
+## `tools/test_harness`
+
+This shell script is used to run automated tests during development.
+
+## `scripts/n2nctl`
+
+This python script provides an easy command line interface to the running
+edge.  It uses UDP communications to talk to the Management API.
+
+Example:
+- `scripts/n2nctl --help`
+- `scripts/n2nctl help`
+
+## `scripts/n2nhttpd`
+
+This python script is a simple http gateway to the running edge.  It provides
+a proxy for REST-like HTTP requests to talk to the Management API.
+
+By default it runs on port 8080.
+
+It also provides a simple HTML page showing some information, which when
+run with default settings can be seen at http://localhost:8080/
+
+Example:
+- `scripts/n2nhttpd --help`
+- `scripts/n2nhttpd 8087`

--- a/doc/Scripts.md
+++ b/doc/Scripts.md
@@ -11,7 +11,7 @@ Short descriptions of these scripts are below.
 
 This shell script is used during development to help build on Windows
 systems.  An example of how to use it is shown in
-the [Duilding document](Building.md)
+the [Building document](Building.md)
 
 ## `tools/test_harness`
 

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -121,9 +121,9 @@ enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 #define N2N_EDGE_MGMT_PORT        5644
 #define N2N_SN_MGMT_PORT          5645
 
-enum mgmt_type {
-    MGMT_READ = 0,
-    MGMT_WRITE = 1,
+enum n2n_mgmt_type {
+    N2N_MGMT_READ = 0,
+    N2N_MGMT_WRITE = 1,
 };
 
 #define N2N_TCP_BACKLOG_QUEUE_SIZE   3         /* number of concurrently pending connections to be accepted */

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -121,6 +121,11 @@ enum sn_purge{SN_PURGEABLE = 0, SN_UNPURGEABLE = 1};
 #define N2N_EDGE_MGMT_PORT        5644
 #define N2N_SN_MGMT_PORT          5645
 
+enum mgmt_type {
+    MGMT_READ = 0,
+    MGMT_WRITE = 1,
+};
+
 #define N2N_TCP_BACKLOG_QUEUE_SIZE   3         /* number of concurrently pending connections to be accepted */
                                                /* NOT the number of max. TCP connections                    */
 

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -831,6 +831,12 @@ typedef struct n2n_sn {
 } n2n_sn_t;
 
 
+/* *************************************************** */
 
+typedef struct n2n_mgmt_handler {
+    char  *cmd;
+    char  *help;
+    void (*func)(n2n_edge_t *eee, char *udp_buf, struct sockaddr_in sender_sock, enum n2n_mgmt_type type, char *tag, char *cmd);
+} n2n_mgmt_handler_t;
 
 #endif /* _N2N_TYPEDEFS_H_ */

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -836,7 +836,7 @@ typedef struct n2n_sn {
 typedef struct n2n_mgmt_handler {
     char  *cmd;
     char  *help;
-    void (*func)(n2n_edge_t *eee, char *udp_buf, struct sockaddr_in sender_sock, enum n2n_mgmt_type type, char *tag, char *cmd);
+    void (*func)(n2n_edge_t *eee, char *udp_buf, struct sockaddr_in sender_sock, enum n2n_mgmt_type type, char *tag, char *argv0, char *argv);
 } n2n_mgmt_handler_t;
 
 #endif /* _N2N_TYPEDEFS_H_ */

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -123,7 +123,24 @@ def subcmd_show_peers(args):
     return str_table(rows, columns)
 
 
+def subcmd_show_help(args):
+    result = 'Commands with pretty-printed output:\n\n'
+    for name, cmd in subcmds.items():
+        result += "{:12} {}\n".format(name, cmd['help'])
+
+    result += "\n"
+    result += "Possble remote commands:\n"
+    result += "(those without pretty-printer, will pass-through)\n\n"
+    rows = send_cmd(args.port, args.debug, args.key, args.cmd)
+    result += json.dumps(rows, sort_keys=True, indent=4)
+    return result
+
+
 subcmds = {
+    'help': {
+        'func': subcmd_show_help,
+        'help': 'Show available commands',
+    },
     'supernodes': {
         'func': subcmd_show_supernodes,
         'help': 'Show the list of supernodes',
@@ -135,6 +152,12 @@ subcmds = {
 }
 
 
+def subcmd_default(args):
+    """Just pass command through to edge"""
+    rows = send_cmd(args.port, args.debug, args.key, args.cmd)
+    return json.dumps(rows, sort_keys=True, indent=4)
+
+
 def main():
     ap = argparse.ArgumentParser(
             description='Query the running local n2n edge')
@@ -144,17 +167,21 @@ def main():
                     help='Password for mgmt commands')
     ap.add_argument('-d', '--debug', action='store_true',
                     help='Also show raw internal data')
-
-    subcmd = ap.add_subparsers(help='Subcommand', dest='cmd')
-    subcmd.required = True
-
-    for key, value in subcmds.items():
-        value['parser'] = subcmd.add_parser(key, help=value['help'])
-        value['parser'].set_defaults(func=value['func'])
+    ap.add_argument('--read', action='store_true',
+                    help='Make a read request (default)')
+    ap.add_argument('--write', action='store_false', dest='read',
+                    help='Make a write request')
+    ap.add_argument('cmd', action='store',
+                    help='Command to run (try "help" for list)')
 
     args = ap.parse_args()
 
-    result = args.func(args)
+    if args.cmd not in subcmds:
+        func = subcmd_default
+    else:
+        func = subcmds[args.cmd]['func']
+
+    result = func(args)
     print(result)
 
 

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -12,6 +12,7 @@ next_tag = 0
 
 
 def send_cmd(port, debug, cmd):
+    """Send a text command to the edge and process the JSON reply packets"""
     global next_tag
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -19,17 +20,23 @@ def send_cmd(port, debug, cmd):
     tagstr = str(next_tag)
     next_tag = (next_tag + 1) % 1000
 
-    message = "{} {}".format(cmd, tagstr).encode('utf8')
+    msgtype = "r"
+
+    message = "{} {} {}".format(msgtype, tagstr, cmd).encode('utf8')
     sock.sendto(message, ("127.0.0.1", 5644))
 
     # FIXME:
     # - there is no timeout for any of the socket handling
 
-    begin, _ = sock.recvfrom(1024)
-    begin = json.loads(begin.decode('utf8'))
-    assert(begin['_tag'] == tagstr)
-    assert(begin['_type'] == 'begin')
-    assert(begin['_cmd'] == cmd)
+    data, _ = sock.recvfrom(1024)
+    data = json.loads(data.decode('utf8'))
+    assert(data['_tag'] == tagstr)
+
+    if data['_type'] == 'error':
+        raise ValueError('Error: {}'.format(data['error']))
+
+    assert(data['_type'] == 'begin')
+    assert(data['cmd'] == cmd)
 
     result = list()
 
@@ -38,8 +45,8 @@ def send_cmd(port, debug, cmd):
         data = json.loads(data.decode('utf8'))
         assert(data['_tag'] == tagstr)
 
-        if data['_type'] == 'unknowncmd':
-            raise ValueError('Unknown command {}'.format(cmd))
+        if data['_type'] == 'error':
+            raise ValueError('Error with command {}'.format(cmd))
 
         if data['_type'] == 'end':
             return result
@@ -86,7 +93,7 @@ def str_table(rows, columns):
 
 
 def subcmd_show_supernodes(args):
-    rows = send_cmd(args.port, args.debug, 'j.super')
+    rows = send_cmd(args.port, args.debug, 'super')
     columns = [
         'version',
         'current',
@@ -99,7 +106,7 @@ def subcmd_show_supernodes(args):
 
 
 def subcmd_show_peers(args):
-    rows = send_cmd(args.port, args.debug, 'j.peer')
+    rows = send_cmd(args.port, args.debug, 'peer')
     columns = [
         'mode',
         'ip4addr',

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -195,7 +195,7 @@ def subcmd_default(rpc, args):
 def main():
     ap = argparse.ArgumentParser(
             description='Query the running local n2n edge')
-    ap.add_argument('-t', '--port', action='store', default=5644,
+    ap.add_argument('-t', '--mgmtport', action='store', default=5644,
                     help='Management Port (default=5644)')
     ap.add_argument('-k', '--key', action='store',
                     help='Password for mgmt commands')
@@ -218,7 +218,7 @@ def main():
     else:
         func = subcmds[args.cmd]['func']
 
-    rpc = JsonUDP(args.port)
+    rpc = JsonUDP(args.mgmtport)
     rpc.debug = args.debug
     rpc.key = args.key
 

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -11,7 +11,7 @@ import collections
 next_tag = 0
 
 
-def send_cmd(port, debug, cmd):
+def send_cmd(port, debug, key, cmd):
     """Send a text command to the edge and process the JSON reply packets"""
     global next_tag
 
@@ -20,9 +20,14 @@ def send_cmd(port, debug, cmd):
     tagstr = str(next_tag)
     next_tag = (next_tag + 1) % 1000
 
+    if key is not None:
+        tagauth = tagstr + ':' + key
+    else:
+        tagauth = tagstr
+
     msgtype = "r"
 
-    message = "{} {} {}".format(msgtype, tagstr, cmd).encode('utf8')
+    message = "{} {} {}".format(msgtype, tagauth, cmd).encode('utf8')
     sock.sendto(message, ("127.0.0.1", 5644))
 
     # FIXME:
@@ -93,7 +98,7 @@ def str_table(rows, columns):
 
 
 def subcmd_show_supernodes(args):
-    rows = send_cmd(args.port, args.debug, 'super')
+    rows = send_cmd(args.port, args.debug, args.key, 'super')
     columns = [
         'version',
         'current',
@@ -106,7 +111,7 @@ def subcmd_show_supernodes(args):
 
 
 def subcmd_show_peers(args):
-    rows = send_cmd(args.port, args.debug, 'peer')
+    rows = send_cmd(args.port, args.debug, args.key, 'peer')
     columns = [
         'mode',
         'ip4addr',
@@ -135,6 +140,8 @@ def main():
             description='Query the running local n2n edge')
     ap.add_argument('-t', '--port', action='store', default=5644,
                     help='Management Port (default=5644)')
+    ap.add_argument('-k', '--key', action='store',
+                    help='Password for mgmt commands')
     ap.add_argument('-d', '--debug', action='store_true',
                     help='Also show raw internal data')
 

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -184,7 +184,7 @@ subcmds = {
 
 def subcmd_default(rpc, args):
     """Just pass command through to edge"""
-    cmdline = args.cmd
+    cmdline = ' '.join([args.cmd] + args.args)
     if args.write:
         rows = rpc.write(cmdline)
     else:
@@ -210,6 +210,8 @@ def main():
 
     ap.add_argument('cmd', action='store',
                     help='Command to run (try "help" for list)')
+    ap.add_argument('args', action='store', nargs="*",
+                    help='Optional args for the command')
 
     args = ap.parse_args()
 

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -8,66 +8,96 @@ import socket
 import json
 import collections
 
-next_tag = 0
 
+class JsonUDP():
+    """encapsulate communication with the edge"""
 
-def send_cmd(port, debug, key, cmd):
-    """Send a text command to the edge and process the JSON reply packets"""
-    global next_tag
+    def __init__(self, port):
+        self.address = "127.0.0.1"
+        self.port = port
+        self.tag = 0
+        self.key = None
+        self.debug = False
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    def _next_tag(self):
+        tagstr = str(self.tag)
+        self.tag = (self.tag + 1) % 1000
+        return tagstr
 
-    tagstr = str(next_tag)
-    next_tag = (next_tag + 1) % 1000
+    def _cmdstr(self, msgtype, cmdline):
+        """Create the full command string to send"""
+        tagstr = self._next_tag()
 
-    if key is not None:
-        options = tagstr + ':1:' + key
-    else:
-        options = tagstr
+        options = [tagstr]
+        if self.key is not None:
+            options += ['1']  # Flags set for auth key field
+            options += [self.key]
+        optionsstr = ':'.join(options)
 
-    msgtype = "r"
+        return tagstr, ' '.join((msgtype, optionsstr, cmdline))
 
-    message = "{} {} {}".format(msgtype, options, cmd).encode('utf8')
-    sock.sendto(message, ("127.0.0.1", 5644))
+    def _rx(self, tagstr):
+        """Wait for rx packets"""
 
-    # FIXME:
-    # - there is no timeout for any of the socket handling
-
-    data, _ = sock.recvfrom(1024)
-    data = json.loads(data.decode('utf8'))
-    assert(data['_tag'] == tagstr)
-
-    if data['_type'] == 'error':
-        raise ValueError('Error: {}'.format(data['error']))
-
-    assert(data['_type'] == 'begin')
-    assert(data['cmd'] == cmd)
-
-    result = list()
-
-    while True:
-        data, _ = sock.recvfrom(1024)
+        # TODO: there are no timeouts with any of the recv calls
+        data, _ = self.sock.recvfrom(1024)
         data = json.loads(data.decode('utf8'))
+
+        # TODO: We assume the first packet we get will be tagged for us
+        # and be either an "error" or a "begin"
         assert(data['_tag'] == tagstr)
 
         if data['_type'] == 'error':
-            raise ValueError('Error with command {}'.format(cmd))
+            raise ValueError('Error: {}'.format(data['error']))
 
-        if data['_type'] == 'end':
-            return result
+        assert(data['_type'] == 'begin')
 
-        if data['_type'] != 'row':
-            raise ValueError('Unknown data type {} from '
-                             'edge'.format(data['_type']))
+        # Ideally, we would confirm that this is our "begin", but that
+        # would need the cmd passed into this method, and that would
+        # probably require parsing the cmdline passed to us :-(
+        # assert(data['cmd'] == cmd)
 
-        # remove our boring metadata
-        del data['_tag']
-        del data['_type']
+        result = list()
 
-        if debug:
-            print(data)
+        while True:
+            data, _ = self.sock.recvfrom(1024)
+            data = json.loads(data.decode('utf8'))
 
-        result.append(data)
+            if data['_tag'] != tagstr:
+                # this packet is not for us, ignore it
+                continue
+
+            if data['_type'] == 'error':
+                raise ValueError('Error: {}'.format(data['error']))
+
+            if data['_type'] == 'end':
+                return result
+
+            if data['_type'] != 'row':
+                raise ValueError('Unknown data type {} from '
+                                 'edge'.format(data['_type']))
+
+            # remove our boring metadata
+            del data['_tag']
+            del data['_type']
+
+            if self.debug:
+                print(data)
+
+            result.append(data)
+
+    def _call(self, msgtype, cmdline):
+        """Perform a rpc call"""
+        tagstr, msgstr = self._cmdstr(msgtype, cmdline)
+        self.sock.sendto(msgstr.encode('utf8'), (self.address, self.port))
+        return self._rx(tagstr)
+
+    def read(self, cmdline):
+        return self._call('r', cmdline)
+
+    def write(self, cmdline):
+        return self._call('w', cmdline)
 
 
 def str_table(rows, columns):
@@ -97,8 +127,8 @@ def str_table(rows, columns):
     return ''.join(result)
 
 
-def subcmd_show_supernodes(args):
-    rows = send_cmd(args.port, args.debug, args.key, 'super')
+def subcmd_show_supernodes(rpc, args):
+    rows = rpc.read('super')
     columns = [
         'version',
         'current',
@@ -110,8 +140,8 @@ def subcmd_show_supernodes(args):
     return str_table(rows, columns)
 
 
-def subcmd_show_peers(args):
-    rows = send_cmd(args.port, args.debug, args.key, 'peer')
+def subcmd_show_peers(rpc, args):
+    rows = rpc.read('peer')
     columns = [
         'mode',
         'ip4addr',
@@ -123,7 +153,7 @@ def subcmd_show_peers(args):
     return str_table(rows, columns)
 
 
-def subcmd_show_help(args):
+def subcmd_show_help(rpc, args):
     result = 'Commands with pretty-printed output:\n\n'
     for name, cmd in subcmds.items():
         result += "{:12} {}\n".format(name, cmd['help'])
@@ -131,7 +161,7 @@ def subcmd_show_help(args):
     result += "\n"
     result += "Possble remote commands:\n"
     result += "(those without pretty-printer, will pass-through)\n\n"
-    rows = send_cmd(args.port, args.debug, args.key, args.cmd)
+    rows = rpc.read('help')
     result += json.dumps(rows, sort_keys=True, indent=4)
     return result
 
@@ -152,9 +182,13 @@ subcmds = {
 }
 
 
-def subcmd_default(args):
+def subcmd_default(rpc, args):
     """Just pass command through to edge"""
-    rows = send_cmd(args.port, args.debug, args.key, args.cmd)
+    cmdline = args.cmd
+    if args.write:
+        rows = rpc.write(cmdline)
+    else:
+        rows = rpc.read(cmdline)
     return json.dumps(rows, sort_keys=True, indent=4)
 
 
@@ -167,10 +201,13 @@ def main():
                     help='Password for mgmt commands')
     ap.add_argument('-d', '--debug', action='store_true',
                     help='Also show raw internal data')
-    ap.add_argument('--read', action='store_true',
-                    help='Make a read request (default)')
-    ap.add_argument('--write', action='store_false', dest='read',
-                    help='Make a write request')
+
+    group = ap.add_mutually_exclusive_group()
+    group.add_argument('--read', action='store_true',
+                       help='Make a read request (default)')
+    group.add_argument('--write', action='store_true',
+                       help='Make a write request')
+
     ap.add_argument('cmd', action='store',
                     help='Command to run (try "help" for list)')
 
@@ -181,7 +218,11 @@ def main():
     else:
         func = subcmds[args.cmd]['func']
 
-    result = func(args)
+    rpc = JsonUDP(args.port)
+    rpc.debug = args.debug
+    rpc.key = args.key
+
+    result = func(rpc, args)
     print(result)
 
 

--- a/scripts/n2nctl
+++ b/scripts/n2nctl
@@ -21,13 +21,13 @@ def send_cmd(port, debug, key, cmd):
     next_tag = (next_tag + 1) % 1000
 
     if key is not None:
-        tagauth = tagstr + ':' + key
+        options = tagstr + ':1:' + key
     else:
-        tagauth = tagstr
+        options = tagstr
 
     msgtype = "r"
 
-    message = "{} {} {}".format(msgtype, tagauth, cmd).encode('utf8')
+    message = "{} {} {}".format(msgtype, options, cmd).encode('utf8')
     sock.sendto(message, ("127.0.0.1", 5644))
 
     # FIXME:

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -18,70 +18,100 @@ import json
 import socketserver
 import http.server
 import signal
+import functools
 
 from http import HTTPStatus
 
 
-next_tag = 0
+class JsonUDP():
+    """encapsulate communication with the edge"""
 
+    def __init__(self, port):
+        self.address = "127.0.0.1"
+        self.port = port
+        self.tag = 0
+        self.key = None
+        self.debug = False
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-def send_cmd(port, debug, key, cmd):
-    """Send a text command to the edge and process the JSON reply packets"""
-    global next_tag
+    def _next_tag(self):
+        tagstr = str(self.tag)
+        self.tag = (self.tag + 1) % 1000
+        return tagstr
 
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    def _cmdstr(self, msgtype, cmdline):
+        """Create the full command string to send"""
+        tagstr = self._next_tag()
 
-    tagstr = str(next_tag)
-    next_tag = (next_tag + 1) % 1000
+        options = [tagstr]
+        if self.key is not None:
+            options += ['1']  # Flags set for auth key field
+            options += [self.key]
+        optionsstr = ':'.join(options)
 
-    if key is not None:
-        options = tagstr + ':1:' + key
-    else:
-        options = tagstr
+        return tagstr, ' '.join((msgtype, optionsstr, cmdline))
 
-    msgtype = "r"
+    def _rx(self, tagstr):
+        """Wait for rx packets"""
 
-    message = "{} {} {}".format(msgtype, options, cmd).encode('utf8')
-    sock.sendto(message, ("127.0.0.1", 5644))
-
-    # FIXME:
-    # - there is no timeout for any of the socket handling
-
-    data, _ = sock.recvfrom(1024)
-    data = json.loads(data.decode('utf8'))
-    assert(data['_tag'] == tagstr)
-
-    if data['_type'] == 'error':
-        raise ValueError('Error: {}'.format(data['error']))
-
-    assert(data['_type'] == 'begin')
-    assert(data['cmd'] == cmd)
-
-    result = list()
-
-    while True:
-        data, _ = sock.recvfrom(1024)
+        # TODO: there are no timeouts with any of the recv calls
+        data, _ = self.sock.recvfrom(1024)
         data = json.loads(data.decode('utf8'))
+
+        # TODO: We assume the first packet we get will be tagged for us
+        # and be either an "error" or a "begin"
         assert(data['_tag'] == tagstr)
 
         if data['_type'] == 'error':
-            raise ValueError('Error with command {}'.format(cmd))
+            raise ValueError('Error: {}'.format(data['error']))
 
-        if data['_type'] == 'end':
-            return result
+        assert(data['_type'] == 'begin')
 
-        if data['_type'] != 'row':
-            raise ValueError('Unknown data type {} from '
-                             'edge'.format(data['_type']))
+        # Ideally, we would confirm that this is our "begin", but that
+        # would need the cmd passed into this method, and that would
+        # probably require parsing the cmdline passed to us :-(
+        # assert(data['cmd'] == cmd)
 
-        # remove our boring metadata
-        del data['_tag']
-        del data['_type']
+        result = list()
 
-        if debug:
-            print(data)
+        while True:
+            data, _ = self.sock.recvfrom(1024)
+            data = json.loads(data.decode('utf8'))
 
-        result.append(data)
+            if data['_tag'] != tagstr:
+                # this packet is not for us, ignore it
+                continue
+
+            if data['_type'] == 'error':
+                raise ValueError('Error: {}'.format(data['error']))
+
+            if data['_type'] == 'end':
+                return result
+
+            if data['_type'] != 'row':
+                raise ValueError('Unknown data type {} from '
+                                 'edge'.format(data['_type']))
+
+            # remove our boring metadata
+            del data['_tag']
+            del data['_type']
+
+            if self.debug:
+                print(data)
+
+            result.append(data)
+
+    def _call(self, msgtype, cmdline):
+        """Perform a rpc call"""
+        tagstr, msgstr = self._cmdstr(msgtype, cmdline)
+        self.sock.sendto(msgstr.encode('utf8'), (self.address, self.port))
+        return self._rx(tagstr)
+
+    def read(self, cmdline):
+        return self._call('r', cmdline)
+
+    def write(self, cmdline):
+        return self._call('w', cmdline)
 
 
 indexhtml = """
@@ -162,6 +192,10 @@ refresh_job();
 
 class SimpleHandler(http.server.BaseHTTPRequestHandler):
 
+    def __init__(self, rpc, *args, **kwargs):
+        self.rpc = rpc
+        super().__init__(*args, **kwargs)
+
     def log_request(self, code='-', size='-'):
         # Dont spam the output
         pass
@@ -187,7 +221,7 @@ class SimpleHandler(http.server.BaseHTTPRequestHandler):
             # if commands ever need args, use more of the path components
 
             try:
-                data = send_cmd(5644, False, None, cmd)
+                data = self.rpc.read(cmd)
             except ValueError:
                 self._simplereply(HTTPStatus.BAD_REQUEST, 'Bad Command')
                 return
@@ -205,21 +239,27 @@ class SimpleHandler(http.server.BaseHTTPRequestHandler):
 def main():
     ap = argparse.ArgumentParser(
             description='Control the running local n2n edge via http')
-    #  TODO - this needs to pass into the handler object
-    # ap.add_argument('-t', '--mgmtport', action='store', default=5644,
-    #                 help='Management Port (default=5644)')
-    # ap.add_argument('-d', '--debug', action='store_true',
-    #                 help='Also show raw internal data')
+    ap.add_argument('-t', '--mgmtport', action='store', default=5644,
+                    help='Management Port (default=5644)')
+    ap.add_argument('-k', '--key', action='store',
+                    help='Password for mgmt commands')
+    ap.add_argument('-d', '--debug', action='store_true',
+                    help='Also show raw internal data')
     ap.add_argument('port', action='store',
                     default=8080, type=int, nargs='?',
                     help='Serve requests on TCP port (default 8080)')
 
     args = ap.parse_args()
 
+    rpc = JsonUDP(args.mgmtport)
+    rpc.debug = args.debug
+    rpc.key = args.key
+
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
     socketserver.TCPServer.allow_reuse_address = True
-    with socketserver.TCPServer(("", args.port), SimpleHandler) as httpd:
+    handler = functools.partial(SimpleHandler, rpc)
+    with socketserver.TCPServer(("", args.port), handler) as httpd:
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -166,6 +166,11 @@ class SimpleHandler(http.server.BaseHTTPRequestHandler):
         # Dont spam the output
         pass
 
+    def _simplereply(self, number, message):
+        self.send_response(number)
+        self.end_headers()
+        self.wfile.write(message.encode('utf8'))
+
     def do_GET(self):
         url_tail = self.path
 
@@ -184,9 +189,7 @@ class SimpleHandler(http.server.BaseHTTPRequestHandler):
             try:
                 data = send_cmd(5644, False, None, cmd)
             except ValueError:
-                self.send_response(HTTPStatus.BAD_REQUEST)
-                self.end_headers()
-                self.wfile.write(b'Bad Command')
+                self._simplereply(HTTPStatus.BAD_REQUEST, 'Bad Command')
                 return
 
             self.send_response(HTTPStatus.OK)
@@ -195,9 +198,7 @@ class SimpleHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(json.dumps(data).encode('utf8'))
             return
 
-        self.send_response(HTTPStatus.NOT_FOUND)
-        self.end_headers()
-        self.wfile.write(b'Not Found')
+        self._simplereply(HTTPStatus.NOT_FOUND, 'Not Found')
         return
 
 

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -218,8 +218,8 @@ def main():
 
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
+    socketserver.TCPServer.allow_reuse_address = True
     with socketserver.TCPServer(("", args.port), SimpleHandler) as httpd:
-        httpd.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         httpd.serve_forever()
 
 

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -220,7 +220,10 @@ def main():
 
     socketserver.TCPServer.allow_reuse_address = True
     with socketserver.TCPServer(("", args.port), SimpleHandler) as httpd:
-        httpd.serve_forever()
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            return
 
 
 if __name__ == '__main__':

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -33,13 +33,13 @@ def send_cmd(port, debug, key, cmd):
     next_tag = (next_tag + 1) % 1000
 
     if key is not None:
-        tagauth = tagstr + ':' + key
+        options = tagstr + ':1:' + key
     else:
-        tagauth = tagstr
+        options = tagstr
 
     msgtype = "r"
 
-    message = "{} {} {}".format(msgtype, tagauth, cmd).encode('utf8')
+    message = "{} {} {}".format(msgtype, options, cmd).encode('utf8')
     sock.sendto(message, ("127.0.0.1", 5644))
 
     # FIXME:

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -32,17 +32,23 @@ def send_cmd(port, debug, cmd):
     tagstr = str(next_tag)
     next_tag = (next_tag + 1) % 1000
 
-    message = "{} {}".format(cmd, tagstr).encode('utf8')
+    msgtype = "r"
+
+    message = "{} {} {}".format(msgtype, tagstr, cmd).encode('utf8')
     sock.sendto(message, ("127.0.0.1", 5644))
 
     # FIXME:
     # - there is no timeout for any of the socket handling
 
-    begin, _ = sock.recvfrom(1024)
-    begin = json.loads(begin.decode('utf8'))
-    assert(begin['_tag'] == tagstr)
-    assert(begin['_type'] == 'begin')
-    assert(begin['_cmd'] == cmd)
+    data, _ = sock.recvfrom(1024)
+    data = json.loads(data.decode('utf8'))
+    assert(data['_tag'] == tagstr)
+
+    if data['_type'] == 'error':
+        raise ValueError('Error: {}'.format(data['error']))
+
+    assert(data['_type'] == 'begin')
+    assert(data['cmd'] == cmd)
 
     result = list()
 
@@ -51,8 +57,8 @@ def send_cmd(port, debug, cmd):
         data = json.loads(data.decode('utf8'))
         assert(data['_tag'] == tagstr)
 
-        if data['_type'] == 'unknowncmd':
-            raise ValueError('Unknown command {}'.format(cmd))
+        if data['_type'] == 'error':
+            raise ValueError('Error with command {}'.format(cmd))
 
         if data['_type'] == 'end':
             return result
@@ -165,7 +171,7 @@ class SimpleHandler(http.server.BaseHTTPRequestHandler):
 
         if url_tail.startswith("/edge/"):
             tail = url_tail.split('/')
-            cmd = 'j.' + tail[2]
+            cmd = tail[2]
             # if commands ever need args, use more of the path components
 
             try:

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -23,7 +23,7 @@ from http import HTTPStatus
 next_tag = 0
 
 
-def send_cmd(port, debug, cmd):
+def send_cmd(port, debug, key, cmd):
     """Send a text command to the edge and process the JSON reply packets"""
     global next_tag
 
@@ -32,9 +32,14 @@ def send_cmd(port, debug, cmd):
     tagstr = str(next_tag)
     next_tag = (next_tag + 1) % 1000
 
+    if key is not None:
+        tagauth = tagstr + ':' + key
+    else:
+        tagauth = tagstr
+
     msgtype = "r"
 
-    message = "{} {} {}".format(msgtype, tagstr, cmd).encode('utf8')
+    message = "{} {} {}".format(msgtype, tagauth, cmd).encode('utf8')
     sock.sendto(message, ("127.0.0.1", 5644))
 
     # FIXME:
@@ -175,7 +180,7 @@ class SimpleHandler(http.server.BaseHTTPRequestHandler):
             # if commands ever need args, use more of the path components
 
             try:
-                data = send_cmd(5644, False, cmd)
+                data = send_cmd(5644, False, None, cmd)
             except ValueError:
                 self.send_response(HTTPStatus.BAD_REQUEST)
                 self.end_headers()

--- a/scripts/n2nhttpd
+++ b/scripts/n2nhttpd
@@ -17,8 +17,10 @@ import socket
 import json
 import socketserver
 import http.server
+import signal
 
 from http import HTTPStatus
+
 
 next_tag = 0
 
@@ -212,6 +214,8 @@ def main():
                     help='Serve requests on TCP port (default 8080)')
 
     args = ap.parse_args()
+
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
     with socketserver.TCPServer(("", args.port), SimpleHandler) as httpd:
         httpd.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1973,14 +1973,15 @@ static void handleMgmtJson_help (n2n_edge_t *eee, char *udp_buf, struct sockaddr
  *   Writes are possibly dangerous, so they need a fake password
  */
 int handleMgmtJson_auth(struct sockaddr_in sender_sock, enum n2n_mgmt_type type, char *auth, char *argv0, char *argv) {
-    if(type==N2N_MGMT_READ) {
-        return 1;
-    }
-    if(!auth) {
-        /* If we have no auth, we will never compare correctly */
+    if(auth) {
+        /* If we have an auth key, it must match */
+        if(0 == strcmp(auth,"CHANGEME")) {
+            return 1;
+        }
         return 0;
     }
-    if(0 == strcmp(auth,"CHANGEME")) {
+    /* if we dont have an auth key, we can still read */
+    if(type==N2N_MGMT_READ) {
         return 1;
     }
     return 0;


### PR DESCRIPTION
Of note, there is the bare bones of an authentication system for the JSON management API in here - see src/edge_utils.c handleMgmtJson_auth() - which will need improving to be actually useful.  I'm thinking that this could be as simple as a new command line option to set the management password (instead of the current hardcoded "CHANGEME" password)

Since this ended up being a larger patch, I did not include any script renames in it.