### PR TITLE
fix build issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ if(N2N_OPTION_USE_OPENSSL)
 endif(N2N_OPTION_USE_OPENSSL)
 
 if(N2N_OPTION_USE_ZSTD)
-  target_link_libraries(n2n zstd)
+  target_link_libraries(n2n ${LIBZSTD})
 endif(N2N_OPTION_USE_ZSTD)
 
 if(N2N_OPTION_USE_CAPLIB)


### PR DESCRIPTION
fix 'cannot find library -lzstd' when build as a subproject with cmake and vcpkg