### PR TITLE
allowed supernode MAC address to be set manually (-m)

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -31,6 +31,8 @@
     tunctl -u UID -t tunX
 */
 
+#define SN_MANUAL_MAC   /* allows supernode MAC address to be set manually */
+
 #define N2N_HAVE_DAEMON /* needs to be defined before it gets undefined */
 #define N2N_HAVE_TCP    /* needs to be defined before it gets undefined */
 


### PR DESCRIPTION
defining the corresponding macro (**no** backport to 3.0 intended).