### PR TITLE
Remove nondeterminism from man compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,6 @@ DOCS=edge.8.gz supernode.1.gz n2n.7.gz
 BUILD_DEP:=\
 	autoconf \
 	build-essential \
-	dh-strip-nondeterminism \
 	flake8 \
 	gcovr \
 	libcap-dev \
@@ -232,7 +231,7 @@ endif
 	cp $< $@
 
 %.gz : %
-	gzip -c $< > $@
+	gzip -n -c $< > $@
 
 $(N2N_LIB): $(N2N_OBJS)
 	$(AR) rcs $(N2N_LIB) $(N2N_OBJS)

--- a/packages/debian/debian/rules.in
+++ b/packages/debian/debian/rules.in
@@ -12,9 +12,6 @@
 # http://www.tin.org/bin/man.cgi?section=7&topic=debhelper
 #
 
-# Not needed for newer debhelper versions, but some builders run older ones
-export GZIP=-n
-
 package=@APP@
 
 build: build-stamp
@@ -47,7 +44,6 @@ binary-arch: build install
 	dh_installman
 	dh_strip
 	dh_compress
-	dh_strip_nondeterminism
 	dh_fixperms
 	dh_installdeb
 	cp -r n2n debian


### PR DESCRIPTION
Replacing the previous attempt (using a debhelper) with simply changing the way we compress the man pages.

The debhelper didnt appear to be working - perhaps because the man page compression was not done within the debian package build framework.