### PR TITLE
differentiated miniupnp includes

### DIFF
--- a/include/n2n_port_mapping.h
+++ b/include/n2n_port_mapping.h
@@ -4,9 +4,17 @@
 #include <stdint.h>
 
 #ifdef HAVE_MINIUPNP
+#ifdef CMAKE_BUILD
+// CMAKE uses static linked lib as submodule which requires different includes than
+//       the dynamically linked, intalled library in case of plain make
+#include <miniupnpc.h>
+#include <upnpcommands.h>
+#include <upnperrors.h>
+#else
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>
 #include <miniupnpc/upnperrors.h>
+#endif // CMAKE_BUILD
 #endif // HAVE_MINIUPNP
 
 


### PR DESCRIPTION
Dynamically linking installed miniupnp library (in case of `make`) seems to require slightly different includes than the statically linked library when included as submodule (in case of `CMake`).

Fixes #908.