### PR TITLE
Use the correct modern windows sockets header

### DIFF
--- a/include/n2n.h
+++ b/include/n2n.h
@@ -56,11 +56,11 @@
 #include "n2n_typedefs.h"
 
 #ifdef WIN32
+#include <winsock2.h>           /* for tcp */
 #include <lmaccess.h>           /* for privilege check in tools/n2n-route */
 #include <lmapibuf.h>           /* for privilege check in tools/n2n-route */
 #include <sys/stat.h>
 #include <windows.h>            /* for privilege check in tools/n2n-route */
-#include <winsock2.h>           /* for tcp */
 #include "wintap.h"
 #define SHUT_RDWR   SD_BOTH     /* for tcp */
 #endif /* #ifdef WIN32 */

--- a/src/edge.c
+++ b/src/edge.c
@@ -43,7 +43,7 @@
 #include "uthash.h"                  // for UT_hash_handle, HASH_ADD, HASH_C...
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>               // for inet_addr, inet_ntop

--- a/src/edge_management.c
+++ b/src/edge_management.c
@@ -36,7 +36,7 @@
 #include "uthash.h"        // for UT_hash_handle, HASH_ITER
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #include "edge_utils_win32.h"
 #else

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -41,7 +41,7 @@
 #include "uthash.h"                  // for UT_hash_handle, HASH_COUNT, HASH...
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #include "edge_utils_win32.h"
 #else

--- a/src/example_sn_embed.c
+++ b/src/example_sn_embed.c
@@ -22,7 +22,7 @@
 #include "n2n.h"         // for n2n_sn_t, open_socket, run_sn_loop, sn_init
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #else
 #include <netinet/in.h>  // for INADDR_ANY, INADDR_LOOPBACK
 #endif

--- a/src/management.h
+++ b/src/management.h
@@ -17,7 +17,7 @@
 #include "strbuf.h"
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #else
 #include <sys/socket.h>    // for sockaddr, sockaddr_storage, socklen_t
 #endif

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -31,7 +31,7 @@
 #include "uthash.h"          // for UT_hash_handle, HASH_DEL, HASH_ITER, HAS...
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include <ws2def.h>
 #include <ws2tcpip.h>
 #else

--- a/src/network_traffic_filter.c
+++ b/src/network_traffic_filter.c
@@ -26,7 +26,7 @@
 #include "uthash.h"                  // for UT_hash_handle, HASH_ITER, HASH_DEL
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>               // for inet_ntoa, inet_addr

--- a/src/sn_management.c
+++ b/src/sn_management.c
@@ -36,7 +36,7 @@
 #include "uthash.h"      // for UT_hash_handle, HASH_ITER, HASH_COUNT
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include "edge_utils_win32.h"
 #else
 #include <sys/socket.h>  // for sendto, socklen_t

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -41,7 +41,7 @@
 #include "uthash.h"             // for UT_hash_handle, HASH_ITER, HASH_DEL
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>          // for inet_addr, inet_ntoa

--- a/src/supernode.c
+++ b/src/supernode.c
@@ -36,7 +36,7 @@
 #include "uthash.h"            // for UT_hash_handle, HASH_ITER, HASH_ADD_STR
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>         // for inet_addr

--- a/src/wire.c
+++ b/src/wire.c
@@ -34,7 +34,7 @@
 #include "n2n_wire.h"    // for decode_PACKET, decode_PEER_INFO, decode_QUER...
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #else
 #include <netinet/in.h>  // for sockaddr_in, sockaddr_in6, in6_addr, in_addr


### PR DESCRIPTION
As suggested in a PR from @Legend-Master (this change is basically unrelated to the main point of his PR, so extracted here)

Windows is a confusing and disappointing development environment.  They completely replaced all the definitions in winsock.h with exact equivalents in winsock2.h (except for a small number of deprecated functions).

However they didnt make them mutually exclusive - so if you include both, you get errors.  They also automatically include winsock.h from windows.h, so you must remember to include winsock2.h first.  They also didnt just remove winsock.h and replace it with the new contents.

(Probably in the name of "compatibility", whilst swearing that the new winsock is the same as the old one - because if you cannot believe two inconsistent things simultaneously, you shouldnt be a windows programmer)

All these things are totally nuts.  Thanks, windows dev environment, for not noticing that this is nuts