### PR TITLE
build(CMakeLists): dynamic link to libcap by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,8 +238,7 @@ if(N2N_OPTION_USE_ZSTD)
 endif(N2N_OPTION_USE_ZSTD)
 
 if(N2N_OPTION_USE_CAPLIB)
-  # TODO: this is a static library, shouldnt we have a generic one?
-  target_link_libraries(edge cap.a)
+  target_link_libraries(edge cap)
 endif(N2N_OPTION_USE_CAPLIB)
 
 if(N2N_OPTION_USE_PORTMAPPING)


### PR DESCRIPTION
This is a only exception while all other libraries are dynamically linked.

The "TODO" does not make any sense as libcap provides both dynamic and static libraries.
There is not reason to explain why it needs to be statically linked 'especially' as dynamic linking works very well.
Then just make it dynamically-linked by default, which also matches the behaviour on autotools.

Compiled and tested on aarch64, no errors found.