### PR TITLE
Autoconf simplification

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           export CFLAGS="-fprofile-arcs -ftest-coverage"
           export LDFLAGS="--coverage"
-          ./configure --with-zstd
+          ./configure
         shell: bash
 
       - name: Run embedded tests
@@ -158,7 +158,7 @@ jobs:
         run: |
           export CFLAGS="-fprofile-arcs -ftest-coverage"
           export LDFLAGS="--coverage"
-          ./configure --with-zstd
+          ./configure
         shell: bash
 
       - name: Run embedded tests

--- a/configure.ac
+++ b/configure.ac
@@ -141,22 +141,11 @@ dnl> wget -O config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=bl
 fi
 AC_DEFINE_UNQUOTED(PACKAGE_OSNAME, "${OSNAME}", [OS name])
 
-if test $MACHINE = "x86_64"; then
-   EXTN="amd64"
-else
-   if test $MACHINE = "i686"; then
-     EXTN="i386"
-   fi
-fi
-
-DATE=`date +"%Y-%m-%d"`
-
 AC_SUBST(CC)
 AC_SUBST(AR)
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST(N2N_VERSION)
-AC_SUBST(N2N_DEFINES)
 AC_SUBST(N2N_LIBS)
 AC_SUBST(ADDITIONAL_TOOLS)
 AC_CONFIG_HEADERS(include/config.h)

--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,7 @@ AS_IF([test "x$enable_miniupnp" != xno],
     [AC_CHECK_LIB([miniupnpc], [upnpDiscover],
         [
             AC_DEFINE([HAVE_MINIUPNP], [1], [Have miniupnp library])
+            AC_DEFINE([HAVE_PORT_FORWARDING],[1],[upnp libs are used])
             N2N_LIBS="-lminiupnpc ${N2N_LIBS}"
         ],
         [AC_MSG_ERROR([miniupnp library not found])]
@@ -75,6 +76,7 @@ AS_IF([test "x$enable_natpmp" != xno],
     [AC_CHECK_LIB([natpmp], [initnatpmp],
         [
             AC_DEFINE([HAVE_NATPMP], [1], [Have natpmp library])
+            AC_DEFINE([HAVE_PORT_FORWARDING],[1],[upnp libs are used])
             N2N_LIBS="-lnatpmp ${N2N_LIBS}"
         ],
         [AC_MSG_ERROR([natpmp library not found])]

--- a/configure.ac
+++ b/configure.ac
@@ -15,16 +15,24 @@ N2N_LIBS=
 
 AC_PROG_CC
 
-AC_ARG_WITH(edgex,    [  --with-edgex            Build for Ubiquity-X])
+# TODO: ideally, should use AC_ARG_ENABLE
+AC_ARG_WITH([edgex],
+    AS_HELP_STRING([--with-edgex], [Build for Ubiquity-X]),
+    [], [with_edgex=no])
+AS_IF([test "x$with_edgex" != "xno"],
+    [
+        AC_MSG_NOTICE([Please contact us with your use case])
+        CC=mipsel-linux-gnu-gcc
+        AR=mipsel-linux-gnu-arzls
+    ],
+)
 
-if test "${with_edgex+set}" = set; then
-   CC=mipsel-linux-gnu-gcc
-   AR=mipsel-linux-gnu-arzls   
-fi
-
-AC_ARG_WITH([zstd], AS_HELP_STRING([--with-zstd], [use zstd library]),,[with_zstd=no])
+# TODO: ideally, should use AC_ARG_ENABLE
+AC_ARG_WITH([zstd],
+    AS_HELP_STRING([--with-zstd], [use zstd library]),
+    [], [with_zstd=no])
 AS_IF([test "x$with_zstd" != "xno"],
-    [AC_CHECK_LIB( [zstd], [ZSTD_compress],
+    [AC_CHECK_LIB([zstd], [ZSTD_compress],
         [
             AC_DEFINE([N2N_HAVE_ZSTD], [1], [Have ZSTD support])
             N2N_LIBS="-lzstd ${N2N_LIBS}"
@@ -33,65 +41,88 @@ AS_IF([test "x$with_zstd" != "xno"],
     )],
 )
 
+# TODO: ideally, should use AC_ARG_ENABLE
 AC_ARG_WITH([openssl],
- [AS_HELP_STRING([--with-openssl],
- [enable support for OpenSSL])],
- [],
- [with_openssl=no])
-if test "x$with_openssl" != xno; then
-  OLD_CFLAGS="${CFLAGS}"
-  OLD_LDFLAGS="${LDFLAGS}"
-  CFLAGS="${CFLAGS} -I/usr/local/opt/openssl@1.1/include"
-  LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl@1.1/lib/"
-  AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_reset])
-  if test "x$ac_cv_lib_crypto_EVP_CIPHER_CTX_reset" != xyes; then
-     AC_MSG_RESULT(OpenSSL 1.1 not present)
-     CFLAGS="${OLD_CFLAGS}"
-     LDFLAGS="${OLD_LDFLAGS}"
-  else
-    AC_DEFINE([HAVE_OPENSSL_1_1], [], [OpenSSL 1.1 is present])
-    N2N_LIBS="-lcrypto ${N2N_LIBS}"
-  fi
-fi
+    [AS_HELP_STRING([--with-openssl], [enable support for OpenSSL])],
+    [], [with_openssl=no])
+AS_IF([test "x$with_openssl" != xno],
+    [AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_reset],
+        [
+            AC_DEFINE([HAVE_OPENSSL_1_1], [1], [OpenSSL 1.1 is present])
+            N2N_LIBS="-lcrypto ${N2N_LIBS}"
+        ],
+        [AC_MSG_ERROR([openssl library not found])]
+    )],
+)
 
-AC_CHECK_LIB([miniupnpc], [upnpDiscover], miniupnp=true)
+AC_ARG_ENABLE([miniupnp],
+    [AS_HELP_STRING([--enable-miniupnp], [support for miniupnp])],
+    [], [enable_miniupnp=no])
+AS_IF([test "x$enable_miniupnp" != xno],
+    [AC_CHECK_LIB([miniupnpc], [upnpDiscover],
+        [
+            AC_DEFINE([HAVE_MINIUPNP], [1], [Have miniupnp library])
+            N2N_LIBS="-lminiupnpc ${N2N_LIBS}"
+        ],
+        [AC_MSG_ERROR([miniupnp library not found])]
+    )],
+)
 
-if test x$miniupnp != x; then
-  AC_DEFINE([HAVE_MINIUPNP], [], [Have miniupnp library])
-  N2N_LIBS="-lminiupnpc ${N2N_LIBS}"
-fi
+AC_ARG_ENABLE([natpmp],
+    [AS_HELP_STRING([--enable-natpmp], [support for natpmp])],
+    [], [enable_natpmp=no])
+AS_IF([test "x$enable_natpmp" != xno],
+    [AC_CHECK_LIB([natpmp], [initnatpmp],
+        [
+            AC_DEFINE([HAVE_NATPMP], [1], [Have natpmp library])
+            N2N_LIBS="-lnatpmp ${N2N_LIBS}"
+        ],
+        [AC_MSG_ERROR([natpmp library not found])]
+    )],
+)
 
-AC_CHECK_LIB([natpmp], [initnatpmp], natpmp=true)
+AC_ARG_ENABLE([pcap],
+    [AS_HELP_STRING([--enable-pcap], [support for pcap])],
+    [], [enable_pcap=no])
+AS_IF([test "x$enable_pcap" != xno],
+    [AC_CHECK_LIB([pcap], [pcap_open_live],
+        [
+            AC_DEFINE([N2N_HAVE_PCAP], [1], [Have PCAP library])
+            N2N_LIBS="-lpcap ${N2N_LIBS}"
+            ADDITIONAL_TOOLS="$ADDITIONAL_TOOLS n2n-decode"
+            AC_CHECK_LIB([pcap], [pcap_set_immediate_mode],
+                AC_DEFINE([HAVE_PCAP_IMMEDIATE_MODE], [1], [Have pcap_immediate_mode])
+            )
+        ],
+        [AC_MSG_ERROR([pcap library not found])]
+    )],
+)
 
-if test x$natpmp != x; then
-  AC_DEFINE([HAVE_NATPMP], [], [Have natpmp library])
-  N2N_LIBS="-lnatpmp ${N2N_LIBS}"
-fi
+AC_ARG_ENABLE([cap],
+    [AS_HELP_STRING([--enable-cap], [support for cap])],
+    [], [enable_cap=no])
+AS_IF([test "x$enable_cap" != xno],
+    [AC_CHECK_LIB([cap], [cap_get_proc],
+        [
+            AC_DEFINE([HAVE_LIBCAP],[1],[Support for linux capabilities])
+            N2N_LIBS="${N2N_LIBS} -lcap"
+        ],
+        [AC_MSG_ERROR([cap library not found])]
+    )],
+)
 
-AC_CHECK_LIB([pcap], [pcap_open_live], pcap=true)
-
-if test x$pcap != x; then
-  AC_DEFINE([N2N_HAVE_PCAP], [], [Have PCAP library])
-  ADDITIONAL_TOOLS="$ADDITIONAL_TOOLS n2n-decode"
-fi
-
-AC_CHECK_LIB([pcap], [pcap_set_immediate_mode], pcap_immediate_mode=true)
-
-if test x$pcap_immediate_mode != x; then
-  AC_DEFINE([HAVE_PCAP_IMMEDIATE_MODE], [], [Have pcap_immediate_mode])
-fi
-
-AC_CHECK_LIB([cap], [cap_get_proc], cap=true)
-if test x$cap != x; then
-  N2N_LIBS="${N2N_LIBS} -lcap"
-  AC_DEFINE([HAVE_LIBCAP],[1],[Support for linux capabilities])
-fi
-
-AC_CHECK_LIB([pthread], [pthread_mutex_trylock], pthread=true)
-if test x$pthread != x; then
-  LDFLAGS="${LDFLAGS} -pthread"
-  AC_DEFINE([HAVE_PTHREAD],[],[pthread is present])
-fi
+AC_ARG_ENABLE([pthread],
+    [AS_HELP_STRING([--enable-pthread], [support for pthread])],
+    [], [enable_pthread=no])
+AS_IF([test "x$enable_pthread" != xno],
+    [AC_CHECK_LIB([pthread], [pthread_mutex_trylock],
+        [
+            AC_DEFINE([HAVE_PTHREAD],[1],[pthread is present])
+            LDFLAGS="${LDFLAGS} -pthread"
+        ],
+        [AC_MSG_ERROR([pthread library not found])]
+    )],
+)
 
 
 MACHINE=`uname -m`

--- a/configure.ac
+++ b/configure.ac
@@ -21,21 +21,17 @@ if test "${with_edgex+set}" = set; then
    CC=mipsel-linux-gnu-gcc
    AR=mipsel-linux-gnu-arzls   
 fi
-   
-AC_ARG_WITH([zstd],
- [AS_HELP_STRING([--with-zstd],
- [enable support for zstd])],
- [],
- [with_zstd=no])
-if test "x$with_zstd" != xno; then
-  AC_CHECK_LIB([zstd], [ZSTD_compress])
-  if test "x$ac_cv_lib_zstd_ZSTD_compress" != xyes; then
-    AC_MSG_RESULT(Building n2n without ZSTD support)
-  else
-    AC_DEFINE([N2N_HAVE_ZSTD], [], [Have ZSTD support])
-    N2N_LIBS="-lzstd ${N2N_LIBS}"
-  fi
-fi
+
+AC_ARG_WITH([zstd], AS_HELP_STRING([--with-zstd], [use zstd library]),,[with_zstd=no])
+AS_IF([test "x$with_zstd" != "xno"],
+    [AC_CHECK_LIB( [zstd], [ZSTD_compress],
+        [
+            AC_DEFINE([N2N_HAVE_ZSTD], [1], [Have ZSTD support])
+            N2N_LIBS="-lzstd ${N2N_LIBS}"
+        ],
+        [AC_MSG_ERROR([zstd library not found])]
+    )],
+)
 
 AC_ARG_WITH([openssl],
  [AS_HELP_STRING([--with-openssl],

--- a/include/n2n_port_mapping.h
+++ b/include/n2n_port_mapping.h
@@ -1,6 +1,8 @@
 #ifndef _N2N_PORT_MAPPING_H_
 #define _N2N_PORT_MAPPING_H_
 
+#ifdef HAVE_PORT_FORWARDING
+
 #include <stdint.h>
 
 #ifdef HAVE_MINIUPNP
@@ -26,4 +28,5 @@
 void n2n_chg_port_mapping (struct n2n_edge *eee, const uint16_t port);
 
 
+#endif // HAVE_PORT_FORWARDING
 #endif // _N2N_PORT_MAPPING_H_

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -334,12 +334,12 @@ int supernode_connect (n2n_edge_t *eee) {
             eee->cb.sock_opened(eee);
     }
 
-#if defined(HAVE_MINIUPNP) || defined(HAVE_NATPMP)
+#ifdef HAVE_PORT_FORWARDING
     if(eee->conf.port_forwarding)
         // REVISIT: replace with mgmt port notification to listener for mgmt port
         //          subscription support
         n2n_chg_port_mapping(eee, eee->conf.preferred_sock.port);
-#endif // HAVE_MINIUPNP || HAVE_NATPMP
+#endif // HAVE_PORT_FORWARDING
     return 0;
 }
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -30,8 +30,10 @@ int resolve_create_thread (n2n_resolve_parameter_t **param, struct peer_info *sn
 int resolve_check (n2n_resolve_parameter_t *param, uint8_t resolution_request, time_t now);
 int resolve_cancel_thread (n2n_resolve_parameter_t *param);
 
+#ifdef HAVE_PORT_FORWARDING
 int port_map_create_thread (n2n_port_map_parameter_t **param, uint16_t mgmt_port);
 int port_map_cancel_thread (n2n_port_map_parameter_t *param);
+#endif
 
 static const char * supernode_ip (const n2n_edge_t * eee);
 static void send_register (n2n_edge_t *eee, const n2n_sock_t *remote_peer, const n2n_mac_t peer_mac, n2n_cookie_t cookie);
@@ -491,7 +493,7 @@ n2n_edge_t* edge_init (const n2n_edge_conf_t *conf, int *rv) {
     if(resolve_create_thread(&(eee->resolve_parameter), eee->conf.supernodes) == 0) {
         traceEvent(TRACE_NORMAL, "successfully created resolver thread");
     }
-#if defined(HAVE_MINIUPNP) || defined(HAVE_NATPMP)
+#ifdef HAVE_PORT_FORWARDING
     if(eee->conf.port_forwarding)
         if(port_map_create_thread(&eee->port_map_parameter, eee->conf.mgmt_port) == 0) {
             traceEvent(TRACE_NORMAL, "successfully created port mapping thread");
@@ -3206,7 +3208,7 @@ int run_edge_loop (n2n_edge_t *eee) {
 void edge_term (n2n_edge_t * eee) {
 
     resolve_cancel_thread(eee->resolve_parameter);
-#if defined(HAVE_MINIUPNP) || defined(HAVE_NATPMP)
+#ifdef HAVE_PORT_FORWARDING
     if(eee->conf.port_forwarding)
         port_map_cancel_thread(eee->port_map_parameter);
 #endif // HAVE_MINIUPNP || HAVE_NATPMP

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -304,9 +304,9 @@ int supernode2sock (n2n_sock_t *sn, const n2n_sn_name_t addrIn) {
 }
 
 
+#ifdef HAVE_PTHREAD
 N2N_THREAD_RETURN_DATATYPE resolve_thread(N2N_THREAD_PARAMETER_DATATYPE p) {
 
-#ifdef HAVE_PTHREAD
     n2n_resolve_parameter_t *param = (n2n_resolve_parameter_t*)p;
     n2n_resolve_ip_sock_t   *entry, *tmp_entry;
     time_t                  rep_time = N2N_RESOLVE_INTERVAL / 10;
@@ -351,8 +351,8 @@ N2N_THREAD_RETURN_DATATYPE resolve_thread(N2N_THREAD_PARAMETER_DATATYPE p) {
         // unlock access
         pthread_mutex_unlock(&param->access);
     }
-#endif
 }
+#endif
 
 
 int resolve_create_thread (n2n_resolve_parameter_t **param, struct peer_info *sn_list) {
@@ -394,6 +394,8 @@ int resolve_create_thread (n2n_resolve_parameter_t **param, struct peer_info *sn
     pthread_mutex_init(&((*param)->access), NULL);
 
     return 0;
+#else
+    return -1;
 #endif
 }
 

--- a/src/n2n_port_mapping.c
+++ b/src/n2n_port_mapping.c
@@ -464,6 +464,7 @@ static int n2n_natpmp_del_port_mapping (const uint16_t port) {
 
 // ----------------------------------------------------------------------------------------------------
 
+#ifdef HAVE_PORT_FORWARDING
 
 static void n2n_set_port_mapping (const uint16_t port) {
 
@@ -618,9 +619,10 @@ int port_map_create_thread (n2n_port_map_parameter_t **param, uint16_t mgmt_port
         return -1;
     }
 
-#endif
-
     return 0;
+#else
+    return -1;
+#endif
 }
 
 
@@ -633,3 +635,14 @@ void port_map_cancel_thread (n2n_port_map_parameter_t *param) {
     free(param);
 #endif
 }
+
+#else
+
+int port_map_create_thread (n2n_port_map_parameter_t **param, uint16_t mgmt_port) {
+    return -1;
+}
+
+void port_map_cancel_thread (n2n_port_map_parameter_t *param) {
+    return;
+}
+#endif // HAVE_PORT_FORWARDING

--- a/src/n2n_port_mapping.c
+++ b/src/n2n_port_mapping.c
@@ -636,13 +636,4 @@ void port_map_cancel_thread (n2n_port_map_parameter_t *param) {
 #endif
 }
 
-#else
-
-int port_map_create_thread (n2n_port_map_parameter_t **param, uint16_t mgmt_port) {
-    return -1;
-}
-
-void port_map_cancel_thread (n2n_port_map_parameter_t *param) {
-    return;
-}
 #endif // HAVE_PORT_FORWARDING

--- a/src/n2n_port_mapping.c
+++ b/src/n2n_port_mapping.c
@@ -54,6 +54,8 @@
  */
 
 
+#ifdef HAVE_PORT_FORWARDING
+
 #include "n2n.h"
 
 
@@ -463,8 +465,6 @@ static int n2n_natpmp_del_port_mapping (const uint16_t port) {
 
 
 // ----------------------------------------------------------------------------------------------------
-
-#ifdef HAVE_PORT_FORWARDING
 
 static void n2n_set_port_mapping (const uint16_t port) {
 


### PR DESCRIPTION
To simplify the testing, cross-compilation and repeatable build process,
no configure options are automatically probed for - they all default to
off and are all using the same template.