### PR TITLE
Add CI for Code Analysing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,42 @@ jobs:
         run: |
           make lint
 
+  analyse:
+    name: Code Analysers
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        flags:
+          - -fsanitize=leak
+          - -fsanitize=address -static-libasan
+          - -fsanitize=undefined -static-libubsan
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fix Checkout
+        run: |
+          git fetch --force --tags
+
+      - name: Make the makefiles
+        run: |
+          ./autogen.sh
+
+          export CFLAGS="${{ matrix.flags }}"
+          export LDFLAGS="${{ matrix.flags }}"
+          ./configure
+
+      - name: Install essential
+        run: |
+          sudo apt update
+          make build-dep
+
+      - name: Run the analysis
+        run: |
+          make test
+
   test_linux:
     needs: smoketest
     name: Test Linux

--- a/src/auth.c
+++ b/src/auth.c
@@ -50,7 +50,7 @@ int bin_to_ascii (char *out, uint8_t *in, size_t in_len) {
         buf1 = in[bit_count / 8];
         buf1 <<= bit_count % 8;
 
-        buf2 = ((bit_count + 6) < (8 * in_len)) ? in[bit_count / 8 + 1] : 0;
+        buf2 = ((bit_count + 8) < (8 * in_len)) ? in[bit_count / 8 + 1] : 0;
         buf2 >>= 8 - (bit_count % 8);
 
         buf1 |= buf2;

--- a/src/cc20.c
+++ b/src/cc20.c
@@ -417,5 +417,6 @@ int cc20_deinit (cc20_context_t *ctx) {
 #if defined (HAVE_OPENSSL_1_1)
     if(ctx->ctx) EVP_CIPHER_CTX_free(ctx->ctx);
 #endif
+    free(ctx);
     return 0;
 }

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2994,6 +2994,7 @@ void edge_term (n2n_edge_t * eee) {
 
     clear_peer_list(&eee->pending_peers);
     clear_peer_list(&eee->known_peers);
+    clear_peer_list(&eee->conf.supernodes);
 
     eee->transop.deinit(&eee->transop);
     eee->transop_lzo.deinit(&eee->transop_lzo);

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -653,6 +653,9 @@ size_t clear_peer_list (struct peer_info ** peer_list) {
     size_t retval = 0;
 
     HASH_ITER(hh, *peer_list, scan, tmp) {
+        if (scan->purgeable == SN_UNPURGEABLE && scan->ip_addr) {
+            free(scan->ip_addr);
+        }
         HASH_DEL(*peer_list, scan);
         mgmt_event_post(N2N_EVENT_PEER,N2N_EVENT_PEER_CLEAR,scan);
         /* FIXME: generates events for more than just p2p */

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -1348,8 +1348,10 @@ static int re_register_and_purge_supernodes (n2n_sn_t *sss, struct sn_community 
         }
 
         // purge long-time-not-seen supernodes
-        purge_expired_nodes(&(comm->edges), sss->sock, &sss->tcp_connections, p_last_re_reg_and_purge,
-                            RE_REG_AND_PURGE_FREQUENCY, LAST_SEEN_SN_INACTIVE);
+        if (comm) {
+            purge_expired_nodes(&(comm->edges), sss->sock, &sss->tcp_connections, p_last_re_reg_and_purge,
+                                RE_REG_AND_PURGE_FREQUENCY, LAST_SEEN_SN_INACTIVE);
+        }
     }
 
     if(comm != NULL) {

--- a/src/transform_aes.c
+++ b/src/transform_aes.c
@@ -41,10 +41,11 @@ static int transop_deinit_aes (n2n_trans_op_t *arg) {
 
     transop_aes_t *priv = (transop_aes_t *)arg->priv;
 
-    if(priv)
+    if(priv) {
         if(priv->ctx)
             aes_deinit(priv->ctx);
         free(priv);
+    }
 
     return 0;
 }

--- a/src/transform_aes.c
+++ b/src/transform_aes.c
@@ -41,10 +41,9 @@ static int transop_deinit_aes (n2n_trans_op_t *arg) {
 
     transop_aes_t *priv = (transop_aes_t *)arg->priv;
 
-    if(priv->ctx)
-        aes_deinit(priv->ctx);
-
     if(priv)
+        if(priv->ctx)
+            aes_deinit(priv->ctx);
         free(priv);
 
     return 0;

--- a/src/transform_cc20.c
+++ b/src/transform_cc20.c
@@ -33,10 +33,9 @@ static int transop_deinit_cc20 (n2n_trans_op_t *arg) {
 
     transop_cc20_t *priv = (transop_cc20_t *)arg->priv;
 
-    if(priv->ctx)
-        cc20_deinit(priv->ctx);
-
     if(priv)
+        if(priv->ctx)
+            cc20_deinit(priv->ctx);
         free(priv);
 
     return 0;

--- a/src/transform_cc20.c
+++ b/src/transform_cc20.c
@@ -33,10 +33,11 @@ static int transop_deinit_cc20 (n2n_trans_op_t *arg) {
 
     transop_cc20_t *priv = (transop_cc20_t *)arg->priv;
 
-    if(priv)
+    if(priv) {
         if(priv->ctx)
             cc20_deinit(priv->ctx);
         free(priv);
+    }
 
     return 0;
 }

--- a/src/transform_speck.c
+++ b/src/transform_speck.c
@@ -33,10 +33,11 @@ static int transop_deinit_speck (n2n_trans_op_t *arg) {
 
     transop_speck_t *priv = (transop_speck_t *)arg->priv;
 
-    if(priv)
+    if(priv) {
         if(priv->ctx)
             speck_deinit(priv->ctx);
         free(priv);
+    }
 
     return 0;
 }

--- a/src/transform_speck.c
+++ b/src/transform_speck.c
@@ -33,10 +33,9 @@ static int transop_deinit_speck (n2n_trans_op_t *arg) {
 
     transop_speck_t *priv = (transop_speck_t *)arg->priv;
 
-    if(priv->ctx)
-        speck_deinit(priv->ctx);
-
     if(priv)
+        if(priv->ctx)
+            speck_deinit(priv->ctx);
         free(priv);
 
     return 0;

--- a/src/transform_tf.c
+++ b/src/transform_tf.c
@@ -41,10 +41,11 @@ static int transop_deinit_tf (n2n_trans_op_t *arg) {
 
     transop_tf_t *priv = (transop_tf_t *)arg->priv;
 
-    if(priv)
+    if(priv) {
         if(priv->ctx)
             tf_deinit(priv->ctx);
         free(priv);
+    }
 
     return 0;
 }

--- a/src/transform_tf.c
+++ b/src/transform_tf.c
@@ -41,10 +41,9 @@ static int transop_deinit_tf (n2n_trans_op_t *arg) {
 
     transop_tf_t *priv = (transop_tf_t *)arg->priv;
 
-    if(priv->ctx)
-        tf_deinit(priv->ctx);
-
     if(priv)
+        if(priv->ctx)
+            tf_deinit(priv->ctx);
         free(priv);
 
     return 0;


### PR DESCRIPTION
This adds a number of code analysis steps to the automated CI.  They will try to catch memory boundary access errors and memory leaks as well as provide a number of warnings for suspicious memory manipulation.

All the fatal errors have been addressed in this branch, but there are still a number of warnings that should be looked at.

The tests done here will generally only trigger for code paths covered by the test suite.