### PR TITLE
Safely remove encryption keys

### DIFF
--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -278,11 +278,13 @@ int load_allowed_sn_community (n2n_sn_t *sss) {
         // remove community
         HASH_DEL(sss->communities, comm);
         if(NULL != comm->header_encryption_ctx_static) {
-            // remove header encryption keys
-            free(comm->header_encryption_ctx_static);
-            free(comm->header_iv_ctx_static);
-            free(comm->header_encryption_ctx_dynamic);
-            free(comm->header_iv_ctx_dynamic);
+  			    if(comm->header_encryption == HEADER_ENCRYPTION_ENABLED) {
+				         // remove header encryption keys
+				        free(comm->header_encryption_ctx_static);
+				        free(comm->header_iv_ctx_static);
+				        free(comm->header_encryption_ctx_dynamic);
+				        free(comm->header_iv_ctx_dynamic);
+			      }
         }
         free(comm);
     }


### PR DESCRIPTION
Fixes supernode crash on Windows when no header encryption is used.
This is not ideal, but these fields are initialized and used only when header encryption is used.
Keep in mind, trying to reload communities while using header encryption will still crash on Windows.
Think of it like a band aid until we have proper fix.
