### PR TITLE
support IOS with n2n 3.0 base

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Here is a list of third-party projects connected to this repository:
 - Docker images: [Docker Hub](https://hub.docker.com/r/supermock/supernode/)
 - Go bindings, management daemons and CLIs for n2n edges and supernodes, Docker, Kubernetes & Helm Charts: [pojntfx/gon2n](https://pojntfx.github.io/gon2n/)
 - Windows GUI (along with a custom version of n2n) but also working with regular n2n: [HappyNet](https://github.com/happynclient/happynwindows)
+- IOS App  working with regular n2n 3.0: [HappyNet](https://apps.apple.com/us/app/happynet/id6448507986)
 
 ---
 


### PR DESCRIPTION
Dear n2n team,

I hope this message finds you well. I wanted to reach out to you regarding my recent contribution to the n2n project. I have created an iOS app that is compatible with n2n3.0 and have made it open source. The GitHub repository for this project can be found at:

https://github.com/happynclient/happynios

I believe that this app would be a valuable addition to the n2n project, as it provides compatibility with iOS devices. I would like to submit a pull request to have this project added to the main README file on the n2n GitHub page. This would make it easier for other users and developers to find and utilize this app.

The app apple store link:
https://apps.apple.com/us/app/happynet/id6448507986

![screenshot-20230526-150823](https://github.com/ntop/n2n/assets/86546534/e9f38fe0-6114-4dd3-838a-747ca42cf7fd)


