### PR TITLE
Automatically upload binaries when tagged

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -410,7 +410,7 @@ jobs:
           path: binaries
 
   upload_release:
-    name: Upload artifacts as Release Assets
+    name: Upload Release Assets
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - package_dpkg
@@ -426,7 +426,7 @@ jobs:
         with:
           path: artifacts
 
-      - name: Upload Assets to release
+      - name: Upload Assets to Release
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -408,3 +408,29 @@ jobs:
         with:
           name: binaries
           path: binaries
+
+  upload_release:
+    name: Upload artifacts as Release Assets
+    needs:
+      - package_dpkg
+      - package_rpm
+      - binaries_windows
+      - binaries_macos
+      - binaries_linux_crosscompile
+    runs-on: ubuntu-latest
+
+    steps:
+      - if: startsWith(github.ref, 'refs/tags/')
+        name: Fetch all Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - if: startsWith(github.ref, 'refs/tags/')
+        name: Upload Assets to release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: |
+            artifacts/packages-dpkg/*.deb
+            artifacts/packages-rpm/*.rpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -430,7 +430,7 @@ jobs:
         name: Upload Assets to release
         uses: softprops/action-gh-release@v1
         with:
-          draft: true
+          prerelease: true
           files: |
             artifacts/packages-dpkg/*.deb
             artifacts/packages-rpm/*.rpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -411,6 +411,7 @@ jobs:
 
   upload_release:
     name: Upload artifacts as Release Assets
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - package_dpkg
       - package_rpm
@@ -420,14 +421,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - if: startsWith(github.ref, 'refs/tags/')
-        name: Fetch all Artifacts
+      - name: Fetch all Artifacts
         uses: actions/download-artifact@v2
         with:
           path: artifacts
 
-      - if: startsWith(github.ref, 'refs/tags/')
-        name: Upload Assets to release
+      - name: Upload Assets to release
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true


### PR DESCRIPTION
This new workflow job will activate when the repository has a tag added to it.  It will upload the binary artifacts generated during the workflows as Assets on a github release page.

This creates a more stable and relatively simpler location to direct people at who wish to download binaries.  The most recent (non "prerelease") can be found at a single stable URL:  https://github.com/ntop/n2n/releases/latest

Any release automatically created by this job will be marked as "prerelease", allowing a human to check anything needed before github starts showing the new release as "latest".  The Assets attached to the release can also be deleted, replaced or added to manually if desired.

(I believe this is also providing the desired result for the first half of #851 but is not directly helpful to people requesting beta-test binaries like in #786 until we start tagging minor and patchlevel releases)