### PR TITLE
edge, supernode: allow -t 0 to disable the management UDP port

### DIFF
--- a/edge.8
+++ b/edge.8
@@ -189,7 +189,7 @@ do not fork and run as a daemon, rather run in foreground
 \fB\-t \fR<\fIport\fR>
 binds the edge management system to the given UDP port. Default 5644. Use this
 if you need to run multiple instance of edge; or something is bound to that
-port.
+port. A value of 0 disables the management API entirely (no UDP socket is bound).
 .TP
 \fB\-\-management-password \fR<\fIpassword\fR>
 sets the password for access to JSON API at the management port, defaults to 'n2n'. The password

--- a/src/edge.c
+++ b/src/edge.c
@@ -361,7 +361,7 @@ static void help (int level) {
         printf(" -f                | do not fork and run as a daemon, rather run in foreground\n");
 #endif
         printf(" -t <port>         | management UDP port, for multiple edges on a machine,\n"
-               "                   | defaults to %u\n", N2N_EDGE_MGMT_PORT);
+               "                   | defaults to %u; 0 disables the management API\n", N2N_EDGE_MGMT_PORT);
         printf(" --management_...  | management port password, defaults to '%s'\n"
                " ...password <pw>  | \n", N2N_MGMT_PASSWORD);
         printf(" -v                | make more verbose, repeat as required\n");

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -3122,10 +3122,14 @@ static int edge_init_sockets (n2n_edge_t *eee) {
         closesocket(eee->udp_multicast_sock);
 #endif
 
-    eee->udp_mgmt_sock = open_socket(eee->conf.mgmt_port, INADDR_LOOPBACK, 0 /* UDP */);
-    if(eee->udp_mgmt_sock < 0) {
-        traceEvent(TRACE_ERROR, "failed to bind management UDP port %u", eee->conf.mgmt_port);
-        return(-2);
+    if(eee->conf.mgmt_port == 0) {
+        traceEvent(TRACE_NORMAL, "management port disabled");
+    } else {
+        eee->udp_mgmt_sock = open_socket(eee->conf.mgmt_port, INADDR_LOOPBACK, 0 /* UDP */);
+        if(eee->udp_mgmt_sock < 0) {
+            traceEvent(TRACE_ERROR, "failed to bind management UDP port %u", eee->conf.mgmt_port);
+            return(-2);
+        }
     }
 
 #ifndef SKIP_MULTICAST_PEERS_DISCOVERY

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2913,7 +2913,8 @@ int run_edge_loop (n2n_edge_t *eee) {
 
         FD_ZERO(&socket_mask);
 
-        FD_SET(eee->udp_mgmt_sock, &socket_mask);
+        if(eee->udp_mgmt_sock >= 0)
+            FD_SET(eee->udp_mgmt_sock, &socket_mask);
         max_sock = eee->udp_mgmt_sock;
 
         if(eee->sock >= 0) {
@@ -2980,7 +2981,7 @@ int run_edge_loop (n2n_edge_t *eee) {
             }
 #endif
 
-            if(FD_ISSET(eee->udp_mgmt_sock, &socket_mask)) {
+            if(eee->udp_mgmt_sock >= 0 && FD_ISSET(eee->udp_mgmt_sock, &socket_mask)) {
                 // read from the management port socket
                 readFromMgmtSocket(eee);
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -2609,7 +2609,8 @@ int run_sn_loop (n2n_sn_t *sss) {
 #ifdef N2N_HAVE_TCP
         FD_SET(sss->tcp_sock, &socket_mask);
 #endif
-        FD_SET(sss->mgmt_sock, &socket_mask);
+        if(sss->mgmt_sock >= 0)
+            FD_SET(sss->mgmt_sock, &socket_mask);
 
         max_sock = MAX(MAX(sss->sock, sss->mgmt_sock), sss->tcp_sock);
 
@@ -2761,7 +2762,7 @@ int run_sn_loop (n2n_sn_t *sss) {
 #endif /* N2N_HAVE_TCP */
 
             // handle management port input
-            if(FD_ISSET(sss->mgmt_sock, &socket_mask)) {
+            if(sss->mgmt_sock >= 0 && FD_ISSET(sss->mgmt_sock, &socket_mask)) {
                 struct sockaddr_storage sas;
                 struct sockaddr *sender_sock = (struct sockaddr*)&sas;
                 socklen_t ss_size = sizeof(sas);

--- a/src/supernode.c
+++ b/src/supernode.c
@@ -163,7 +163,7 @@ static void help (int level) {
         printf(" -f                | do not fork and run as a daemon, rather run in foreground\n");
 #endif
         printf(" -t <port>         | management UDP port, for multiple supernodes on a machine,\n"
-               "                   | defaults to %u\n", N2N_SN_MGMT_PORT);
+               "                   | defaults to %u; 0 disables the management API\n", N2N_SN_MGMT_PORT);
         printf(" --management_...  | management port password, defaults to '%s'\n"
                " ...password <pw>  | \n", N2N_MGMT_PASSWORD);
         printf(" -v                | make more verbose, repeat as required\n");
@@ -225,13 +225,8 @@ static int setOption (int optkey, char *_optarg, n2n_sn_t *sss) {
             break;
         }
 
-        case 't': /* mgmt-port */
+        case 't': /* mgmt-port; 0 disables the management API */
             sss->mport = atoi(_optarg);
-
-            if(sss->mport == 0)
-                traceEvent(TRACE_WARNING, "bad management port format, defaulting to %u", N2N_SN_MGMT_PORT);
-                // default is made sure in sn_init()
-
             break;
 
         case 'l': { /* supernode:port */
@@ -677,12 +672,16 @@ int main (int argc, char * const argv[]) {
     }
 #endif
 
-    sss_node.mgmt_sock = open_socket(sss_node.mport, INADDR_LOOPBACK, 0 /* UDP */);
-    if(-1 == sss_node.mgmt_sock) {
-        traceEvent(TRACE_ERROR, "failed to open management socket, %s", strerror(errno));
-        exit(-2);
+    if(sss_node.mport == 0) {
+        traceEvent(TRACE_NORMAL, "management port disabled");
     } else {
-        traceEvent(TRACE_NORMAL, "supernode is listening on UDP %u (management)", sss_node.mport);
+        sss_node.mgmt_sock = open_socket(sss_node.mport, INADDR_LOOPBACK, 0 /* UDP */);
+        if(-1 == sss_node.mgmt_sock) {
+            traceEvent(TRACE_ERROR, "failed to open management socket, %s", strerror(errno));
+            exit(-2);
+        } else {
+            traceEvent(TRACE_NORMAL, "supernode is listening on UDP %u (management)", sss_node.mport);
+        }
     }
 
     HASH_ITER(hh, sss_node.federation->edges, scan, tmp)

--- a/supernode.1
+++ b/supernode.1
@@ -66,7 +66,8 @@ defaults to '10.128.255.0-10.255.255.0/24'
 disable daemon mode (UNIX) and run in foreground.
 .TP
 \fB\-t \fR<\fIport\fR>, \fB\-\-mgmt-port\fR=<\fIport\fR>
-management UDP port, for multiple supernodes on a machine, defaults to 5645
+management UDP port, for multiple supernodes on a machine, defaults to 5645.
+A value of 0 disables the management API entirely (no UDP socket is bound).
 .TP
 \fB\-\-management-password \fR<\fIpassword\fR>
 sets the password for access to JSON API at the management port, defaults to 'n2n'. The password


### PR DESCRIPTION
## Summary

Passing `-t 0` to `edge` (default mgmt port 5644) or `supernode` (default 5645) now skips opening the management UDP socket entirely. The socket field stays at its `-1` init value and the `select()`-loop `FD_SET`/`FD_ISSET` calls are guarded with `>= 0`.

Motivation: operators who don't use the JSON-over-UDP management API and want one fewer loopback socket bound (e.g. for hardening) had no way to suppress it. The mgmt port also exposes a small UDP parser and request dispatcher that some deployments would rather not have running.

## Changes

- `src/supernode.c`, `src/sn_utils.c` — gate the mgmt-socket open and the loop's `FD_SET`/`FD_ISSET` calls; remove the misleading `bad management port format, defaulting to %u` warning that fired on `-t 0` (it never actually restored the default — the `// default is made sure in sn_init()` comment was wrong; `sn_init` runs *before* CLI parsing).
- `src/edge.c`, `src/edge_utils.c` — same gating for the edge.
- `supernode.1`, `edge.8` — one-line note under the `-t` entry: "A value of 0 disables the management API entirely (no UDP socket is bound)."
- Help text for `-t` in both binaries appended \`; 0 disables the management API\`.

The existing \`MAX(...)\` expressions in both \`select()\` loops absorb a \`-1\` correctly because the macro is a signed comparison, so they're left untouched.

No tests added. The existing \`tests-*\` unit suite doesn't cover socket lifecycle. The shell-based integration harness exercises the management API on default ports; extending it to cover the disabled case would require spinning a second daemon instance. Happy to add either on request.