### PR TITLE
Only trigger automatic release process on annotated tags - Take two

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -514,8 +514,9 @@ jobs:
       #
       - name: Checkout
         run: |
-          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY $GITHUB_WORKSPACE
-          echo git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY $GITHUB_WORKSPACE
+          git init .
+          git remote add origin GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+          git fetch --tags origin +$GITHUB_SHA:$GITHUB_REF
 
       - name: Get Tag Type
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -502,6 +502,8 @@ jobs:
         run: |
           TAGTYPE=$(git cat-file -t $GITHUB_REF)
           echo TAGTYPE=$TAGTYPE
+          echo REF=$GITHUB_REF
+          git for-each-ref refs/tags
           echo "::set-output name=TAGTYPE::$TAGTYPE"
 
       - name: Fetch all Artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -508,12 +508,12 @@ jobs:
       # We build a workaround
       - name: Get Tag Type
         run: |
-          if git cat-file tag $GITHUB_REF; then TAGTYPE=tag; else TAGTYPE=commit; fi
-          echo "::set-output name=TAGTYPE::$TAGTYPE"
+          if git cat-file tag $GITHUB_REF; then TYPE=tag; else TYPE=commit; fi
+          echo "::set-output name=TAGTYPE::$TYPE"
 
           echo ================Debug
           echo REF=$GITHUB_REF
-          echo TAGTYPE=$TAGTYPE
+          echo TAGTYPE=$TYPE
           echo ================
           echo git for-each-ref refs/tags
           git for-each-ref refs/tags
@@ -521,8 +521,8 @@ jobs:
           echo git for-each-ref refs/heads
           git for-each-ref refs/heads
           echo ================
-          echo git cat-file $TAGTYPE $GITHUB_REF
-          git cat-file $TAGTYPE $GITHUB_REF
+          echo git cat-file $TYPE $GITHUB_REF
+          git cat-file $TYPE $GITHUB_REF
           echo ================
 
       - name: Fetch all Artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -495,24 +495,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-
-      # There is something strange with the github runners
-      # normally, `git for-each-ref refs/tags` will show annotated tags
-      # with a type of "tag" and lightweight with type "commit".
-      # But not in the github runner environment...
-      #
-      # Additionally, it seems that if you push both a commit and an annotated
-      # tag at the same time, two workflow actions start (as expected), and
-      # the annotated tag is visible in the "commit" action, but looks like a
-      # lightweight tag in the "tag" action
+      # There is something strange with the repo that you end up with
+      # using actions/checkout@v2.
       #
       # It appears that the repository that is checked out as part of a tag
       # action does not have the correct tag object in it.  As a work around,
-      # we do a force pull of the repo to get the correct tag details.
+      # we dont use the actions/checkout@v2
+      #
+      # Normally, `git for-each-ref refs/tags` will show annotated tags
+      # with a type of "tag" and lightweight with type "commit".
+      # But not with this checkout
+      #
+      # Additionally, it seems that if you push both a commit and an annotated
+      # tag at the same time, two workflow actions start (as expected), and
+      # the two checkouts show different things:
+      # - the annodated tag is visible in the "commit" action
+      # - but it looks like a lightweight tag in the "tag" action
+      #
+      - name: Checkout
+        run: |
+          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY $GITHUB_WORKSPACE
+
       - name: Get Tag Type
         run: |
-          git pull --no-rebase --tags --force origin HEAD
           TYPE=$(git cat-file -t $GITHUB_REF)
           echo "::set-output name=TAGTYPE::$TYPE"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -498,7 +498,9 @@ jobs:
     steps:
       - name: Get Tag Type
         run: |
-          echo '::set-output name=TAGTYPE::$(git cat-file -t $GITHUB_REF)'
+          TAGTYPE=$(git cat-file -t $GITHUB_REF)
+          echo TAGTYPE=$TAGTYPE
+          echo "::set-output name=TAGTYPE::$TAGTYPE"
 
       - name: Fetch all Artifacts
         if: steps.get_tagtype.outputs.TAGTYPE == 'tag'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -512,7 +512,7 @@ jobs:
       # we do a force pull of the repo to get the correct tag details.
       - name: Get Tag Type
         run: |
-          git pull --tags --force origin HEAD
+          git pull --no-rebase --tags --force origin HEAD
           TYPE=$(git cat-file -t $GITHUB_REF)
           echo "::set-output name=TAGTYPE::$TYPE"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -531,7 +531,7 @@ jobs:
           TYPE=$(git cat-file -t $GITHUB_REF)
           echo ==========
           echo REF=$GITHUB_REF
-          echo TAGTYPE=$GITHUB_REF
+          echo TAGTYPE=$TYPE
           echo ==========
           echo git cat-file $TYPE $GITHUB_REF
           git cat-file $TYPE $GITHUB_REF
@@ -575,7 +575,7 @@ jobs:
           echo "::set-output name=TAGTYPE::$TYPE"
           echo ==========
           echo REF=$GITHUB_REF
-          echo TAGTYPE=$GITHUB_REF
+          echo TAGTYPE=$TYPE
 
       - name: Fetch all Artifacts
         if: steps.get_tagtype.outputs.TAGTYPE == 'tag'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -513,6 +513,9 @@ jobs:
       # - the annodated tag is visible in the "commit" action
       # - but it looks like a lightweight tag in the "tag" action
       #
+      # See https://github.com/actions/checkout/issues/290 for a whole lot of
+      # 'no comment' from github
+      #
       - name: Checkout
         run: |
           git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -502,10 +502,19 @@ jobs:
       - name: Get Tag Type
         run: |
           TAGTYPE=$(git cat-file -t $GITHUB_REF)
-          echo TAGTYPE=$TAGTYPE
-          echo REF=$GITHUB_REF
-          git for-each-ref refs/tags
           echo "::set-output name=TAGTYPE::$TAGTYPE"
+          echo ================Debug
+          echo REF=$GITHUB_REF
+          echo TAGTYPE=$TAGTYPE
+          echo git for-each-ref refs/tags
+          git for-each-ref refs/tags
+          echo ================
+          echo git for-each-ref refs/heads
+          git for-each-ref refs/heads
+          echo ================
+          echo git cat-file $TAGTYPE $GITHUB_REF
+          git cat-file $TAGTYPE $GITHUB_REF
+          echo ================
 
       - name: Fetch all Artifacts
         if: steps.get_tagtype.outputs.TAGTYPE == 'tag'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -499,13 +499,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      # There is something strange with the github runners
+      # normally, `git for-each-ref refs/tags` will show annotated tags
+      # with a type of "tag" and lightweight with type "commit".
+      # But not in the github runner environment...
+      # So, instead of:
+      #    TAGTYPE=$(git cat-file -t $GITHUB_REF)
+      # We build a workaround
       - name: Get Tag Type
         run: |
-          TAGTYPE=$(git cat-file -t $GITHUB_REF)
+          git cat-file tag $GITHUB_REF
+          if $? -eq 0; then TAGTYPE=tag; else TAGTYPE=commit; fi
           echo "::set-output name=TAGTYPE::$TAGTYPE"
+
           echo ================Debug
           echo REF=$GITHUB_REF
           echo TAGTYPE=$TAGTYPE
+          echo ================
           echo git for-each-ref refs/tags
           git for-each-ref refs/tags
           echo ================

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -524,6 +524,9 @@ jobs:
           echo git cat-file $TYPE $GITHUB_REF
           git cat-file $TYPE $GITHUB_REF
           echo ================
+          echo cat .git/$GITHUB_REF
+          cat .git/$GITHUB_REF
+          echo ================
 
       - name: Fetch all Artifacts
         if: steps.get_tagtype.outputs.TAGTYPE == 'tag'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -503,11 +503,18 @@ jobs:
       # normally, `git for-each-ref refs/tags` will show annotated tags
       # with a type of "tag" and lightweight with type "commit".
       # But not in the github runner environment...
+      #
+      # Additionally, it seems that if you push both a commit and an annotated
+      # tag at the same time, two workflow actions start (as expected), and
+      # the annotated tag is visible in the "commit" action, but looks like a
+      # lightweight tag in the "tag" action
+      #
       # So, instead of:
       #    TAGTYPE=$(git cat-file -t $GITHUB_REF)
-      # We build a workaround
+      # We try to build a workaround
       - name: Get Tag Type
         run: |
+          git pull --tags
           if git cat-file tag $GITHUB_REF; then TYPE=tag; else TYPE=commit; fi
           echo "::set-output name=TAGTYPE::$TYPE"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -514,6 +514,41 @@ jobs:
   # This workflow has added a `git fetch --force --tags` to every job that
   # needs to have working tags
   #
+  get_tagtype:
+    name: Get type of Tag
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fix Checkout
+        run: |
+          git fetch --force --tags
+
+      - name: Debug data for Get Tag Type
+        run: |
+          TYPE=$(git cat-file -t $GITHUB_REF)
+          echo ==========
+          echo REF=$GITHUB_REF
+          echo TAGTYPE=$GITHUB_REF
+          echo ==========
+          echo git cat-file $TYPE $GITHUB_REF
+          git cat-file $TYPE $GITHUB_REF
+          echo ==========
+          echo ls .git/refs/heads
+          ls .git/refs/heads
+          echo ==========
+          echo ls .git/refs/tags
+          ls .git/refs/tags
+          echo ==========
+          echo git for-each-ref refs/heads
+          git for-each-ref refs/heads
+          echo ==========
+          echo git for-each-ref refs/tags
+          git for-each-ref refs/tags
+
+
   upload_release:
     name: Upload Release Assets
     if: startsWith(github.ref, 'refs/tags/')
@@ -534,27 +569,13 @@ jobs:
           git fetch --force --tags
 
       - name: Get Tag Type
+        id: get_tagtype
         run: |
           TYPE=$(git cat-file -t $GITHUB_REF)
           echo "::set-output name=TAGTYPE::$TYPE"
           echo ==========
           echo REF=$GITHUB_REF
           echo TAGTYPE=$GITHUB_REF
-          echo ==========
-          echo git cat-file $GITHUB_REF
-          git cat-file $GITHUB_REF
-          echo ==========
-          echo ls .git/refs/heads
-          ls .git/refs/heads
-          echo ==========
-          echo ls .git/refs/tags
-          ls .git/refs/tags
-          echo ==========
-          echo git for-each-ref refs/heads
-          git for-each-ref refs/heads
-          echo ==========
-          echo git for-each-ref refs/tags
-          git for-each-ref refs/tags
 
       - name: Fetch all Artifacts
         if: steps.get_tagtype.outputs.TAGTYPE == 'tag'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -496,6 +496,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
+
       - name: Get Tag Type
         run: |
           TAGTYPE=$(git cat-file -t $GITHUB_REF)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -508,8 +508,7 @@ jobs:
       # We build a workaround
       - name: Get Tag Type
         run: |
-          git cat-file tag $GITHUB_REF
-          if $? -eq 0; then TAGTYPE=tag; else TAGTYPE=commit; fi
+          if git cat-file tag $GITHUB_REF; then TAGTYPE=tag; else TAGTYPE=commit; fi
           echo "::set-output name=TAGTYPE::$TAGTYPE"
 
           echo ================Debug

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -496,6 +496,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Get Tag Type
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -537,6 +537,24 @@ jobs:
         run: |
           TYPE=$(git cat-file -t $GITHUB_REF)
           echo "::set-output name=TAGTYPE::$TYPE"
+          echo ==========
+          echo REF=$GITHUB_REF
+          echo TAGTYPE=$GITHUB_REF
+          echo ==========
+          echo git cat-file $GITHUB_REF
+          git cat-file $GITHUB_REF
+          echo ==========
+          echo ls .git/refs/heads
+          ls .git/refs/heads
+          echo ==========
+          echo ls .git/refs/tags
+          ls .git/refs/tags
+          echo ==========
+          echo git for-each-ref refs/heads
+          git for-each-ref refs/heads
+          echo ==========
+          echo git for-each-ref refs/tags
+          git for-each-ref refs/tags
 
       - name: Fetch all Artifacts
         if: steps.get_tagtype.outputs.TAGTYPE == 'tag'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -515,7 +515,7 @@ jobs:
       - name: Checkout
         run: |
           git init .
-          git remote add origin GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+          git remote add origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
           git fetch --tags origin +$GITHUB_SHA:$GITHUB_REF
 
       - name: Get Tag Type

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -507,13 +507,13 @@ jobs:
       # the annotated tag is visible in the "commit" action, but looks like a
       # lightweight tag in the "tag" action
       #
-      # So, instead of:
-      #    TAGTYPE=$(git cat-file -t $GITHUB_REF)
-      # We try to build a workaround
+      # It appears that the repository that is checked out as part of a tag
+      # action does not have the correct tag object in it.  As a work around,
+      # we do a force pull of the repo to get the correct tag details.
       - name: Get Tag Type
         run: |
-          git pull --tags --force
-          if git cat-file tag $GITHUB_REF; then TYPE=tag; else TYPE=commit; fi
+          git pull --tags --force origin HEAD
+          TYPE=$(git cat-file -t $GITHUB_REF)
           echo "::set-output name=TAGTYPE::$TYPE"
 
           echo ================Debug

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -515,9 +515,16 @@ jobs:
       - name: Checkout
         run: |
           git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY $GITHUB_WORKSPACE
+          echo git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY $GITHUB_WORKSPACE
 
       - name: Get Tag Type
         run: |
+          echo ================Debug
+          echo ls .git/refs/heads
+          ls .git/refs/heads
+          echo ls .git/refs/tags
+          ls .git/refs/tags
+          echo ================
           TYPE=$(git cat-file -t $GITHUB_REF)
           echo "::set-output name=TAGTYPE::$TYPE"
 
@@ -534,8 +541,8 @@ jobs:
           echo git cat-file $TYPE $GITHUB_REF
           git cat-file $TYPE $GITHUB_REF
           echo ================
-          echo cat .git/$GITHUB_REF
-          cat .git/$GITHUB_REF
+          echo cat .git/$GITHUB_REF || true
+          cat .git/$GITHUB_REF || true
           echo ================
 
       - name: Fetch all Artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,6 +251,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix Checkout
+        run: |
+          git fetch --force --tags
+
       - name: Install packages needed for build
         run: |
           sudo apt-get update
@@ -293,6 +297,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix Checkout
+        run: |
+          git fetch --force --tags
+
       - name: Install packages needed for build
         run: |
           sudo apt-get install rpm
@@ -328,6 +336,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Fix Checkout
+        run: |
+          git fetch --force --tags
+
       - name: Configure and Build
         shell: bash
         run: |
@@ -359,6 +371,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Fix Checkout
+        run: |
+          git fetch --force --tags
 
       - name: Install packages needed for build
         run: |
@@ -402,6 +418,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Fix Checkout
+        run: |
+          git fetch --force --tags
 
       - name: Install packages needed for build
         run: |
@@ -452,6 +472,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Fix Checkout
+        run: |
+          git fetch --force --tags
+
       - name: Install cross compiler
         run: |
           sudo apt-get update
@@ -481,7 +505,14 @@ jobs:
 
   # Given the clearly documented use of annotated tags to signal releases,
   # it seems strange that there is no simple way to trigger actions if the
-  # tag is annotated.  So we need to jump through some hoops.
+  # tag is annotated.  So we need to jump through some extra hoops.
+  #
+  # Looking at https://github.com/actions/checkout/issues/290 seems to show
+  # that github just doesnt care about how git expects annotated tags to be
+  # used.
+  #
+  # This workflow has added a `git fetch --force --tags` to every job that
+  # needs to have working tags
   #
   upload_release:
     name: Upload Release Assets
@@ -496,29 +527,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # There is something strange with the repo that you end up with
-      # using actions/checkout@v2.
-      #
-      # It appears that the repository that is checked out as part of a tag
-      # action does not have the correct tag object in it.  As a work around,
-      # we dont use the actions/checkout@v2
-      #
-      # Normally, `git for-each-ref refs/tags` will show annotated tags
-      # with a type of "tag" and lightweight with type "commit".
-      # But not with the actions/checkout@v2 checkout
-      #
-      # Additionally, it seems that if you push both a commit and an annotated
-      # tag at the same time, two workflow actions start (as expected), and
-      # the two checkouts show different things:
-      # - the annodated tag is visible in the "commit" action
-      # - but it looks like a lightweight tag in the "tag" action
-      #
-      # See https://github.com/actions/checkout/issues/290 for a whole lot of
-      # 'no comment' from github
-      #
-      - name: Checkout
+      - uses: actions/checkout@v2
+
+      - name: Fix Checkout
         run: |
-          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY .
+          git fetch --force --tags
 
       - name: Get Tag Type
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -496,8 +496,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       # There is something strange with the github runners
       # normally, `git for-each-ref refs/tags` will show annotated tags
@@ -514,7 +512,7 @@ jobs:
       # We try to build a workaround
       - name: Get Tag Type
         run: |
-          git pull --tags
+          git pull --tags --force
           if git cat-file tag $GITHUB_REF; then TYPE=tag; else TYPE=commit; fi
           echo "::set-output name=TAGTYPE::$TYPE"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -513,41 +513,6 @@ jobs:
   #
   # This workflow has added a `git fetch --force --tags` to every job that
   # needs to have working tags
-  #
-  get_tagtype:
-    name: Get type of Tag
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Fix Checkout
-        run: |
-          git fetch --force --tags
-
-      - name: Debug data for Get Tag Type
-        run: |
-          TYPE=$(git cat-file -t $GITHUB_REF)
-          echo ==========
-          echo REF=$GITHUB_REF
-          echo TAGTYPE=$TYPE
-          echo ==========
-          echo git cat-file $TYPE $GITHUB_REF
-          git cat-file $TYPE $GITHUB_REF
-          echo ==========
-          echo ls .git/refs/heads
-          ls .git/refs/heads
-          echo ==========
-          echo ls .git/refs/tags
-          ls .git/refs/tags
-          echo ==========
-          echo git for-each-ref refs/heads
-          git for-each-ref refs/heads
-          echo ==========
-          echo git for-each-ref refs/tags
-          git for-each-ref refs/tags
-
 
   upload_release:
     name: Upload Release Assets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -485,6 +485,7 @@ jobs:
   #
   upload_release:
     name: Upload Release Assets
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - package_dpkg
       - package_rpm
@@ -504,7 +505,7 @@ jobs:
       #
       # Normally, `git for-each-ref refs/tags` will show annotated tags
       # with a type of "tag" and lightweight with type "commit".
-      # But not with this checkout
+      # But not with the actions/checkout@v2 checkout
       #
       # Additionally, it seems that if you push both a commit and an annotated
       # tag at the same time, two workflow actions start (as expected), and
@@ -515,36 +516,12 @@ jobs:
       - name: Checkout
         run: |
           git init .
-          git remote add origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
-          git fetch --tags origin +$GITHUB_SHA:$GITHUB_REF
+          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
 
       - name: Get Tag Type
         run: |
-          echo ================Debug
-          echo ls .git/refs/heads
-          ls .git/refs/heads
-          echo ls .git/refs/tags
-          ls .git/refs/tags
-          echo ================
           TYPE=$(git cat-file -t $GITHUB_REF)
           echo "::set-output name=TAGTYPE::$TYPE"
-
-          echo ================Debug
-          echo REF=$GITHUB_REF
-          echo TAGTYPE=$TYPE
-          echo ================
-          echo git for-each-ref refs/tags
-          git for-each-ref refs/tags
-          echo ================
-          echo git for-each-ref refs/heads
-          git for-each-ref refs/heads
-          echo ================
-          echo git cat-file $TYPE $GITHUB_REF
-          git cat-file $TYPE $GITHUB_REF
-          echo ================
-          echo cat .git/$GITHUB_REF || true
-          cat .git/$GITHUB_REF || true
-          echo ================
 
       - name: Fetch all Artifacts
         if: steps.get_tagtype.outputs.TAGTYPE == 'tag'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -485,7 +485,6 @@ jobs:
   #
   upload_release:
     name: Upload Release Assets
-    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - package_dpkg
       - package_rpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -515,8 +515,7 @@ jobs:
       #
       - name: Checkout
         run: |
-          git init .
-          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY .
 
       - name: Get Tag Type
         run: |


### PR DESCRIPTION
Github's actions/checkout@v2 helper simply throws away the annotated tag data, discovering this required a bunch of testing.

See https://github.com/actions/checkout/issues/290 for some more discussion