### PR TITLE
fix: use lzo1x_decompress_safe to prevent stack buffer overflow (CAN-2026-2035137)

### DIFF
--- a/src/transform_lzo.c
+++ b/src/transform_lzo.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>     // for size_t, calloc, free, NULL
 #include <string.h>     // for memset
 #include <sys/types.h>  // for time_t
-#include "minilzo.h"    // for lzo1x_1_compress, lzo1x_decompress, LZO1X_1_M...
+#include "minilzo.h"    // for lzo1x_1_compress, lzo1x_decompress_safe, LZO1X_1_M...
 #include "n2n.h"        // for n2n_trans_op_t, TRACE_ERROR, traceEvent, N2N_...
 
 
@@ -92,10 +92,8 @@ static int transop_decode_lzo (n2n_trans_op_t *arg,
         return 0;
     }
 
-    lzo1x_decompress(inbuf, in_len, outbuf, &deflated_len, NULL);
-
-    if(deflated_len > N2N_PKT_BUF_SIZE) {
-        traceEvent(TRACE_ERROR, "decode_lzo outbuf wrong size (%ul) decompressed", deflated_len);
+    if(lzo1x_decompress_safe(inbuf, in_len, outbuf, &deflated_len, NULL) != LZO_E_OK) {
+        traceEvent(TRACE_ERROR, "decode_lzo decompression failed or output exceeds buffer");
         return 0;
     }
 


### PR DESCRIPTION
## Summary

Replace `lzo1x_decompress()` with `lzo1x_decompress_safe()` in `transop_decode_lzo()` to prevent a stack buffer overflow.

## Problem

The unsafe `lzo1x_decompress()` does not enforce an output buffer size limit. A crafted LZO-compressed payload that decompresses to more than `N2N_PKT_BUF_SIZE` (2048) bytes overflows the stack buffer `deflate_buf` in `handle_PACKET()` (edge_utils.c:1718).

The post-decompression size check (`if(deflated_len > N2N_PKT_BUF_SIZE)`) was ineffective because the overflow already occurred during decompression.

## Fix

Use `lzo1x_decompress_safe()` which validates output bounds during decompression. This function is already bundled in `src/minilzo.c` but was not being used.

## Reference

CAN-2026-2035137