### PR TITLE
Makefile.in: Remove space after -L and -I

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,8 +16,8 @@ PLATOPTS_SPARC64=-mcpu=ultrasparc -pipe -fomit-frame-pointer -ffast-math -finlin
 export CFLAGS
 export LDFLAGS
 
-CFLAGS=@CFLAGS@ -I ./include
-LDFLAGS=@LDFLAGS@ -L .
+CFLAGS=@CFLAGS@ -I./include
+LDFLAGS=@LDFLAGS@ -L.
 
 OPENSSL_CFLAGS=$(shell pkg-config openssl; echo $$?)
 ifeq ($(OPENSSL_CFLAGS), 0)


### PR DESCRIPTION
Fixes link failure with gcc-4.2:

```
ld: -L must be immediately followed by a directory path (no space)
```

This was originally reported to MacPorts: https://trac.macports.org/ticket/64894