### PR TITLE
Fix CMake compatibility with modern CMake (>= 4.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.5...3.31)
 project(n2n)
-cmake_minimum_required(VERSION 2.6)
 include(CheckFunctionExists)
 SET(CMAKE_VERBOSE_MAKEFILE ON)
 


### PR DESCRIPTION
## Summary

The CMake workflow (`cmake-linux.yml`) fails on `macos-latest` because the runner now ships CMake 4.x, which dropped compatibility with versions below 3.5.

Two issues in `CMakeLists.txt`:
1. `project()` was called before `cmake_minimum_required()` — CMake requires the opposite order
2. `cmake_minimum_required(VERSION 2.6)` — version 2.6 is rejected by CMake >= 4.0

### Fix
- Reorder so `cmake_minimum_required()` comes first
- Use `VERSION 3.5...3.31` range syntax: floor of 3.5 (oldest CMake still supported by modern CMake) with policies up to 3.31

### Before
```
project(n2n)
cmake_minimum_required(VERSION 2.6)
```

### After
```
cmake_minimum_required(VERSION 3.5...3.31)
project(n2n)
```

## Test plan
- CMake workflow should now pass on all three platforms (ubuntu-latest, macos-latest, windows-latest)