### PR TITLE
Let the kernel takes care of assigning the port ID of the netlink socket on Linux

### DIFF
--- a/src/tuntap_linux.c
+++ b/src/tuntap_linux.c
@@ -187,7 +187,6 @@ int tuntap_open (tuntap_dev *device,
     memset(&sa, 0, sizeof(sa));
     sa.nl_family = PF_NETLINK;
     sa.nl_groups = RTMGRP_LINK;
-    sa.nl_pid = getpid();
 
     memset(&msg, 0, sizeof(msg));
     msg.msg_name = &sa;


### PR DESCRIPTION
Let the kernel takes care of assigning the port ID of the netlink socket on Linux.

I had a problem where I couldn't start an n2n edge node under Docker, because it happened that the netlink socket created by n2n with port ID set to the internal process ID would conflict another process on the host. I would get an error like "Could not bind NETLINK socket: Address already in use [98]". This is because the container's process has two process IDs, one that for inside the container and the another in the host. By calling getpid() from inside the container, n2n seems to get the internal process ID rather than an unique process ID on the host. The error did not occurred when running the n2n edge node on the host (i.e. without Docker), because then the process ID obtained would be unique, and so the port ID of the netlink socket.

As per the documentation from https://man7.org/linux/man-pages/man7/netlink.7.html :
_If the application sets nl_pid before calling [bind(2)](https://man7.org/linux/man-pages/man2/bind.2.html), then it is up to
 the application to make sure that nl_pid is unique.  If the
 application sets it to 0, the kernel takes care of assigning it.
 The kernel assigns the process ID to the first netlink socket the
 process opens and assigns a unique nl_pid to every netlink socket
 that the process subsequently creates._

It seems it would be best for the application to set the port ID to 0 and let the kernel handle this.

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/n2n/issues):

Describe changes:
- Set nl_pid to 0, to avoid potential conflicts when running under Docker.
