### PR TITLE
Windows XP support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -706,6 +706,8 @@ jobs:
 
           # Unfortunately, the ubnuts mingw package names dont follow the
           # same naming convention as every other cross-compiler.
+          - arch: i686-w64-mingw32
+            package_suffix: mingw-w64-i686
           - arch: x86_64-w64-mingw32
             package_suffix: mingw-w64-x86-64
 

--- a/Makefile
+++ b/Makefile
@@ -189,15 +189,15 @@ N2N_OBJS+=src/win32/edge_utils_win32.o
 N2N_OBJS+=src/win32/getopt1.o
 N2N_OBJS+=src/win32/getopt.o
 N2N_OBJS+=src/win32/wintap.o
+N2N_OBJS+=src/win32/edge_rc.o
+endif
 
 src/win32/edge.rc: src/win32/edge.manifest
 src/win32/edge_rc.o: src/win32/edge.rc
 	$(WINDRES) $< -O coff -o $@
 
-src/edge: src/win32/edge_rc.o
 src/edge.exe: src/edge
 src/supernode.exe: src/supernode
-endif
 
 %: src/%
 	cp $< $@

--- a/examples/example_edge_embed.c
+++ b/examples/example_edge_embed.c
@@ -58,10 +58,8 @@ int main() {
                    "10.0.0.1",          // Set ip address
                    "255.255.255.0",     // Netmask to use
                    "DE:AD:BE:EF:01:10", // Set mac address
-                   DEFAULT_MTU         // MTU to use
-#ifdef _WIN32
-				 , 0
-#endif
+                   DEFAULT_MTU,         // MTU to use
+                   0                    // Metric - unused in n2n on most OS
                    ) < 0)
         {
                 return -1;

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -127,11 +127,7 @@ void _traceEvent (int eventTraceLevel, char* file, int line, char * format, ...)
 
 /* Tuntap API */
 int tuntap_open (struct tuntap_dev *device, char *dev, const char *address_mode, char *device_ip,
-                 char *device_mask, const char * device_mac, int mtu
-#ifdef _WIN32
-				, int metric
-#endif
-                 );
+                 char *device_mask, const char * device_mac, int mtu, int metric);
 int tuntap_read (struct tuntap_dev *tuntap, unsigned char *buf, int len);
 int tuntap_write (struct tuntap_dev *tuntap, unsigned char *buf, int len);
 void tuntap_close (struct tuntap_dev *tuntap);

--- a/src/edge.c
+++ b/src/edge.c
@@ -1246,11 +1246,8 @@ int main (int argc, char* argv[]) {
         if(runlevel == 4) { /* configure the TUNTAP device, including routes */
             if(tuntap_open(&tuntap, eee->tuntap_priv_conf.tuntap_dev_name, eee->tuntap_priv_conf.ip_mode,
                            eee->tuntap_priv_conf.ip_addr, eee->tuntap_priv_conf.netmask,
-                           eee->tuntap_priv_conf.device_mac, eee->tuntap_priv_conf.mtu
-#ifdef _WIN32
-                           , eee->tuntap_priv_conf.metric
-#endif
-                                                           ) < 0)
+                           eee->tuntap_priv_conf.device_mac, eee->tuntap_priv_conf.mtu,
+                           eee->tuntap_priv_conf.metric) < 0)
                 exit(1);
             memcpy(&eee->device, &tuntap, sizeof(tuntap));
             traceEvent(TRACE_NORMAL, "created local tap device IP: %s, Mask: %s, MAC: %s",

--- a/src/edge.c
+++ b/src/edge.c
@@ -43,8 +43,7 @@
 #include "uthash.h"                  // for UT_hash_handle, HASH_ADD, HASH_C...
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
+#include "win32/defs.h"
 #else
 #include <arpa/inet.h>               // for inet_addr, inet_ntop
 #include <netinet/in.h>              // for INADDR_ANY, INADDR_NONE, ntohl

--- a/src/edge_management.c
+++ b/src/edge_management.c
@@ -36,8 +36,7 @@
 #include "uthash.h"        // for UT_hash_handle, HASH_ITER
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
+#include "win32/defs.h"
 #else
 #include <arpa/inet.h>     // for inet_ntoa
 #include <netinet/in.h>    // for in_addr, htonl, in_addr_t

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -41,8 +41,7 @@
 #include "uthash.h"                  // for UT_hash_handle, HASH_COUNT, HASH...
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
+#include "win32/defs.h"
 #include "win32/edge_utils_win32.h"
 #else
 #include <arpa/inet.h>               // for inet_ntoa, inet_addr, inet_ntop

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2182,10 +2182,8 @@ void edge_read_from_tap (n2n_edge_t * eee) {
         sleep(3);
         tuntap_close(&(eee->device));
         tuntap_open(&(eee->device), eee->tuntap_priv_conf.tuntap_dev_name, eee->tuntap_priv_conf.ip_mode, eee->tuntap_priv_conf.ip_addr,
-                    eee->tuntap_priv_conf.netmask, eee->tuntap_priv_conf.device_mac, eee->tuntap_priv_conf.mtu
-#ifdef _WIN32
-				   ,eee->tuntap_priv_conf.metric
-#endif
+                    eee->tuntap_priv_conf.netmask, eee->tuntap_priv_conf.device_mac, eee->tuntap_priv_conf.mtu,
+                    eee->tuntap_priv_conf.metric
                     );
     } else {
         const uint8_t * mac = eth_pkt;
@@ -3295,11 +3293,8 @@ int quick_edge_init (char *device_name, char *community_name,
     /* Open the tuntap device */
     if(tuntap_open(&tuntap, device_name, "static",
                    local_ip_address, "255.255.255.0",
-                   device_mac, DEFAULT_MTU
-#ifdef _WIN32
-				 , 0
-#endif
-                   ) < 0)
+                   device_mac, DEFAULT_MTU,
+                   0) < 0)
         return(-2);
 
     /* Init edge */

--- a/src/management.c
+++ b/src/management.c
@@ -12,7 +12,9 @@
 #include "management.h"
 #include "n2n.h"         // for TRACE_DEBUG, traceEvent
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include "win32/defs.h"
+#else
 #include <netdb.h>       // for getnameinfo, NI_NUMERICHOST, NI_NUMERICSERV
 #include <sys/socket.h>  // for sendto, sockaddr
 #endif

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -35,9 +35,8 @@
 #endif
 
 #ifdef _WIN32
-#include <winsock2.h>
+#include "win32/defs.h"
 #include <ws2def.h>
-#include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>       // for inet_ntop
 #include <netdb.h>           // for addrinfo, freeaddrinfo, gai_strerror

--- a/src/network_traffic_filter.c
+++ b/src/network_traffic_filter.c
@@ -26,8 +26,7 @@
 #include "uthash.h"                  // for UT_hash_handle, HASH_ITER, HASH_DEL
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
+#include "win32/defs.h"
 #else
 #include <arpa/inet.h>               // for inet_ntoa, inet_addr
 #include <netinet/in.h>              // for in_addr, in_addr_t, ntohs, ntohl

--- a/src/sn_management.c
+++ b/src/sn_management.c
@@ -36,7 +36,7 @@
 #include "uthash.h"      // for UT_hash_handle, HASH_ITER, HASH_COUNT
 
 #ifdef _WIN32
-#include <winsock2.h>
+#include "win32/defs.h"
 #else
 #include <sys/socket.h>  // for sendto, socklen_t
 #endif

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -41,8 +41,7 @@
 #include "uthash.h"             // for UT_hash_handle, HASH_ITER, HASH_DEL
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
+#include "win32/defs.h"
 #else
 #include <arpa/inet.h>          // for inet_addr, inet_ntoa
 #include <netinet/in.h>         // for ntohl, in_addr_t, sockaddr_in, INADDR...

--- a/src/supernode.c
+++ b/src/supernode.c
@@ -36,8 +36,7 @@
 #include "uthash.h"            // for UT_hash_handle, HASH_ITER, HASH_ADD_STR
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
+#include "win32/defs.h"
 #else
 #include <arpa/inet.h>         // for inet_addr
 #include <netinet/in.h>        // for ntohl, INADDR_ANY, INADDR_NONE, in_addr_t

--- a/src/tuntap_freebsd.c
+++ b/src/tuntap_freebsd.c
@@ -36,7 +36,8 @@ int tuntap_open (tuntap_dev *device /* ignored */,
                  char *device_ip,
                  char *device_mask,
                  const char * device_mac,
-                 int mtu) {
+                 int mtu,
+                 int ignored) {
 
     int i;
     char tap_device[N2N_FREEBSD_TAPDEVICE_SIZE];

--- a/src/tuntap_linux.c
+++ b/src/tuntap_linux.c
@@ -120,7 +120,8 @@ int tuntap_open (tuntap_dev *device,
                  char *device_ip,
                  char *device_mask,
                  const char * device_mac,
-                 int mtu) {
+                 int mtu,
+                 int ignored) {
 
     char *tuntap_device = "/dev/net/tun";
     int ioctl_fd;

--- a/src/tuntap_netbsd.c
+++ b/src/tuntap_netbsd.c
@@ -40,7 +40,8 @@ int tuntap_open (tuntap_dev *device /* ignored */,
                  char *device_ip,
                  char *device_mask,
                  const char * device_mac,
-                 int mtu) {
+                 int mtu,
+                 int ignored) {
 
     char tap_device[N2N_NETBSD_TAPDEVICE_SIZE];
     struct ifreq req;

--- a/src/tuntap_osx.c
+++ b/src/tuntap_osx.c
@@ -36,7 +36,8 @@ int tuntap_open (tuntap_dev *device /* ignored */,
                  char *device_ip,
                  char *device_mask,
                  const char * device_mac,
-                 int mtu) {
+                 int mtu,
+                 int ignored) {
 
     int i;
     char tap_device[N2N_OSX_TAPDEVICE_SIZE];

--- a/src/win32/defs.h
+++ b/src/win32/defs.h
@@ -1,0 +1,27 @@
+/*
+ * Basic definitions needed for any windows compile
+ *
+ */
+
+#ifndef _WIN32_DEFS_H_
+#define _WIN32_DEFS_H_
+
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#define WIN32_LEAN_AND_MEAN
+
+#ifndef _WIN64
+/* needs to be defined before winsock gets included */
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x501
+
+const char *subst_inet_ntop (int, const void *, char *, int);
+#define inet_ntop subst_inet_ntop
+#endif
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#endif

--- a/src/win32/edge_utils_win32.c
+++ b/src/win32/edge_utils_win32.c
@@ -17,6 +17,7 @@
  */
 
 #include <winsock2.h>
+#include <iphlpapi.h>
 
 #include "edge_utils_win32.h"
 

--- a/src/win32/edge_utils_win32.c
+++ b/src/win32/edge_utils_win32.c
@@ -23,6 +23,39 @@
 
 /* ************************************** */
 
+#ifndef _WIN64
+/*
+ * This function was not included in windows until after Windows XP
+ */
+
+const char *inet_ntop (int af, const void *src, char *dst, socklen_t size) {
+    if(af == AF_INET) {
+        struct sockaddr_in in;
+        memset(&in, 0, sizeof(in));
+
+        in.sin_family = AF_INET;
+        memcpy(&in.sin_addr, src, sizeof(in.sin_addr));
+        getnameinfo((struct sockaddr *)&in,sizeof(in),dst,size,NULL,0,NI_NUMERICHOST);
+        return dst;
+    }
+
+    if(af == AF_INET6) {
+        struct sockaddr_in6 in6;
+        memset(&in6, 0, sizeof(in6));
+
+        in6.sin6_family = AF_INET6;
+        memcpy(&in6.sin6_addr, src, sizeof(in6.sin6_addr));
+        getnameinfo((struct sockaddr *)&in6,sizeof(in6),dst,size,NULL,0,NI_NUMERICHOST);
+        return dst;
+    }
+
+    return NULL;
+}
+
+#endif /* _WIN64 */
+
+/* ************************************** */
+
 static DWORD* tunReadThread (LPVOID lpArg) {
 
     struct tunread_arg *arg = (struct tunread_arg*)lpArg;

--- a/src/win32/edge_utils_win32.c
+++ b/src/win32/edge_utils_win32.c
@@ -16,7 +16,7 @@
  *
  */
 
-#include <winsock2.h>
+#include "defs.h"
 #include <iphlpapi.h>
 
 #include "edge_utils_win32.h"
@@ -28,7 +28,7 @@
  * This function was not included in windows until after Windows XP
  */
 
-const char *inet_ntop (int af, const void *src, char *dst, socklen_t size) {
+const char *subst_inet_ntop (int af, const void *src, char *dst, int size) {
     if(af == AF_INET) {
         struct sockaddr_in in;
         memset(&in, 0, sizeof(in));

--- a/src/win32/n2n_win32.h
+++ b/src/win32/n2n_win32.h
@@ -7,21 +7,6 @@
 #ifndef _N2N_WIN32_H_
 #define _N2N_WIN32_H_
 
-#ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS
-#endif
-
-#define WIN32_LEAN_AND_MEAN
-
-#if defined(__MINGW32__)
-/* should be defined here and before winsock gets included */
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x501 //Otherwise the linker doesnt find getaddrinfo
-#endif /* #ifndef _WIN32_WINNT */
-#include <inttypes.h>
-#endif /* #if defined(__MINGW32__) */
-
-
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2def.h>

--- a/src/win32/wintap.c
+++ b/src/win32/wintap.c
@@ -2,8 +2,8 @@
   (C) 2007-22 - Luca Deri <deri@ntop.org>
 */
 
+#include "defs.h"
 #ifndef _WIN64
-#include <winsock2.h>
 #include <iphlpapi.h>
 #endif
 

--- a/src/win32/wintap.c
+++ b/src/win32/wintap.c
@@ -2,8 +2,10 @@
   (C) 2007-22 - Luca Deri <deri@ntop.org>
 */
 
+#ifndef _WIN64
 #include <winsock2.h>
 #include <iphlpapi.h>
+#endif
 
 #include "n2n.h"
 #include "n2n_win32.h"

--- a/src/win32/wintap.c
+++ b/src/win32/wintap.c
@@ -2,6 +2,9 @@
   (C) 2007-22 - Luca Deri <deri@ntop.org>
 */
 
+#include <winsock2.h>
+#include <iphlpapi.h>
+
 #include "n2n.h"
 #include "n2n_win32.h"
 
@@ -333,6 +336,15 @@ int open_wintap(struct tuntap_dev *device,
 
   /* ****************** */
 
+#ifdef _WIN64
+  /* Setting the metric is not actually 64-bit specific.
+   * The assumption here is that anyone needing a metric set will also
+   * need a new enough OS that they will be on 64-bit.
+   *
+   * The alternative is that people trying to run old games are probably on
+   * Windows XP and are probably 32-bit.
+   */
+
   /* metric */
 
   PMIB_IPINTERFACE_ROW Row;
@@ -357,6 +369,7 @@ int open_wintap(struct tuntap_dev *device,
     
     free(Row);
   }
+#endif /* _WIN64 */
 
   /* ****************** */
 
@@ -452,6 +465,8 @@ int tuntap_open(struct tuntap_dev *device,
 
 void tuntap_close(struct tuntap_dev *tuntap) {
 
+#ifdef _WIN64
+  /* See comment in open_wintap for notes about this ifdef */
   PMIB_IPINTERFACE_ROW Row;
 
   if(tuntap->metric) { /* only required if a value has been given (and thus stored) */
@@ -471,6 +486,7 @@ void tuntap_close(struct tuntap_dev *tuntap) {
 
     free(Row);
   }
+#endif /* _WIN64 */
 
   CloseHandle(tuntap->device_handle);
 }

--- a/src/wire.c
+++ b/src/wire.c
@@ -34,8 +34,7 @@
 #include "n2n_wire.h"    // for decode_PACKET, decode_PEER_INFO, decode_QUER...
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
+#include "win32/defs.h"
 #else
 #include <netinet/in.h>  // for sockaddr_in, sockaddr_in6, in6_addr, in_addr
 #include <sys/socket.h>  // for AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM

--- a/tools/n2n-route.c
+++ b/tools/n2n-route.c
@@ -51,7 +51,14 @@
 #include <sys/socket.h>        // for send, socket, AF_INET, recv, connect
 #endif
 
-#if defined (__linux__) || defined(_WIN32)  /*  currently, Linux and Windows only */
+#if defined (__linux__) || defined(_WIN64)  /*  currently, Linux and Windows only */
+/* Technically, this could be supported on some 32-bit windows.
+ * The assumption here is that a version of Windows new enough to
+ * support the features needed is probably running with 64-bit.
+ *
+ * The alternative is that people trying to run old games are probably on
+ * Windows XP and are probably 32-bit.
+ */
 
 
 #define WITH_ADDRESS            1
@@ -1088,16 +1095,16 @@ end_route_tool:
 }
 
 
-#else  /* if defined(__linux__) || defined(_WIN32) --  currently, Linux and Windows only */
+#else  /* if defined(__linux__) || defined(_WIN64) --  currently, Linux and Windows only */
 
 
 int main (int argc, char* argv[]) {
 
-    traceEvent(TRACE_WARNING, "currently, only Linux and Windows are supported");
+    traceEvent(TRACE_WARNING, "currently, only Linux and 64-bit Windows are supported");
     traceEvent(TRACE_WARNING, "if you want to port to other OS, please find the source code having clearly marked the platform-dependant portions");
 
     return 0;
 }
 
 
-#endif /* if defined (__linux__) || defined(_WIN32)  --  currently, Linux and Windows only */
+#endif /* if defined (__linux__) || defined(_WIN64)  --  currently, Linux and Windows only */


### PR DESCRIPTION
It is now possible to build n2n for Windows XP.

The simplest way of doing this is to cross-compile from Linux using the mingw toolkit:
```
apt install binutils-mingw-w64-i686 gcc-mingw-w64-i686
./autogen.sh
./configure --host i686-w64-mingw32
make install DESTDIR=binaries/i686-w64-mingw32
```
This will place the output in the `binaries` dir


Due to the age of Windows XP, some required features are missing and thus some helper parts of n2n were disabled

See also: #847
