### PR TITLE
added MAC address based supernode selection

### DIFF
--- a/edge.8
+++ b/edge.8
@@ -105,6 +105,10 @@ compress outgoing data packets, -z1 = lzo1x, disabled by default
 \fB\-\-select-rtt\fR
 select supernode by round trip time if several to choose from (federation),
 defaults to load-based selection strategy if not provided.
+.TP
+\fB\-\-select-mac\fR
+select supernode by MAC address if several to choose from (federation),
+lowest MAC address first.
 .SH TAP DEVICE AND OVERLAY NETWORK CONFIGURATION
 .TP
 \fB\-a \fR[\fImode\fR]<\fIip\fR>[\fI/n\fR]

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -288,7 +288,7 @@ typedef char n2n_version_t[N2N_VERSION_STRING_SIZE];
 
 #define SN_SELECTION_STRATEGY_LOAD       1
 #define SN_SELECTION_STRATEGY_RTT        2
-#define SN_SELECTION_STRATEGY_MAC        3 /* REVISIT: not implemented yet */
+#define SN_SELECTION_STRATEGY_MAC        3
 
 
 typedef struct n2n_ip_subnet {

--- a/src/edge.c
+++ b/src/edge.c
@@ -232,6 +232,7 @@ static void help (int level) {
           "\n                      [-r]  enable packet forwarding through n2n community"
           "\n                      [-E]  accept multicast MAC addresses"
           "\n            [--select-rtt]  select supernode by round trip time"
+          "\n            [--select-mac]  select supernode by MAC address"
 #ifndef WIN32
           "\n                      [-f]  do not fork but run in foreground"
 #endif
@@ -290,7 +291,8 @@ static void help (int level) {
                                      "-z2 = zstd, "
 #endif
                                      "disabled by default\n");
-        printf("--select-rtt       | supernode selection based on round trip time (default:\n"
+        printf("--select-rtt       | supernode selection based on round trip time\n"
+               "--select-mac       | supernode selection based on MAC address (default:\n"
                "                   | by load)\n");
 
         printf ("\n");
@@ -737,7 +739,14 @@ static int setOption (int optkey, char *optargument, n2n_tuntap_priv_config_t *e
             break;
         }
 
-        case ']': /* password for management port */ {
+        case ']': /* mac-address-based supernode selection strategy */ {
+            // overwrites the default load-based strategy
+            conf->sn_selection_strategy = SN_SELECTION_STRATEGY_MAC;
+
+            break;
+        }
+
+        case '{': /* password for management port */ {
             conf->mgmt_password_hash = pearson_hash_64((uint8_t*)optargument, strlen(optargument));
 
             break;
@@ -797,7 +806,8 @@ static const struct option long_options[] =
         { "verbose",             no_argument,       NULL, 'v' },
         { "help",                no_argument,       NULL, '@' }, /* internal special character '@' to identify long help case */
         { "select-rtt",          no_argument,       NULL, '[' }, /*                            '['             rtt selection strategy */
-        { "management-password", required_argument, NULL, ']' }, /*                            ']'             management port password */
+        { "select-mac",          no_argument,       NULL, ']' }, /*                            ']'             mac selection strategy */
+        { "management-password", required_argument, NULL, '{' }, /*                            '{'             management port password */
         { NULL,                  0,                 NULL,  0  }
     };
 


### PR DESCRIPTION
This PR adds a supernode selection scheme `--select-mac` to the edge selecting the supernode by its MAC address, lowest MAC address preferred. Note that supernodes' MAC addresses can optionally be set manually using `-m`. This allows implementation of fixed "main" and further "backup" supernodes.

~~This feature requires compilation with `-DSN_MANUAL_MAC` set.~~ _changed by #886_

Please keep in mind that the first sorting happens after some 30 seconds at the edge, so first connection still might go to another supernode.

Closes #860.