### PR TITLE
Fix build system errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -371,7 +371,9 @@ jobs:
           export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
           ./autogen.sh
           export CC=clang
-          ./configure CFLAGS="-target ${{ matrix.arch }}" --host=${{ matrix.arch }}
+          export CFLAGS="-target ${{ matrix.arch }}"
+          export LDFLAGS="-target ${{ matrix.arch }}"
+          ./configure --host=${{ matrix.arch }}
           make
 
       - if: ${{ failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -367,6 +367,7 @@ jobs:
         shell: bash
         run: |
           ./autogen.sh
+          export CC=clang
           ./configure CFLAGS="-target ${{ matrix.arch }}" --host=${{ matrix.arch }}
           make
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -418,6 +418,7 @@ jobs:
 
       - name: Install cross compiler
         run: |
+          sudo apt-get update
           sudo apt-get install \
             binutils-${{ matrix.arch }} \
             gcc-${{ matrix.arch }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -354,14 +354,19 @@ jobs:
       matrix:
         arch:
           - x86_64-apple-macos
-          - arm64-apple-macos
+
+          # the config.log shows "missing required architecture arm64"
+          # when using the github runner.  I have not found any CLI method
+          # to request the architecture be installed, so need to turn this
+          # architecture off :-(
+          #
+          # - arm64-apple-macos
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Install packages needed for build
         run: |
-          xcode-select --install
           brew install automake
 
       - name: Configure and Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -391,7 +391,7 @@ jobs:
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: binaries-${{ matrix.arch }}
+          name: binaries
           path: binaries
 
   binaries_macos_universal:
@@ -427,7 +427,7 @@ jobs:
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: binaries-${{ matrix.arch }}
+          name: binaries
           path: binaries
 
   binaries_linux_crosscompile:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -349,6 +349,12 @@ jobs:
     needs:
       - test_macos
     runs-on: macos-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        arch:
+          - x86_64-apple-macos
+          - arm64-apple-macos
 
     steps:
       - uses: actions/checkout@v2
@@ -361,7 +367,7 @@ jobs:
         shell: bash
         run: |
           ./autogen.sh
-          ./configure
+          ./configure CFLAGS="-target ${{ matrix.arch }}" --host=${{ matrix.arch }}
           make
 
       - name: Create binary dir
@@ -372,7 +378,7 @@ jobs:
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: binaries
+          name: binaries-${{ matrix.arch }}
           path: binaries
 
   binaries_linux_crosscompile:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,6 +253,7 @@ jobs:
 
       - name: Install packages needed for build
         run: |
+          sudo apt-get update
           sudo apt-get install debhelper build-essential \
             crossbuild-essential-${{ matrix.arch }}
 
@@ -345,7 +346,7 @@ jobs:
           path: binaries
 
   binaries_macos:
-    name: Binaries for MacOS (x86_64-apple-darwin)
+    name: Binaries for MacOS
     needs:
       - test_macos
     runs-on: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -354,13 +354,7 @@ jobs:
       matrix:
         arch:
           - x86_64-apple-macos
-
-          # the config.log shows "missing required architecture arm64"
-          # when using the github runner.  I have not found any CLI method
-          # to request the architecture be installed, so need to turn this
-          # architecture off :-(
-          #
-          # - arm64-apple-macos
+          - arm64-apple-macos
 
     steps:
       - uses: actions/checkout@v2
@@ -372,6 +366,8 @@ jobs:
       - name: Configure and Build
         shell: bash
         run: |
+          # this is a hack! it assumes the default SDK is the 'right' one
+          export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
           ./autogen.sh
           export CC=clang
           ./configure CFLAGS="-target ${{ matrix.arch }}" --host=${{ matrix.arch }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -361,6 +361,7 @@ jobs:
 
       - name: Install packages needed for build
         run: |
+          xcode-select --install
           brew install automake
 
       - name: Configure and Build
@@ -375,7 +376,7 @@ jobs:
         name: Upload config.log output
         uses: actions/upload-artifact@v2
         with:
-          name: config-log-${{matrix.os}}
+          name: config-log-${{ matrix.arch }}
           path: config.log
 
       - name: Create binary dir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -394,6 +394,42 @@ jobs:
           name: binaries-${{ matrix.arch }}
           path: binaries
 
+  binaries_macos_universal:
+    name: Binaries for MacOS (universal arch)
+    needs:
+      - test_macos
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install packages needed for build
+        run: |
+          brew install automake
+
+      - name: Configure and Build
+        shell: bash
+        run: |
+          # this is a hack! it assumes the default SDK is the 'right' one
+          export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+          ./autogen.sh
+          export CC=clang
+          export CFLAGS="-arch x86_64 -arch arm64"
+          export LDFLAGS="-arch x86_64 -arch arm64"
+          ./configure
+          make
+
+      - name: Create binary dir
+        shell: bash
+        run: |
+          make install DESTDIR=binaries/universal-apple-darwin
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: binaries-${{ matrix.arch }}
+          path: binaries
+
   binaries_linux_crosscompile:
     name: Binaries for linux
     needs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -487,6 +487,7 @@ jobs:
       - package_rpm
       - binaries_windows
       - binaries_macos
+      - binaries_macos_universal
       - binaries_linux_crosscompile
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -386,7 +386,7 @@ jobs:
       - name: Create binary dir
         shell: bash
         run: |
-          make install DESTDIR=binaries/x86_64-apple-darwin
+          make install DESTDIR=binaries/${{ matrix.arch }}
 
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -371,6 +371,13 @@ jobs:
           ./configure CFLAGS="-target ${{ matrix.arch }}" --host=${{ matrix.arch }}
           make
 
+      - if: ${{ failure() }}
+        name: Upload config.log output
+        uses: actions/upload-artifact@v2
+        with:
+          name: config-log-${{matrix.os}}
+          path: config.log
+
       - name: Create binary dir
         shell: bash
         run: |


### PR DESCRIPTION
The github runners have an inconsistent package database, so this pull adds the needed `apt-get update` lines.
It also includes some macos cross compile builder additions.