### PR TITLE
Fix support for python versions prior to 3.6

### DIFF
--- a/scripts/n2n-httpd
+++ b/scripts/n2n-httpd
@@ -521,11 +521,12 @@ def main():
 
     socketserver.TCPServer.allow_reuse_address = True
     handler = functools.partial(SimpleHandler, rpc, snrpc)
-    with socketserver.TCPServer(("", args.port), handler) as httpd:
-        try:
-            httpd.serve_forever()
-        except KeyboardInterrupt:
-            return
+
+    httpd = socketserver.TCPServer(("", args.port), handler)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        return
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
which do not support a context manager in the socketserver