### PR TITLE
CI(openwrt): refactor build and test process

### DIFF
--- a/.github/openwrt/Dockerfile
+++ b/.github/openwrt/Dockerfile
@@ -1,0 +1,6 @@
+ARG ARCH=x86-64
+FROM openwrt/rootfs:$ARCH
+
+ADD entrypoint.sh /entrypoint.sh
+
+CMD ["/entrypoint.sh"]

--- a/.github/openwrt/entrypoint.sh
+++ b/.github/openwrt/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+. /etc/openwrt_release
+
+mkdir -p /var/lock/
+
+opkg update
+
+for PKG in "/ci/ipk-$DISTRIB_ARCH"/*.ipk; do
+	tar -xzOf "$PKG" ./control.tar.gz | tar xzf - ./control
+	# package name including variant
+	PKG_NAME=$(sed -ne 's#^Package: \(.*\)$#\1#p' ./control)
+	# package version without release
+	PKG_VERSION=$(sed -ne 's#^Version: \(.*\)-[0-9]*$#\1#p' ./control)
+	# package source contianing test.sh script
+	PKG_SOURCE=$(sed -ne 's#^Source: .*/\(.*\)$#\1#p' ./control)
+
+	echo "Testing package $PKG_NAME in version $PKG_VERSION from $PKG_SOURCE"
+
+	opkg install "$PKG"
+
+	export PKG_NAME PKG_VERSION
+
+	TEST_SCRIPT="/ci/.github/openwrt/test.sh"
+
+	if [ -f "$TEST_SCRIPT" ]; then
+		echo "Use package specific test.sh"
+		if sh "$TEST_SCRIPT" "$PKG_NAME" "$PKG_VERSION"; then
+			echo "Test successful"
+		else
+			echo "Test failed"
+			exit 1
+		fi
+	else
+		echo "No test.sh script available"
+	fi
+
+	opkg remove "$PKG_NAME" --force-removal-of-dependent-packages --force-remove
+done

--- a/.github/openwrt/test.sh
+++ b/.github/openwrt/test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+case "$1" in
+	"n2n-edge"|"n2n-supernode")
+		eval "${1#n2n-}" | grep "$2"
+		;;
+	"n2n-tests")
+		for test in $(grep -v '#' '/usr/bin/n2n-tests_units.list'); do
+			eval "n2n-$test"
+		done
+		;;
+esac

--- a/.github/workflows/openwrt.yml
+++ b/.github/workflows/openwrt.yml
@@ -17,33 +17,43 @@ jobs:
         include:
           - arch: arc_archs
             target: archs38-generic
+            runtime_test: false
 
           - arch: arm_cortex-a9_vfpv3-d16
             target: mvebu-cortexa9
+            runtime_test: false
 
           - arch: mips_24kc
             target: ath79-generic
+            runtime_test: false
 
           - arch: mipsel_24kc
             target: mt7621
+            runtime_test: false
 
           - arch: powerpc_464fp
             target: apm821xx-nand
+            runtime_test: false
 
           - arch: powerpc_8540
             target: mpc85xx-p1010
+            runtime_test: false
 
           - arch: aarch64_cortex-a53
             target: mvebu-cortexa53
+            runtime_test: true
 
           - arch: arm_cortex-a15_neon-vfpv4
             target: armvirt-32
+            runtime_test: true
 
           - arch: i386_pentium-mmx
             target: x86-geode
+            runtime_test: true
 
           - arch: x86_64
             target: x86-64
+            runtime_test: true
 
     steps:
       - uses: actions/checkout@v3
@@ -79,3 +89,19 @@ jobs:
 
       - name: Remove logs
         run: sudo rm -rf logs-${{ matrix.arch }}/ || true
+
+      - name: Register QEMU
+        if: ${{ matrix.runtime_test }}
+        run: sudo docker run --rm --privileged aptman/qus -s -- -p
+
+      - name: Build Docker container
+        if: ${{ matrix.runtime_test }}
+        run: |
+          git checkout HEAD .github/openwrt
+          docker build -t test-container --build-arg ARCH .github/openwrt/
+        env:
+          ARCH: ${{ matrix.arch }}
+
+      - name: Test via Docker container
+        if: ${{ matrix.runtime_test }}
+        run: docker run --rm -v $GITHUB_WORKSPACE:/ci test-container

--- a/.github/workflows/openwrt.yml
+++ b/.github/workflows/openwrt.yml
@@ -1,112 +1,81 @@
 ---
-name: Openwrt Build
+name: OpenWrt Build
 
 # yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
-      - created
-      - edited
   push:
-    branches:
-      - openwrt
-
+  pull_request:
   workflow_dispatch:
 
 jobs:
   build:
-    name: Build ipkg
+    name: Test ${{ matrix.arch }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arc_archs
+            target: archs38-generic
 
-    defaults:
-      run:
-        working-directory: openwrt
+          - arch: arm_cortex-a9_vfpv3-d16
+            target: mvebu-cortexa9
+
+          - arch: mips_24kc
+            target: ath79-generic
+
+          - arch: mipsel_24kc
+            target: mt7621
+
+          - arch: powerpc_464fp
+            target: apm821xx-nand
+
+          - arch: powerpc_8540
+            target: mpc85xx-p1010
+
+          - arch: aarch64_cortex-a53
+            target: mvebu-cortexa53
+
+          - arch: arm_cortex-a15_neon-vfpv4
+            target: armvirt-32
+
+          - arch: i386_pentium-mmx
+            target: x86-geode
+
+          - arch: x86_64
+            target: x86-64
 
     steps:
-      - name: Checkout openwrt
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          path: openwrt
-          repository: openwrt/openwrt
-
-      - name: Set openwrt ref
-        id: openwrt_ref
-        run: |
-          echo ::set-output name=REF::$(git rev-parse --short HEAD)
-          git rev-parse --short HEAD
-
-      - name: Checkout n2n
-        uses: actions/checkout@v2
-        with:
-          path: n2n
           fetch-depth: 0
 
-      - name: Fix Checkout
-        run: |
-          git fetch --force --tags
-        working-directory: n2n
-
-      - name: Set n2n ref
-        id: n2n_ref
-        run: |
-          echo ::set-output name=REF::$(./scripts/version.sh)
-          ./scripts/version.sh
-        working-directory: n2n
-
-      - name: Copy n2n package definition into openwrt
-        run: |
-          cp -r n2n/packages/openwrt openwrt/package/n2n
-        working-directory: ./
-
-      - name: Cache openwrt source downloads
-        uses: actions/cache@v2
-        with:
-          path: openwrt/dl
-          key: openwrt-dl-${{ steps.openwrt_ref.outputs.REF }}
-
-      - name: Setup openwrt config and environment
-        run: |
-          echo "CONFIG_TARGET_x86=y" >.config
-          echo "CONFIG_TARGET_x86_64=y" >>.config
-
-      - name: Add n2n package to openwrt config
-        run: |
-          echo "CONFIG_PACKAGE_n2n-edge=m" >>.config
-          echo "CONFIG_PACKAGE_n2n-supernode=m" >>.config
-
-      - name: Build a full config from our stub file
-        run: |
-          make defconfig
-
-      - name: Download openwrt sources
-        run: |
-          make download
-
-      - name: Build openwrt build environment
-        run: |
-          make -j `nproc` tools/install toolchain/install
-
-      - name: Build n2n dependancies
-        run: |
-          make -j `nproc` package/libs/libpcap/compile
-
-      - name: Build n2n openwrt packages
+      - name: Build
+        uses: openwrt/gh-action-sdk@v5
         env:
-          N2N_PKG_VERSION: ${{ steps.n2n_ref.outputs.REF }}
+          ARCH: ${{ matrix.arch }}
+          FEEDNAME: n2n_ci
+          PACKAGES: openwrt
+
+      - name: Move created packages to project dir
         run: |
-          echo "Build for $N2N_PKG_VERSION"
-          export N2N_PKG_VERSION
-          make package/n2n/clean V=s
-          make package/n2n/prepare USE_SOURCE_DIR=$GITHUB_WORKSPACE/n2n V=s
-          make package/n2n/compile V=s
+          mkdir -p ipk-${{ matrix.arch }}
+          cp bin/packages/${{ matrix.arch }}/n2n_ci/*.ipk ipk-${{ matrix.arch }} || true
 
-# FIXME: add a way to run the test suite!
-#      - name: Run embedded tests
-#        run: make test
-
-      - name: Upload built artifacts
+      - name: Store packages
         uses: actions/upload-artifact@v2
         with:
-          name: built-ipkgs
-          path: openwrt/bin/packages/*/base/*.ipk
+          name: packages
+          path: ipk-${{ matrix.arch }}/
+
+      - name: Rename logs
+        run: sudo mv -f logs logs-${{ matrix.arch }}
+
+      - name: Store logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: logs-${{ matrix.arch }}/
+
+      - name: Remove logs
+        run: sudo rm -rf logs-${{ matrix.arch }}/ || true

--- a/packages/openwrt/Makefile
+++ b/packages/openwrt/Makefile
@@ -1,38 +1,20 @@
-#
 # Copyright (C) 2021 - ntop.org and contributors
-#
+# Copyright (C) 2022 ImmortalWrt.org
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=n2n
-PKG_VERSION:=HEAD
+PKG_VERSION:=$(shell ../../scripts/version.sh)
 PKG_RELEASE:=1
+PKG_BUILD_DIR:=$(CURDIR)/../..
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-
-# These are defaults for compiling without any environmental overrides
-# (eg, the github action calculates the correct overrides for each build)
-PKG_SOURCE_URL:=https://github.com/ntop/n2n
-PKG_SOURCE_VERSION:=dev
-PKG_MIRROR_HASH:=skip
-
-# Apply overrides from the build environment
-ifdef N2N_PKG_SOURCE_URL
-    PKG_SOURCE_URL:=$(N2N_PKG_SOURCE_URL)
-endif
-ifdef N2N_PKG_SOURCE_VERSION
-    PKG_SOURCE_VERSION:=$(N2N_PKG_SOURCE_VERSION)
-endif
-ifdef N2N_PKG_VERSION
-    PKG_VERSION:=$(N2N_PKG_VERSION)
-endif
-
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILE:=LICENSE
 PKG_MAINTAINER:=Emanuele Faranda <faranda@ntop.org>
-PKG_LICENSE:=GPL3
 
-# autogen fix
 PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -51,50 +33,49 @@ define Package/n2n-edge
   DEPENDS+=+kmod-tun
 endef
 
-define Package/n2n-supernode
-  $(call Package/n2n/Default)
-  TITLE+= server (supernode)
-endef
-
 define Package/n2n-edge/description
-The client node for the N2N infrastructure
-endef
-
-define Package/n2n-supernode/description
-The supernode for the N2N infrastructure
-endef
-
-define Build/Configure
-	( cd $(PKG_BUILD_DIR); \
-	./autogen.sh; \
-	./configure )
+  The client node for the N2N infrastructure
 endef
 
 define Package/n2n-edge/conffiles
 /etc/n2n/edge.conf
 endef
 
-define Package/n2n-edge/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/edge $(1)/usr/bin/
-	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/etc/init.d/edge $(1)/etc/init.d/edge
-	$(INSTALL_DIR) $(1)/etc/n2n
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/etc/n2n/edge.conf.sample $(1)/etc/n2n/edge.conf
+define Package/n2n-supernode
+  $(call Package/n2n/Default)
+  TITLE+= server (supernode)
+endef
+
+define Package/n2n-supernode/description
+  The supernode for the N2N infrastructure
 endef
 
 define Package/n2n-supernode/conffiles
 /etc/n2n/supernode.conf
 endef
 
+CONFIGURE_ARGS+= --enable-cap
+
+MAKE_VARS+= CONFIG_TARGET=generic
+
+define Package/n2n-edge/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/edge $(1)/usr/bin/edge
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/etc/init.d/edge $(1)/etc/init.d/edge
+	$(INSTALL_DIR) $(1)/etc/n2n
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/etc/n2n/edge.conf.sample $(1)/etc/n2n/edge.conf
+endef
+
 define Package/n2n-supernode/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/supernode $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/supernode $(1)/usr/bin/supernode
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/etc/init.d/supernode $(1)/etc/init.d/supernode
 	$(INSTALL_DIR) $(1)/etc/n2n
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/etc/n2n/supernode.conf.sample $(1)/etc/n2n/supernode.conf
 endef
+
 
 $(eval $(call BuildPackage,n2n-edge))
 $(eval $(call BuildPackage,n2n-supernode))

--- a/packages/openwrt/Makefile
+++ b/packages/openwrt/Makefile
@@ -24,7 +24,7 @@ define Package/n2n/Default
   TITLE:=N2N Peer-to-peer VPN
   URL:=http://www.ntop.org/n2n
   SUBMENU:=VPN
-  DEPENDS+=+libcap
+  DEPENDS+=+libcap +libpcap
 endef
 
 define Package/n2n-edge
@@ -54,7 +54,18 @@ define Package/n2n-supernode/conffiles
 /etc/n2n/supernode.conf
 endef
 
-CONFIGURE_ARGS+= --enable-cap
+define Package/n2n-utils
+  $(call Package/n2n/Default)
+  TITLE+= utilities
+endef
+
+define Package/n2n-utils/description
+  The extend utilities for the N2N infrastructure
+endef
+
+CONFIGURE_ARGS+= \
+	--enable-cap \
+	--enable-pcap
 
 MAKE_VARS+= CONFIG_TARGET=generic
 
@@ -76,6 +87,15 @@ define Package/n2n-supernode/install
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/etc/n2n/supernode.conf.sample $(1)/etc/n2n/supernode.conf
 endef
 
+define Package/n2n-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/n2n-benchmark $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/n2n-decode $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/n2n-keygen $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/n2n-portfwd $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/n2n-route $(1)/usr/bin/
+endef
 
 $(eval $(call BuildPackage,n2n-edge))
 $(eval $(call BuildPackage,n2n-supernode))
+$(eval $(call BuildPackage,n2n-utils))

--- a/packages/openwrt/Makefile
+++ b/packages/openwrt/Makefile
@@ -24,7 +24,7 @@ define Package/n2n/Default
   TITLE:=N2N Peer-to-peer VPN
   URL:=http://www.ntop.org/n2n
   SUBMENU:=VPN
-  DEPENDS+=+libcap +libpcap
+  DEPENDS+=+libcap +libpcap +libzstd
 endef
 
 define Package/n2n-edge
@@ -54,6 +54,15 @@ define Package/n2n-supernode/conffiles
 /etc/n2n/supernode.conf
 endef
 
+define Package/n2n-tests
+  $(call Package/n2n/Default)
+  TITLE+= tests
+endef
+
+define Package/n2n-tests/description
+  The tests for the N2N infrastructure
+endef
+
 define Package/n2n-utils
   $(call Package/n2n/Default)
   TITLE+= utilities
@@ -65,7 +74,8 @@ endef
 
 CONFIGURE_ARGS+= \
 	--enable-cap \
-	--enable-pcap
+	--enable-pcap \
+	--enable-zstd
 
 MAKE_VARS+= CONFIG_TARGET=generic
 
@@ -87,6 +97,14 @@ define Package/n2n-supernode/install
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/etc/n2n/supernode.conf.sample $(1)/etc/n2n/supernode.conf
 endef
 
+define Package/n2n-tests/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/tests/tests_units.list $(1)/usr/bin/n2n-tests_units.list
+	( for i in $$$$(grep -v '#' $(PKG_BUILD_DIR)/tests/tests_units.list); do \
+		$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/$$$$i $(1)/usr/bin/n2n-$$$$i ; \
+	done )
+endef
+
 define Package/n2n-utils/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/n2n-benchmark $(1)/usr/bin/
@@ -98,4 +116,5 @@ endef
 
 $(eval $(call BuildPackage,n2n-edge))
 $(eval $(call BuildPackage,n2n-supernode))
+$(eval $(call BuildPackage,n2n-tests))
 $(eval $(call BuildPackage,n2n-utils))

--- a/packages/openwrt/README.md
+++ b/packages/openwrt/README.md
@@ -1,62 +1,48 @@
-## Prerequisites
+This instructions explain how to build an OpenWrt .ipk package for n2n.
 
-This instructions explain how to build an OpenWRT .ipk package for n2n.
+1. Install build dependencies
 
-You will either need to build a full OpenWRT buildchain (See the github
-action for building openwrt.yml for some example steps) or have a working
-cross-compiling build environment for the OpenWRT version installed into
-your device.
+   See [\[OpenWrt Wiki\] Build system setup](https://openwrt.org/docs/guide-developer/toolchain/install-buildsystem).
 
-### Downloading a cross-compiling build environment
+2. Download and extract the SDK
 
-This usually comes down to the following steps:
+   Go to [downloads.openwrt.org](https://downloads.openwrt.org/) and download the correspond SDK for your device.
 
-1. Download and extract the SDK toolchain for your device. The toolchain
-   must match the *exact* OpenWRT version installed in your device. Toolchain
-   for official OpenWRT images can be downloaded from https://downloads.openwrt.org
+   Note: The SDK must match the **exact OpenWrt version and architecture** installed in your device.
 
-2. Build the toolchain: run `make menuconfig`, save the configuration, then
-   run `make` to build the cross compiling tools
+   For details, see [\[OpenWrt Wiki\] Using the SDK](https://openwrt.org/docs/guide-developer/toolchain/using_the_sdk).
 
-3. Download the feeds with `./scripts/feeds update -a`
+3. Update feeds
 
-## Compilation
+   ```bash
+   ./scripts/feeds update -a && ./scripts/feeds install -a
+   ```
 
-These instructions are for building the current checked out version of the
-n2n source  (The generally used OpenWRT alternative is to download a tar.gz
-file of a specific n2n version, but that is not as suitable for development
-or local builds)
+4. Clone the n2n source code
 
-You need both the openwrt repository and the n2n repository checked out
-for this.  In these instructions, we assume that `openwrt` is the directory
-where your openwrt checkout is located and `n2n` is the directory for
-the n2n repository.
+   ```bash
+   git clone https://github.com/ntop/n2n packages/n2n
+   ```
 
-```
-git clone https://github.com/ntop/n2n n2n
-N2N_PKG_VERSION=$(n2n/scripts/version.sh)
-export N2N_PKG_VERSION
+5. Build n2n
 
-cp -r n2n/packages/openwrt openwrt/package/n2n
+   ```bash
+   make defconfig
+   make package/n2n/packages/openwrt/compile -j$(nproc) V=s
+   ```
 
-cd openwrt
-make menuconfig # select Network -> VPN -> n2n-edge and n2n-supernode
-make package/n2n/clean V=s
-make package/n2n/prepare USE_SOURCE_DIR=../n2n V=s
-make package/n2n/compile V=s
-```
+6. Install
 
-If everything went fine, two ipk will be generated, one for the n2n-edge
-and the other for n2n-supernode. They can be found with `find . -name "n2n*.ipk"`,
-copied to the target device, and installed with `opkg install`.
+   If everything went fine, four ipk will be generated.
 
-The github action described in `.github/workflows/openwrt.yml` implements
-an automated version of the above steps.
+   Generally speaking, you just need the n2n-edge and n2n-supernode.
 
-## Configuration
+   They can be found with `find bin/packages -name "n2n*.ipk"`.
 
-The edge node can be started with `/etc/init.d/edge start`.
-Its configuration file is `/etc/n2n/edge.conf`.
+   Copy them to the target device, and install with `opkg install`.
 
-The supernode can be started with `/etc/init.d/supernode start`.
-Its configuration file is `/etc/n2n/supernode.conf`.
+7. Configure
+
+   The edge node can be started with `/etc/init.d/edge start`. Its configuration file is `/etc/n2n/edge.conf`.
+
+   The supernode can be started with `/etc/init.d/supernode start`. Its configuration file is `/etc/n2n/supernode.conf`.

--- a/packages/openwrt/etc/init.d/edge
+++ b/packages/openwrt/etc/init.d/edge
@@ -14,9 +14,10 @@ start_service() {
 	procd_close_instance
 }
 
-stop_service()
+reload_service()
 {
-	service_stop $PROG
+	stop
+	start
 }
 
 service_triggers()

--- a/packages/openwrt/etc/init.d/supernode
+++ b/packages/openwrt/etc/init.d/supernode
@@ -14,9 +14,10 @@ start_service() {
 	procd_close_instance
 }
 
-stop_service()
+reload_service()
 {
-	service_stop $PROG
+	stop
+	start
 }
 
 service_triggers()


### PR DESCRIPTION
This refactored the whole build & test process.

Cleaned up the Makefile, and switched to cmake build.

For CI, switched to OpenWrt's official build process, and build ipk for popular architectures.
Also implemented runtime test for armv7 / aarch64 and i386 / amd64.