### PR TITLE
Change when version.sh chooses a fallback vresion

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -10,10 +10,16 @@ usage() {
     exit 0
 }
 
-VER_FILE_DIR=$(dirname "$0")/..
-VER_FILE_SHORT=$(cat "${VER_FILE_DIR}/VERSION")
+# We assume this script is in the TOPDIR/scripts directory and use that
+# to find any other files we need
+TOPDIR=$(dirname "$0")/..
 
-if git status >/dev/null; then
+VER_FILE_SHORT=$(cat "${TOPDIR}/VERSION")
+
+if [ -d "$TOPDIR/.git" ]; then
+    # If there is a .git directory in our TOPDIR, then this is assumed to be
+    # real git checkout
+
     VER_GIT_SHORT=$(git describe --abbrev=0)
 
     if [ "$VER_FILE_SHORT" != "$VER_GIT_SHORT" ]; then
@@ -25,6 +31,9 @@ if git status >/dev/null; then
     VER_HASH=$(git rev-parse --short HEAD)
     VER=$(git describe --abbrev=7 --dirty)
 else
+    # If there is no .git directory in our TOPDIR, we fall back on relying on
+    # the VERSION file
+
     VER_SHORT="$VER_FILE_SHORT"
     VER_HASH="HEAD"
     VER="$VER_FILE_SHORT"


### PR DESCRIPTION
We aim to always build with the full version number from the git
checkout, however if the current build is not being made from a git
repository, we need to fallback to using the version number from
the "VERSION" file.

This patch changes the choice of the fallback path from just assuming
that any git repo is our git repo to explicitly looking for a `.git` dir
in the top of our checkout.

Some integrated build systems end up doing a tar extract of the n2n
source code inside their build-system git repo, and the old fallback
check was failing in that case.

We still need to identify these build systems and work out a way to
provide them with the full and correct version number for their build,
but this patch should make things more reliable until then.