### PR TITLE
Add SRV record support for win32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ src/edge: $(N2N_LIB)
 src/supernode: $(N2N_LIB)
 
 ifneq (,$(findstring mingw,$(CONFIG_HOST_OS)))
+LDLIBS+=-ldnsapi
 N2N_OBJS+=src/win32/edge_utils_win32.o
 N2N_OBJS+=src/win32/getopt1.o
 N2N_OBJS+=src/win32/getopt.o

--- a/src/edge.c
+++ b/src/edge.c
@@ -579,6 +579,20 @@ static int setOption (int optkey, char *optargument, n2n_tuntap_priv_config_t *e
 
         case 'l': /* supernode-list */ {
             if(optargument) {
+#ifdef _WIN32
+#include <Winsock2.h>
+#include <windns.h>
+                DNS_RECORDA* pDnsRecord = NULL;
+                DnsQuery_A(optargument, DNS_TYPE_SRV, DNS_QUERY_STANDARD, NULL, (PDNS_RECORD*)&pDnsRecord, NULL);
+                while (pDnsRecord != NULL) {
+                    if (pDnsRecord->wType == DNS_TYPE_SRV) {
+                        DNS_SRV_DATAA pSrvData = pDnsRecord->Data.SRV;
+                        sprintf(optargument, "%s:%d\0", pSrvData.pNameTarget, pSrvData.wPort);
+                        break;
+                    }
+                    pDnsRecord = pDnsRecord->pNext;
+                }
+#endif
                 if(edge_conf_add_supernode(conf, optargument) != 0) {
                     traceEvent(TRACE_WARNING, "failed to add supernode '%s'", optargument);
                 }

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -1083,12 +1083,14 @@ static ssize_t sendto_fd (n2n_edge_t *eee, const void *buf,
         level = TRACE_DEBUG;
     }
 
+/*
     traceEvent(level, "sendto(%s) failed (%d) %s",
             sock_to_cstr(sockbuf, n2ndest),
             errno, errstr);
 #ifdef _WIN32
     traceEvent(level, "WSAGetLastError(): %u", WSAGetLastError());
 #endif
+*/
 
     /*
      * we get here if the sock is not ready or


### PR DESCRIPTION
just for hidding the port.
like i can connect to n2n server by using this
```
edge -c cf -l _n2n_udp.example.com --no-port-forwarding -r -D -E
```
instead of
```
edge -c cf -l example.com:7777 --no-port-forwarding -r -D -E
```
but i don't know how to use a cross-platfrom way to get SRV records. so only win32 is implemented.

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/n2n/issues):


Describe changes:


