### PR TITLE
Only trigger automatic release process on annotated tags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -479,8 +479,12 @@ jobs:
           name: binaries
           path: binaries
 
-  upload_release:
-    name: Upload Release Assets
+  # Given the clearly documented use of annotated tags to signal releases,
+  # it seems strange that there is no simple way to trigger actions if the
+  # tag is annotated.  So we need to jump through some hoops.
+  #
+  get_tagtype:
+    name: Get the type of Tag
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - package_dpkg
@@ -489,6 +493,18 @@ jobs:
       - binaries_macos
       - binaries_macos_universal
       - binaries_linux_crosscompile
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set variable
+        run: |
+          echo '::set-output name=TAGTYPE::$(git cat-file -t $GITHUB_REF)'
+
+  upload_release:
+    name: Upload Release Assets
+    if: steps.get_tagtype.outputs.TAGTYPE == 'tag'
+    needs:
+      - get_tagtype
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -483,8 +483,8 @@ jobs:
   # it seems strange that there is no simple way to trigger actions if the
   # tag is annotated.  So we need to jump through some hoops.
   #
-  get_tagtype:
-    name: Get the type of Tag
+  upload_release:
+    name: Upload Release Assets
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - package_dpkg
@@ -496,24 +496,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set variable
+      - name: Get Tag Type
         run: |
           echo '::set-output name=TAGTYPE::$(git cat-file -t $GITHUB_REF)'
 
-  upload_release:
-    name: Upload Release Assets
-    if: steps.get_tagtype.outputs.TAGTYPE == 'tag'
-    needs:
-      - get_tagtype
-    runs-on: ubuntu-latest
-
     steps:
       - name: Fetch all Artifacts
+        if: steps.get_tagtype.outputs.TAGTYPE == 'tag'
         uses: actions/download-artifact@v2
         with:
           path: artifacts
 
       - name: Upload Assets to Release
+        if: steps.get_tagtype.outputs.TAGTYPE == 'tag'
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -500,7 +500,6 @@ jobs:
         run: |
           echo '::set-output name=TAGTYPE::$(git cat-file -t $GITHUB_REF)'
 
-    steps:
       - name: Fetch all Artifacts
         if: steps.get_tagtype.outputs.TAGTYPE == 'tag'
         uses: actions/download-artifact@v2


### PR DESCRIPTION
There are well documented differences and expected use cases for lightweight and annotated tags - this PR simply makes the automation follow those expectations.

(Unfortunately, github does have any visible difference in the UI between the two types of tags)